### PR TITLE
refactor: migrate to GlobalPrometheusRegistry for metrics collection

### DIFF
--- a/apps/host/README.md
+++ b/apps/host/README.md
@@ -49,7 +49,7 @@
 
 ## 监控
 
-Host 通过 `MetricsMeterProvider` 注册多项指标（如连接建立数量、消息大小直方图等），并在终端通道中发布，便于 Prometheus 或其他监控系统拉取。src/host-manager.ts:37
+Host 通过 `GlobalPrometheusRegistry` 注册多项指标（如连接建立数量、消息大小直方图等），并在终端通道中发布，便于 Prometheus 或其他监控系统拉取。src/host-manager.ts:37
 
 ## 开发与调试
 

--- a/common/changes/@yuants/app-host/2025-10-25-06-15.json
+++ b/common/changes/@yuants/app-host/2025-10-25-06-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/app-host",
+      "comment": "refactor to new prom",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/app-host"
+}

--- a/common/changes/@yuants/data-account/2025-10-25-06-12.json
+++ b/common/changes/@yuants/data-account/2025-10-25-06-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/data-account",
+      "comment": "refactor to new prom",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/data-account"
+}

--- a/common/changes/@yuants/data-account/2025-10-25-06-15.json
+++ b/common/changes/@yuants/data-account/2025-10-25-06-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/data-account",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@yuants/data-account"
+}

--- a/common/changes/@yuants/protocol/2025-10-25-06-12.json
+++ b/common/changes/@yuants/protocol/2025-10-25-06-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/protocol",
+      "comment": "refactor to new prom",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/protocol"
+}

--- a/common/changes/@yuants/protocol/2025-10-25-06-15.json
+++ b/common/changes/@yuants/protocol/2025-10-25-06-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/protocol",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@yuants/protocol"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2119,9 +2119,6 @@ importers:
     specifiers:
       '@cfworker/json-schema': ~4.1.1
       '@microsoft/api-extractor': ~7.30.0
-      '@opentelemetry/api': ~1.9.0
-      '@opentelemetry/exporter-prometheus': ~0.200.0
-      '@opentelemetry/sdk-metrics': ~2.0.0
       '@roamhq/wrtc': ~0.8.0
       '@rushstack/heft': ~0.47.5
       '@rushstack/heft-jest-plugin': ~0.16.8
@@ -2131,6 +2128,7 @@ importers:
       '@types/node': '22'
       '@types/simple-peer': ~9.11.8
       '@yuants/cache': workspace:*
+      '@yuants/prometheus': workspace:*
       '@yuants/prometheus-client': workspace:*
       '@yuants/tool-kit': workspace:*
       '@yuants/utils': workspace:*
@@ -2144,11 +2142,9 @@ importers:
       ws: ~8.11.0
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/exporter-prometheus': 0.200.0_@opentelemetry+api@1.9.0
-      '@opentelemetry/sdk-metrics': 2.0.0_@opentelemetry+api@1.9.0
       '@roamhq/wrtc': 0.8.0
       '@yuants/cache': link:../cache
+      '@yuants/prometheus': link:../prometheus
       '@yuants/prometheus-client': link:../prometheus-client
       '@yuants/utils': link:../utils
       ajv: 8.12.0
@@ -8710,55 +8706,6 @@ packages:
   /@opentelemetry/api/1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-    dev: false
