### PR TITLE
refactor: update account info handling to use new API for multiple ve…

### DIFF
--- a/apps/vendor-gate/src/index.ts
+++ b/apps/vendor-gate/src/index.ts
@@ -3,6 +3,7 @@ import {
   IAccountInfo,
   IAccountMoney,
   IPosition,
+  provideAccountInfoService,
   publishAccountInfo,
 } from '@yuants/data-account';
 import { IOrder } from '@yuants/data-order';
@@ -242,40 +243,34 @@ const memoizeMap = <T extends (...params: any[]) => any>(fn: T): T => {
   publishAccountInfo(terminal, UNIFIED_USDT_ACCOUNT_ID, unifiedUsdtAccountInfo$);
   addAccountMarket(terminal, { account_id: UNIFIED_USDT_ACCOUNT_ID, market_id: 'GATE/UNIFIED' });
 
-  const spotAccountInfo$ = defer(async (): Promise<IAccountInfo> => {
-    const res = await client.getSpotAccounts();
-    if (!(res instanceof Array)) {
-      throw new Error(`${res}`);
-    }
-    const balance = +(res.find((v) => v.currency === 'USDT')?.available ?? '0');
-    const equity = balance;
-    const free = equity;
-    const money: IAccountMoney = {
-      currency: 'USDT',
-      equity,
-      profit: 0,
-      balance,
-      free,
-      used: 0,
-    };
-    return {
-      updated_at: Date.now(),
-      account_id: SPOT_USDT_ACCOUNT_ID,
-      money,
-      positions: [],
-    };
-  }).pipe(
-    //
-    tap({
-      error: (err) => {
-        console.error(formatTime(Date.now()), 'spotAccountInfo$', err);
-      },
-    }),
-    retry({ delay: 5000 }),
-    repeat({ delay: 1000 }),
-    shareReplay(1),
+  provideAccountInfoService(
+    terminal,
+    SPOT_USDT_ACCOUNT_ID,
+    async (): Promise<IAccountInfo> => {
+      const res = await client.getSpotAccounts();
+      if (!(res instanceof Array)) {
+        throw new Error(`${res}`);
+      }
+      const balance = +(res.find((v) => v.currency === 'USDT')?.available ?? '0');
+      const equity = balance;
+      const free = equity;
+      const money: IAccountMoney = {
+        currency: 'USDT',
+        equity,
+        profit: 0,
+        balance,
+        free,
+        used: 0,
+      };
+      return {
+        updated_at: Date.now(),
+        account_id: SPOT_USDT_ACCOUNT_ID,
+        money,
+        positions: [],
+      };
+    },
+    { auto_refresh_interval: 1000 },
   );
-  publishAccountInfo(terminal, SPOT_USDT_ACCOUNT_ID, spotAccountInfo$);
   addAccountMarket(terminal, { account_id: SPOT_USDT_ACCOUNT_ID, market_id: 'GATE/SPOT' });
 
   // const futuresTickers$ = defer(async () => {

--- a/apps/vendor-huobi/src/index.ts
+++ b/apps/vendor-huobi/src/index.ts
@@ -3,7 +3,7 @@ import {
   IAccountInfo,
   IAccountMoney,
   IPosition,
-  publishAccountInfo,
+  provideAccountInfoService,
 } from '@yuants/data-account';
 import { IOrder } from '@yuants/data-order';
 import { Terminal } from '@yuants/protocol';
@@ -71,109 +71,105 @@ const terminal = Terminal.fromNodeEnv();
     shareReplay(1),
   );
 
-  const perpetualContractAccountInfo$ = defer(async () => {
-    // balance
-    const balance = await client.getUnifiedAccountInfo();
-    if (!balance.data) {
-      throw new Error('Failed to get unified account info');
-    }
-    const balanceData = balance.data.find((v) => v.margin_asset === 'USDT');
-    if (!balanceData) {
-      throw new Error('No USDT balance found in unified account');
-    }
-    const money: IAccountMoney = {
-      currency: 'USDT',
-      balance: balanceData.cross_margin_static,
-      equity: balanceData.margin_balance,
-      profit: balanceData.cross_profit_unreal,
-      free: balanceData.withdraw_available,
-      used: balanceData.margin_balance - balanceData.withdraw_available,
-    };
-
-    // positions
-    const positionsRes = await client.getSwapCrossPositionInfo();
-    const mapProductIdToPerpetualProduct = await firstValueFrom(mapProductIdToPerpetualProduct$);
-    const positions: IPosition[] = (positionsRes.data || []).map((v): IPosition => {
-      const product_id = v.contract_code;
-      const theProduct = mapProductIdToPerpetualProduct?.get(product_id);
-      const valuation = v.volume * v.last_price * (theProduct?.value_scale || 1);
-      return {
-        position_id: `${v.contract_code}/${v.contract_type}/${v.direction}/${v.margin_mode}`,
-        datasource_id: 'HUOBI-SWAP',
-        product_id,
-        direction: v.direction === 'buy' ? 'LONG' : 'SHORT',
-        volume: v.volume,
-        free_volume: v.available,
-        position_price: v.cost_hold,
-        closable_price: v.last_price,
-        floating_profit: v.profit_unreal,
-        valuation,
+  provideAccountInfoService(
+    terminal,
+    SWAP_ACCOUNT_ID,
+    async () => {
+      // balance
+      const balance = await client.getUnifiedAccountInfo();
+      if (!balance.data) {
+        throw new Error('Failed to get unified account info');
+      }
+      const balanceData = balance.data.find((v) => v.margin_asset === 'USDT');
+      if (!balanceData) {
+        throw new Error('No USDT balance found in unified account');
+      }
+      const money: IAccountMoney = {
+        currency: 'USDT',
+        balance: balanceData.cross_margin_static,
+        equity: balanceData.margin_balance,
+        profit: balanceData.cross_profit_unreal,
+        free: balanceData.withdraw_available,
+        used: balanceData.margin_balance - balanceData.withdraw_available,
       };
-    });
 
-    // orders
-    // const orders: IOrder[] = [];
-    // let page_index = 1;
-    // const page_size = 50;
+      // positions
+      const positionsRes = await client.getSwapCrossPositionInfo();
+      const mapProductIdToPerpetualProduct = await firstValueFrom(mapProductIdToPerpetualProduct$);
+      const positions: IPosition[] = (positionsRes.data || []).map((v): IPosition => {
+        const product_id = v.contract_code;
+        const theProduct = mapProductIdToPerpetualProduct?.get(product_id);
+        const valuation = v.volume * v.last_price * (theProduct?.value_scale || 1);
+        return {
+          position_id: `${v.contract_code}/${v.contract_type}/${v.direction}/${v.margin_mode}`,
+          datasource_id: 'HUOBI-SWAP',
+          product_id,
+          direction: v.direction === 'buy' ? 'LONG' : 'SHORT',
+          volume: v.volume,
+          free_volume: v.available,
+          position_price: v.cost_hold,
+          closable_price: v.last_price,
+          floating_profit: v.profit_unreal,
+          valuation,
+        };
+      });
 
-    // while (true) {
-    //   const ordersRes = await client.getSwapOpenOrders({ page_index, page_size });
-    //   if (!ordersRes.data?.orders || ordersRes.data.orders.length === 0) {
-    //     break;
-    //   }
+      // orders
+      // const orders: IOrder[] = [];
+      // let page_index = 1;
+      // const page_size = 50;
 
-    //   const pageOrders: IOrder[] = ordersRes.data.orders.map((v): IOrder => {
-    //     return {
-    //       order_id: v.order_id_str,
-    //       account_id: SWAP_ACCOUNT_ID,
-    //       product_id: v.contract_code,
-    //       order_type: ['lightning'].includes(v.order_price_type)
-    //         ? 'MARKET'
-    //         : ['limit', 'opponent', 'post_only', 'optimal_5', 'optimal_10', 'optimal_20'].includes(
-    //             v.order_price_type,
-    //           )
-    //         ? 'LIMIT'
-    //         : ['fok'].includes(v.order_price_type)
-    //         ? 'FOK'
-    //         : v.order_price_type.includes('ioc')
-    //         ? 'IOC'
-    //         : 'STOP', // unreachable code
-    //       order_direction:
-    //         v.direction === 'open'
-    //           ? v.offset === 'buy'
-    //             ? 'OPEN_LONG'
-    //             : 'OPEN_SHORT'
-    //           : v.offset === 'buy'
-    //           ? 'CLOSE_SHORT'
-    //           : 'CLOSE_LONG',
-    //       volume: v.volume,
-    //       submit_at: v.created_at,
-    //       price: v.price,
-    //       traded_volume: v.trade_volume,
-    //     };
-    //   });
+      // while (true) {
+      //   const ordersRes = await client.getSwapOpenOrders({ page_index, page_size });
+      //   if (!ordersRes.data?.orders || ordersRes.data.orders.length === 0) {
+      //     break;
+      //   }
 
-    //   orders.push(...pageOrders);
-    //   page_index++;
-    // }
+      //   const pageOrders: IOrder[] = ordersRes.data.orders.map((v): IOrder => {
+      //     return {
+      //       order_id: v.order_id_str,
+      //       account_id: SWAP_ACCOUNT_ID,
+      //       product_id: v.contract_code,
+      //       order_type: ['lightning'].includes(v.order_price_type)
+      //         ? 'MARKET'
+      //         : ['limit', 'opponent', 'post_only', 'optimal_5', 'optimal_10', 'optimal_20'].includes(
+      //             v.order_price_type,
+      //           )
+      //         ? 'LIMIT'
+      //         : ['fok'].includes(v.order_price_type)
+      //         ? 'FOK'
+      //         : v.order_price_type.includes('ioc')
+      //         ? 'IOC'
+      //         : 'STOP', // unreachable code
+      //       order_direction:
+      //         v.direction === 'open'
+      //           ? v.offset === 'buy'
+      //             ? 'OPEN_LONG'
+      //             : 'OPEN_SHORT'
+      //           : v.offset === 'buy'
+      //           ? 'CLOSE_SHORT'
+      //           : 'CLOSE_LONG',
+      //       volume: v.volume,
+      //       submit_at: v.created_at,
+      //       price: v.price,
+      //       traded_volume: v.trade_volume,
+      //     };
+      //   });
 
-    const accountInfo: IAccountInfo = {
-      updated_at: Date.now(),
-      account_id: SWAP_ACCOUNT_ID,
-      money: money,
-      positions,
-    };
+      //   orders.push(...pageOrders);
+      //   page_index++;
+      // }
 
-    return accountInfo;
-  }).pipe(
-    repeat({ delay: 1000 }),
-    tap({
-      error: (e) => {
-        console.error(formatTime(Date.now()), 'perpetualContractAccountInfo', e);
-      },
-    }),
-    retry({ delay: 1000 }),
-    shareReplay(1),
+      const accountInfo: IAccountInfo = {
+        updated_at: Date.now(),
+        account_id: SWAP_ACCOUNT_ID,
+        money: money,
+        positions,
+      };
+
+      return accountInfo;
+    },
+    { auto_refresh_interval: 1000 },
   );
 
   const superMarginUnifiedRawAccountBalance$ = defer(() =>
@@ -227,113 +223,107 @@ const terminal = Terminal.fromNodeEnv();
       }
     });
 
-  const superMarginAccountInfo$ = defer(async () => {
-    // get account balance
-    const accountBalance = await client.getSpotAccountBalance(superMarginAccountUid);
-    const balanceList = accountBalance.data?.list || [];
+  provideAccountInfoService(
+    terminal,
+    SUPER_MARGIN_ACCOUNT_ID,
+    async () => {
+      // get account balance
+      const accountBalance = await client.getSpotAccountBalance(superMarginAccountUid);
+      const balanceList = accountBalance.data?.list || [];
 
-    // calculate usdt balance
-    const usdtBalance = balanceList
-      .filter((v) => v.currency === 'usdt')
-      .reduce((acc, cur) => acc + +cur.balance, 0);
+      // calculate usdt balance
+      const usdtBalance = balanceList
+        .filter((v) => v.currency === 'usdt')
+        .reduce((acc, cur) => acc + +cur.balance, 0);
 
-    // get positions (non-usdt currencies)
-    const positions: IPosition[] = [];
-    const nonUsdtCurrencies = balanceList
-      .filter((v) => v.currency !== 'usdt')
-      .reduce((acc, cur) => {
-        const existing = acc.find((item) => item.currency === cur.currency);
-        if (existing) {
-          existing.balance += +cur.balance;
-        } else {
-          acc.push({ currency: cur.currency, balance: +cur.balance });
-        }
-        return acc;
-      }, [] as { currency: string; balance: number }[]);
-
-    // get prices and create positions
-    for (const currencyData of nonUsdtCurrencies) {
-      if (currencyData.balance > 0) {
-        try {
-          // get current price from websocket or fallback to REST API
-          let price: number;
-          try {
-            const tickPrice = await firstValueFrom(
-              client.spot_ws.input$.pipe(
-                //
-                first((v) => v.ch?.includes('ticker') && v.ch?.includes(currencyData.currency) && v.tick),
-                map((v): number => v.tick.bid),
-                timeout(5000),
-                tap({
-                  error: (e) => {
-                    subscriptions.clear();
-                  },
-                }),
-              ),
-            );
-            price = tickPrice;
-          } catch {
-            // fallback to REST API
-            const tickerRes = await client.getSpotTick({ symbol: `${currencyData.currency}usdt` });
-            price = tickerRes.tick.close;
+      // get positions (non-usdt currencies)
+      const positions: IPosition[] = [];
+      const nonUsdtCurrencies = balanceList
+        .filter((v) => v.currency !== 'usdt')
+        .reduce((acc, cur) => {
+          const existing = acc.find((item) => item.currency === cur.currency);
+          if (existing) {
+            existing.balance += +cur.balance;
+          } else {
+            acc.push({ currency: cur.currency, balance: +cur.balance });
           }
+          return acc;
+        }, [] as { currency: string; balance: number }[]);
 
-          positions.push({
-            position_id: `${currencyData.currency}/usdt/spot`,
-            product_id: `${currencyData.currency}usdt`,
-            direction: 'LONG',
-            volume: currencyData.balance,
-            free_volume: currencyData.balance,
-            position_price: price,
-            closable_price: price,
-            floating_profit: 0,
-            valuation: currencyData.balance * price,
-          });
-        } catch (error) {
-          console.warn(formatTime(Date.now()), `Failed to get price for ${currencyData.currency}:`, error);
+      // get prices and create positions
+      for (const currencyData of nonUsdtCurrencies) {
+        if (currencyData.balance > 0) {
+          try {
+            // get current price from websocket or fallback to REST API
+            let price: number;
+            try {
+              const tickPrice = await firstValueFrom(
+                client.spot_ws.input$.pipe(
+                  //
+                  first((v) => v.ch?.includes('ticker') && v.ch?.includes(currencyData.currency) && v.tick),
+                  map((v): number => v.tick.bid),
+                  timeout(5000),
+                  tap({
+                    error: (e) => {
+                      subscriptions.clear();
+                    },
+                  }),
+                ),
+              );
+              price = tickPrice;
+            } catch {
+              // fallback to REST API
+              const tickerRes = await client.getSpotTick({ symbol: `${currencyData.currency}usdt` });
+              price = tickerRes.tick.close;
+            }
+
+            positions.push({
+              position_id: `${currencyData.currency}/usdt/spot`,
+              product_id: `${currencyData.currency}usdt`,
+              direction: 'LONG',
+              volume: currencyData.balance,
+              free_volume: currencyData.balance,
+              position_price: price,
+              closable_price: price,
+              floating_profit: 0,
+              valuation: currencyData.balance * price,
+            });
+          } catch (error) {
+            console.warn(formatTime(Date.now()), `Failed to get price for ${currencyData.currency}:`, error);
+          }
         }
       }
-    }
 
-    // calculate equity
-    const equity = positions.reduce((acc, cur) => acc + cur.closable_price * cur.volume, 0) + usdtBalance;
+      // calculate equity
+      const equity = positions.reduce((acc, cur) => acc + cur.closable_price * cur.volume, 0) + usdtBalance;
 
-    const money: IAccountMoney = {
-      currency: 'USDT',
-      balance: equity,
-      equity: equity,
-      profit: 0,
-      free: equity,
-      used: 0,
-    };
+      const money: IAccountMoney = {
+        currency: 'USDT',
+        balance: equity,
+        equity: equity,
+        profit: 0,
+        free: equity,
+        used: 0,
+      };
 
-    const accountInfo: IAccountInfo = {
-      updated_at: Date.now(),
-      account_id: SUPER_MARGIN_ACCOUNT_ID,
-      money: money,
-      positions,
-    };
+      const accountInfo: IAccountInfo = {
+        updated_at: Date.now(),
+        account_id: SUPER_MARGIN_ACCOUNT_ID,
+        money: money,
+        positions,
+      };
 
-    return accountInfo;
-  }).pipe(
-    repeat({ delay: 1000 }),
-    tap({
-      error: (e) => {
-        console.error(formatTime(Date.now()), 'superMarginAccountInfo', e);
-      },
-    }),
-    retry({ delay: 5000 }),
-    shareReplay(1),
+      return accountInfo;
+    },
+    { auto_refresh_interval: 1000 },
   );
 
-  const spotRawBalance$ = defer(() => client.getSpotAccountBalance(spotAccountUid)).pipe(
-    repeat({ delay: 1000 }),
-    retry({ delay: 5000 }),
-    shareReplay(1),
-  );
+  provideAccountInfoService(
+    terminal,
+    SPOT_ACCOUNT_ID,
+    async () => {
+      const spotBalance = await client.getSpotAccountBalance(spotAccountUid);
 
-  const spotAccountInfo$ = spotRawBalance$.pipe(
-    map((spotBalance): IAccountInfo => {
       const balance = +(spotBalance.data.list.find((v) => v.currency === 'usdt')?.balance ?? 0);
       const equity = balance;
       const free = equity;
@@ -351,15 +341,11 @@ const terminal = Terminal.fromNodeEnv();
         money: money,
         positions: [],
       };
-    }),
-    shareReplay(1),
+    },
+    { auto_refresh_interval: 1000 },
   );
-
-  publishAccountInfo(terminal, SPOT_ACCOUNT_ID, spotAccountInfo$);
   addAccountMarket(terminal, { account_id: SPOT_ACCOUNT_ID, market_id: 'HUOBI/SPOT' });
-  publishAccountInfo(terminal, SUPER_MARGIN_ACCOUNT_ID, superMarginAccountInfo$);
   addAccountMarket(terminal, { account_id: SUPER_MARGIN_ACCOUNT_ID, market_id: 'HUOBI/SUPER-MARGIN' });
-  publishAccountInfo(terminal, SWAP_ACCOUNT_ID, perpetualContractAccountInfo$);
   addAccountMarket(terminal, { account_id: SWAP_ACCOUNT_ID, market_id: 'HUOBI/SWAP' });
 
   // Submit order

--- a/apps/vendor-hyperliquid/src/index.ts
+++ b/apps/vendor-hyperliquid/src/index.ts
@@ -1,76 +1,61 @@
-import {
-  addAccountMarket,
-  IAccountInfo,
-  IAccountMoney,
-  IPosition,
-  publishAccountInfo,
-} from '@yuants/data-account';
-import { encodePath, formatTime } from '@yuants/utils';
-import { defer, repeat, retry, shareReplay, tap } from 'rxjs';
+import { addAccountMarket, IAccountMoney, IPosition, provideAccountInfoService } from '@yuants/data-account';
+import { encodePath } from '@yuants/utils';
 import { client } from './api';
+import './interest_rate';
 import './order';
 import './product';
 import { terminal } from './terminal';
-import './interest_rate';
-
-const memoizeMap = <T extends (...params: any[]) => any>(fn: T): T => {
-  const cache: Record<string, any> = {};
-  return ((...params: any[]) => (cache[encodePath(params)] ??= fn(...params))) as T;
-};
 
 (async () => {
   // swap account info
   {
-    const swapAccountInfo$ = defer(async (): Promise<IAccountInfo> => {
-      const accountRes = await client.getUserPerpetualsAccountSummary({
-        user: client.public_key!,
-      });
+    const account_id = `Hyperliquid/${client.public_key}`;
 
-      const profit = accountRes.assetPositions
-        .map((pos) => +pos.position.unrealizedPnl)
-        .reduce((a, b) => a + b, 0);
+    provideAccountInfoService(
+      terminal,
+      account_id,
+      async () => {
+        const accountRes = await client.getUserPerpetualsAccountSummary({
+          user: client.public_key!,
+        });
 
-      const money: IAccountMoney = {
-        currency: 'USDC',
-        equity: +accountRes.crossMarginSummary.accountValue,
-        profit: profit,
-        free: +accountRes.withdrawable,
-        used: +accountRes.crossMarginSummary.accountValue - +accountRes.withdrawable,
-        balance: +accountRes.crossMarginSummary.accountValue - profit,
-      };
+        const profit = accountRes.assetPositions
+          .map((pos) => +pos.position.unrealizedPnl)
+          .reduce((a, b) => a + b, 0);
 
-      return {
-        account_id: `Hyperliquid/${client.public_key}`,
-        money: money,
-        positions: accountRes.assetPositions.map(
-          (position): IPosition => ({
-            position_id: `${position.position.coin}-USD`,
-            datasource_id: 'HYPERLIQUID',
-            product_id: encodePath('PERPETUAL', `${position.position.coin}-USD`),
-            direction: +position.position.szi > 0 ? 'LONG' : 'SHORT',
-            volume: Math.abs(+position.position.szi),
-            free_volume: Math.abs(+position.position.szi),
-            position_price: +position.position.entryPx,
-            closable_price: Math.abs(+position.position.positionValue / +position.position.szi),
-            floating_profit: +position.position.unrealizedPnl,
-            valuation: +position.position.positionValue,
-            margin: +position.position.marginUsed,
-          }),
-        ),
-        updated_at: Date.now(),
-      };
-    }).pipe(
-      //
-      tap({
-        error: (e) => {
-          console.error(formatTime(Date.now()), 'PerpetualAccountInfo', e);
-        },
-      }),
-      retry({ delay: 5000 }),
-      repeat({ delay: 1000 }),
-      shareReplay(1),
+        const money: IAccountMoney = {
+          currency: 'USDC',
+          equity: +accountRes.crossMarginSummary.accountValue,
+          profit: profit,
+          free: +accountRes.withdrawable,
+          used: +accountRes.crossMarginSummary.accountValue - +accountRes.withdrawable,
+          balance: +accountRes.crossMarginSummary.accountValue - profit,
+        };
+
+        return {
+          account_id: `Hyperliquid/${client.public_key}`,
+          money: money,
+          positions: accountRes.assetPositions.map(
+            (position): IPosition => ({
+              position_id: `${position.position.coin}-USD`,
+              datasource_id: 'HYPERLIQUID',
+              product_id: encodePath('PERPETUAL', `${position.position.coin}-USD`),
+              direction: +position.position.szi > 0 ? 'LONG' : 'SHORT',
+              volume: Math.abs(+position.position.szi),
+              free_volume: Math.abs(+position.position.szi),
+              position_price: +position.position.entryPx,
+              closable_price: Math.abs(+position.position.positionValue / +position.position.szi),
+              floating_profit: +position.position.unrealizedPnl,
+              valuation: +position.position.positionValue,
+              margin: +position.position.marginUsed,
+            }),
+          ),
+          updated_at: Date.now(),
+        };
+      },
+      { auto_refresh_interval: 1000 },
     );
-    publishAccountInfo(terminal, `Hyperliquid/${client.public_key}`, swapAccountInfo$);
+
     addAccountMarket(terminal, { account_id: `Hyperliquid/${client.public_key}`, market_id: 'Hyperliquid' });
   }
 

--- a/common/changes/@yuants/vendor-bitget/2025-09-21-22-23.json
+++ b/common/changes/@yuants/vendor-bitget/2025-09-21-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-bitget",
+      "comment": "use new api",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-bitget"
+}

--- a/common/changes/@yuants/vendor-ccxt/2025-09-21-22-23.json
+++ b/common/changes/@yuants/vendor-ccxt/2025-09-21-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-ccxt",
+      "comment": "new api",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-ccxt"
+}

--- a/common/changes/@yuants/vendor-gate/2025-09-21-22-23.json
+++ b/common/changes/@yuants/vendor-gate/2025-09-21-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-gate",
+      "comment": "new api",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-gate"
+}

--- a/common/changes/@yuants/vendor-huobi/2025-09-21-22-23.json
+++ b/common/changes/@yuants/vendor-huobi/2025-09-21-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-huobi",
+      "comment": "new api",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-huobi"
+}

--- a/common/changes/@yuants/vendor-hyperliquid/2025-09-21-22-23.json
+++ b/common/changes/@yuants/vendor-hyperliquid/2025-09-21-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-hyperliquid",
+      "comment": "new api",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-hyperliquid"
+}

--- a/common/changes/@yuants/vendor-okx/2025-09-21-22-23.json
+++ b/common/changes/@yuants/vendor-okx/2025-09-21-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-okx",
+      "comment": "new api",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-okx"
+}


### PR DESCRIPTION
…ndors

- vendor-bitget: replaced publishAccountInfo with provideAccountInfoService for account info updates.
- vendor-ccxt: switched to provideAccountInfoService for funding account info.
- vendor-gate: updated spot account info to use provideAccountInfoService.
- vendor-huobi: refactored account info retrieval to use provideAccountInfoService.
- vendor-hyperliquid: transitioned to provideAccountInfoService for perpetual account info.
- vendor-okx: modified earning account info to utilize provideAccountInfoService.
- vendor-okx: updated loan account info to use provideAccountInfoService.