### PR TITLE
Normalize ASTER product identifiers across services

### DIFF
--- a/apps/vendor-aster/src/account.ts
+++ b/apps/vendor-aster/src/account.ts
@@ -1,5 +1,6 @@
 import { IPosition, provideAccountInfoService } from '@yuants/data-account';
 import { Terminal } from '@yuants/protocol';
+import { encodePath } from '@yuants/utils';
 import { getFApiV4Account } from './api';
 
 const ADDRESS = process.env.ADDRESS!;
@@ -19,7 +20,7 @@ provideAccountInfoService(
       .map(
         (p): IPosition => ({
           position_id: p.symbol,
-          product_id: p.symbol,
+          product_id: encodePath('PERPETUAL', p.symbol),
           datasource_id: 'ASTER',
           direction: p.positionSide === 'BOTH' ? (+p.positionAmt > 0 ? 'LONG' : 'SHORT') : p.positionSide,
           volume: Math.abs(+p.positionAmt),

--- a/apps/vendor-aster/src/order.ts
+++ b/apps/vendor-aster/src/order.ts
@@ -12,8 +12,11 @@ terminal.server.provideService<IOrder>(
   async (msg) => {
     const order = msg.req;
 
-    const [, decodedSymbol] = decodePath(order.product_id ?? '');
-    const symbol = decodedSymbol ?? order.product_id;
+    const [, decodedSymbol] = decodePath(order.product_id);
+    if (!decodedSymbol) {
+      throw new Error(`Invalid product_id: unable to decode symbol from "${order.product_id}"`);
+    }
+    const symbol = decodedSymbol;
 
     const side = ({ OPEN_LONG: 'BUY', OPEN_SHORT: 'SELL', CLOSE_LONG: 'SELL', CLOSE_SHORT: 'BUY' } as const)[
       order.order_direction!

--- a/apps/vendor-aster/src/order.ts
+++ b/apps/vendor-aster/src/order.ts
@@ -1,5 +1,6 @@
 import { Terminal } from '@yuants/protocol';
 import { IOrder } from '@yuants/data-order';
+import { decodePath } from '@yuants/utils';
 import { ACCOUNT_ID } from './account';
 import { postFApiV1Order } from './api';
 
@@ -11,7 +12,8 @@ terminal.server.provideService<IOrder>(
   async (msg) => {
     const order = msg.req;
 
-    const symbol = order.product_id;
+    const [, decodedSymbol] = decodePath(order.product_id ?? '');
+    const symbol = decodedSymbol ?? order.product_id;
 
     const side = ({ OPEN_LONG: 'BUY', OPEN_SHORT: 'SELL', CLOSE_LONG: 'SELL', CLOSE_SHORT: 'BUY' } as const)[
       order.order_direction!

--- a/common/changes/@yuants/vendor-aster/product-id-alignment.json
+++ b/common/changes/@yuants/vendor-aster/product-id-alignment.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Ensure ASTER uses encoded product identifiers for storage while decoding them before submitting orders.",
+      "type": "patch",
+      "packageName": "@yuants/vendor-aster"
+    }
+  ],
+  "packageName": "@yuants/vendor-aster"
+}


### PR DESCRIPTION
## Summary
- decode encoded ASTER product identifiers before forwarding orders to the exchange API
- emit encoded product identifiers from the ASTER account service to align with the product catalog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690866e3ab60832c8ef9a2610ca1d50d