-
-  /@opentelemetry/core/2.0.0_@opentelemetry+api@1.9.0:
-    resolution: {integrity: sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.33.0
-    dev: false
-
-  /@opentelemetry/exporter-prometheus/0.200.0_@opentelemetry+api@1.9.0:
-    resolution: {integrity: sha512-ZYdlU9r0USuuYppiDyU2VFRA0kFl855ylnb3N/2aOlXrbA4PMCznen7gmPbetGQu7pz8Jbaf4fwvrDnVdQQXSw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0_@opentelemetry+api@1.9.0
-      '@opentelemetry/resources': 2.0.0_@opentelemetry+api@1.9.0
-      '@opentelemetry/sdk-metrics': 2.0.0_@opentelemetry+api@1.9.0
-    dev: false
-
-  /@opentelemetry/resources/2.0.0_@opentelemetry+api@1.9.0:
-    resolution: {integrity: sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0_@opentelemetry+api@1.9.0
-      '@opentelemetry/semantic-conventions': 1.33.0
-    dev: false
-
-  /@opentelemetry/sdk-metrics/2.0.0_@opentelemetry+api@1.9.0:
-    resolution: {integrity: sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.0.0_@opentelemetry+api@1.9.0
-      '@opentelemetry/resources': 2.0.0_@opentelemetry+api@1.9.0
-    dev: false
-
-  /@opentelemetry/semantic-conventions/1.33.0:
-    resolution: {integrity: sha512-TIpZvE8fiEILFfTlfPnltpBaD3d9/+uQHVCyC3vfdh6WfCXKhNFzoP5RyDDIndfvZC5GrA4pyEDNyjPloJud+w==}
-    engines: {node: '>=14'}
     dev: false
 
   /@originjs/vite-plugin-commonjs/1.0.3:

--- a/libraries/protocol/README.md
+++ b/libraries/protocol/README.md
@@ -6,7 +6,7 @@
 - **智能寻址**：`TerminalClient` 基于 JSON Schema 自动筛选可用终端，内建随机负载均衡与断线重试逻辑。
 - **自描述生态**：`TerminalServer` 通过 `IServiceInfo` 广播接口契约，Host 即时感知终端能力，实现零配置编排。
 - **双通道容错**：同时支持 WebSocket 与 WebRTC，自动降级回退，保障大流量与跨网络场景稳定。
-- **可观测性先行**：`MetricsMeterProvider` 默认集成 OpenTelemetry，终端伸缩、性能瓶颈一目了然。
+- **可观测性先行**：默认集成 Prometheus，终端伸缩、性能瓶颈一目了然。
 
 ## 快速上手
 
@@ -66,8 +66,8 @@ terminal.channel.publishChannel('Heartbeat', { const: '' }, () => interval(1000)
 
 ### 指标与监控
 
-- `MetricsExporter`：基于 OpenTelemetry 的自定义 MetricReader，可将采集结果序列化为 Prometheus 文本格式。
-- `MetricsMeterProvider`：全局 MeterProvider，终端及其子模块通过它创建计数器、直方图、仪表等指标。
+- `GlobalPrometheusRegistry`： 全局 Prometheus 指标注册表，预定义多项终端与服务相关指标，供终端实例直接使用。
+- `terminal.metrics`：终端实例的 Prometheus 指标集合，终端私有指标可通过该对象创建并注册。
 - `PromRegistry`：历史遗留的 Prometheus 注册表（已标记为弃用），保留给旧版代码渐进迁移。
 
 ### 安全握手与密钥协商
@@ -79,4 +79,3 @@ terminal.channel.publishChannel('Heartbeat', { const: '' }, () => interval(1000)
 
 - 建议通过环境变量配置 `HOST_URL`、`TERMINAL_ID` 等参数，并统一使用 `Terminal.fromNodeEnv()` 创建终端实例。
 - 为保证类型安全，请在 `provideService()` 时提供完整的 JSON Schema，终端客户端会利用它自动选择匹配的服务实例。
-- 指标默认通过 `MetricsMeterProvider` 暴露，可配合 `MetricsExporter.export()` 输出 Prometheus 兼容文本，实现监控集成。

--- a/libraries/protocol/etc/protocol.api.md
+++ b/libraries/protocol/etc/protocol.api.md
@@ -6,9 +6,8 @@
 
 import { ICache } from '@yuants/cache';
 import { IEd25519KeyPair } from '@yuants/utils';
+import { IRegistry } from '@yuants/prometheus';
 import { JSONSchema7 } from 'json-schema';
-import { MeterProvider } from '@opentelemetry/sdk-metrics';
-import { MetricReader } from '@opentelemetry/sdk-metrics';
 import { Observable } from 'rxjs';
 import { ObservableInput } from 'rxjs';
 import { Registry } from '@yuants/prometheus-client';
@@ -19,6 +18,9 @@ export function createConnectionJson<T = any>(URL: string): IConnection<T>;
 
 // @public
 export function createConnectionWs<T = any>(URL: string): IConnection<T>;
+
+// @public
+export const GlobalPrometheusRegistry: IRegistry;
 
 // @public
 export interface IConnection<T> {
@@ -136,15 +138,7 @@ export interface ITerminalMessage {
     trace_id: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "YuanMetricsReader" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export const MetricsExporter: YuanMetricsReader;
-
-// @public (undocumented)
-export const MetricsMeterProvider: MeterProvider;
-
-// @public
+// @public @deprecated
 export const PromRegistry: Registry;
 
 // @public
@@ -168,6 +162,7 @@ export class Terminal {
     input$: Subject<ITerminalMessage>;
     isConnected$: Observable<boolean>;
     keyPair: IEd25519KeyPair;
+    metrics: IRegistry;
     // (undocumented)
     options: {
         verbose?: boolean;

--- a/libraries/protocol/package.json
+++ b/libraries/protocol/package.json
@@ -21,11 +21,9 @@
     "url": "~0.11.0",
     "ws": "~8.11.0",
     "@yuants/prometheus-client": "workspace:*",
+    "@yuants/prometheus": "workspace:*",
     "simple-peer": "~9.11.1",
     "@roamhq/wrtc": "~0.8.0",
-    "@opentelemetry/api": "~1.9.0",
-    "@opentelemetry/sdk-metrics": "~2.0.0",
-    "@opentelemetry/exporter-prometheus": "~0.200.0",
     "@cfworker/json-schema": "~4.1.1"
   },
   "devDependencies": {

--- a/libraries/protocol/src/metrics.ts
+++ b/libraries/protocol/src/metrics.ts
@@ -1,61 +1,17 @@
-import { PrometheusSerializer } from '@opentelemetry/exporter-prometheus';
-import {
-  AggregationTemporality,
-  AggregationType,
-  MeterProvider,
-  MetricReader,
-} from '@opentelemetry/sdk-metrics';
+import { createRegistry } from '@yuants/prometheus';
 import { Registry } from '@yuants/prometheus-client';
-
-class YuanMetricsReader extends MetricReader {
-  private serializer: PrometheusSerializer;
-  constructor(
-    public config: {
-      prefix?: string;
-    },
-  ) {
-    super({
-      aggregationSelector: (_instrumentType) => {
-        return {
-          type: AggregationType.DEFAULT,
-        };
-      },
-      aggregationTemporalitySelector: (_instrumentType) => AggregationTemporality.CUMULATIVE,
-    });
-    this.serializer = new PrometheusSerializer(this.config?.prefix);
-  }
-
-  async export(): Promise<string> {
-    const { resourceMetrics, errors } = await this.collect();
-    if (errors.length > 0) {
-      console.error('MetricsExporter: Error collecting metrics:', errors);
-    }
-    return this.serializer.serialize(resourceMetrics);
-  }
-
-  override async onForceFlush(): Promise<void> {
-    /** do nothing */
-  }
-
-  protected onShutdown(): Promise<void> {
-    return Promise.resolve(undefined);
-  }
-}
-
-/**
- * @public
- */
-export const MetricsExporter = new YuanMetricsReader({});
-
-/**
- * @public
- */
-export const MetricsMeterProvider = new MeterProvider({
-  readers: [MetricsExporter],
-});
 
 /**
  * Prometheus Metrics Registry
+ *
+ * @deprecated - use terminal.metrics or GlobalPrometheusRegistry instead
+ *
  * @public
  */
 export const PromRegistry = new Registry();
+
+/**
+ * Global Prometheus Metrics Registry
+ * @public
+ */
+export const GlobalPrometheusRegistry = createRegistry();


### PR DESCRIPTION
- Updated metrics registration from MetricsMeterProvider to GlobalPrometheusRegistry across various modules.
- Removed OpenTelemetry dependencies and related metrics code.
- Enhanced README and API documentation to reflect changes in metrics handling.
- Adjusted terminal and server classes to utilize the new metrics system.
- Cleaned up legacy code related to OpenTelemetry metrics.