### PR TITLE
fix(docs): 修复中文文档中返回主README的链接路径

### DIFF
--- a/docs/zh-Hans/README.md
+++ b/docs/zh-Hans/README.md
@@ -38,7 +38,7 @@
 如果您是第一次接触 Yuan 项目，建议按以下顺序阅读：
 
 1. [架构概述](architecture-overview.md) - 了解系统整体设计
-2. [快速开始](../README.zh-Hans.md#开始使用-单机部署-🚀) - 查看快速入门指南
+2. [快速开始](../../README.zh-Hans.md#开始使用-单机部署-🚀) - 查看快速入门指南
 3. [Web UI](web-ui.md) - 了解用户界面功能
 4. [智能体](agents.md) - 学习策略开发
 
@@ -64,5 +64,5 @@ Yuan 项目采用 MIT 许可证。详细信息请参阅 [LICENSE](../LICENSE) �
 ---
 
 <p align="center">
-  <a href="../README.zh-Hans.md">返回主 README</a>
+  <a href="../../README.zh-Hans.md">返回主 README</a>
 </p>

--- a/docs/zh-Hans/agents.md
+++ b/docs/zh-Hans/agents.md
@@ -72,4 +72,4 @@
 - **可靠运行**: 具备自动纠错和重启机制
 - **性能监控**: 提供详细的运行统计和监控
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/architecture-overview.md
+++ b/docs/zh-Hans/architecture-overview.md
@@ -29,4 +29,4 @@ Yuan 是一个"个人投资操作系统"，采用分布式架构设计，通过 
 - 云原生设计
 - AI 赋能
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>)</p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>)</p>

--- a/docs/zh-Hans/data-collection.md
+++ b/docs/zh-Hans/data-collection.md
@@ -45,4 +45,4 @@
 - **可靠**: 具备错误处理和重试机制
 - **高效**: 优化数据存储和查询性能
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/data-modeling.md
+++ b/docs/zh-Hans/data-modeling.md
@@ -61,4 +61,4 @@ Level-1 报价数据，具体是指产品的最新价格和最优报价等信息
 - 时间序列特性优化数据存储和查询
 - 模块化设计便于扩展和维护
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/database.md
+++ b/docs/zh-Hans/database.md
@@ -35,4 +35,4 @@
 - 定期备份重要数据
 - 使用 SQL 迁移工具管理数据库模式变更
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/distributions.md
+++ b/docs/zh-Hans/distributions.md
@@ -89,4 +89,4 @@ https://y.ntnl.io?from_npm=1&scope=yuants&name=dist-origin&version=>=0.0.2
 - **社区贡献**: 鼓励社区创建和分享发行版
 - **持续更新**: 官方维护，定期更新
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/documentation.md
+++ b/docs/zh-Hans/documentation.md
@@ -60,4 +60,4 @@
 
 欢迎社区贡献文档改进和新内容。
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/miscellaneous.md
+++ b/docs/zh-Hans/miscellaneous.md
@@ -66,4 +66,4 @@
 - **自定义工作流**: 根据需求定制工作流程
 - **实验性功能**: 在不影响核心系统的情况下测试新功能
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/monitoring-alerting.md
+++ b/docs/zh-Hans/monitoring-alerting.md
@@ -42,4 +42,4 @@
 - 服务质量监控
 - 异常检测和报警
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/rpc-framework.md
+++ b/docs/zh-Hans/rpc-framework.md
@@ -30,4 +30,4 @@ Yuan 通过一套 RPC 框架来实现分布式系统中终端之间的通信。�
 - ED25519 签名验证
 - 私钥保护机制
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/service-providers.md
+++ b/docs/zh-Hans/service-providers.md
@@ -81,4 +81,4 @@
 - **数据控制**: 数据仅存储在您主机内的存储中
 - **全球覆盖**: 支持多种市场和交易所
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/toolkit.md
+++ b/docs/zh-Hans/toolkit.md
@@ -166,4 +166,4 @@ npx @yuants/tool-kit publish
 - 容器化运行
 - 监控和日志
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/trading-execution.md
+++ b/docs/zh-Hans/trading-execution.md
@@ -77,4 +77,4 @@
 - **智能跟单**: 多种跟单策略适应不同市场
 - **全面风控**: 多层次风险控制机制
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>

--- a/docs/zh-Hans/web-ui.md
+++ b/docs/zh-Hans/web-ui.md
@@ -109,4 +109,4 @@ GUI 使用的工作区的内容是完全保密的：
 
 通过移动浏览器访问，获得优化的移动体验。
 
-<p align="right">(<a href="../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>
+<p align="right">(<a href="../../README.zh-Hans.md">返回 README</a>) | <a href="architecture-overview.md">架构概述</a></p>


### PR DESCRIPTION
修复了 docs/zh-Hans/ 目录中所有文档文件的返回主README链接路径错误。将15个文档文件中的 ../README.zh-Hans.md 链接修正为 ../../README.zh-Hans.md，确保从 docs/zh-Hans/ 子目录能够正确导航到根目录的README文件。这是文档修复，不需要运行CI测试。