### PR TITLE
Refactor account info retrieval to return positions directly

### DIFF
--- a/apps/vendor-aster/src/services/accounts/perp.ts
+++ b/apps/vendor-aster/src/services/accounts/perp.ts
@@ -24,12 +24,5 @@ export const getPerpAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = a
         valuation: Math.abs(+p.notional),
       }),
     );
-  return {
-    money: {
-      currency: 'USD',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-aster/src/services/accounts/spot.ts
+++ b/apps/vendor-aster/src/services/accounts/spot.ts
@@ -1,4 +1,4 @@
-import { IActionHandlerOfGetAccountInfo, IPosition } from '@yuants/data-account';
+import { IActionHandlerOfGetAccountInfo, IPosition, makeSpotPosition } from '@yuants/data-account';
 import { getApiV1Account, getApiV1TickerPrice, ICredential } from '../../api/private-api';
 
 export const getSpotAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (
@@ -13,37 +13,15 @@ export const getSpotAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = a
   const positions = x.balances.map((b): IPosition => {
     const thePrice = b.asset === 'USDT' ? 1 : prices.find((p) => p.symbol === b.asset + 'USDT')?.price ?? 0;
 
-    const volume = +b.free + +b.locked;
-
-    const position_price = +thePrice;
-    const closable_price = +thePrice;
-    const valuation = volume * closable_price;
-    const floating_profit = 0;
-
-    return {
+    return makeSpotPosition({
       position_id: b.asset,
       datasource_id: 'ASTER',
       product_id: b.asset,
-      direction: 'LONG',
-      volume,
+      volume: +b.free + +b.locked,
       free_volume: +b.free,
-      position_price,
-      closable_price,
-      floating_profit,
-      valuation,
-    };
+      closable_price: +thePrice,
+    });
   });
 
-  const usdtAsset = x.balances.find((b) => b.asset === 'USDT');
-  const equity = positions.reduce((a, b) => a + b.valuation, 0);
-  const free = usdtAsset ? +usdtAsset.free : 0;
-
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-binance/src/legacy_index.ts
+++ b/apps/vendor-binance/src/legacy_index.ts
@@ -3,7 +3,6 @@ import { IOrder, providePendingOrdersService } from '@yuants/data-order';
 import { Terminal } from '@yuants/protocol';
 import { addAccountTransferAddress } from '@yuants/transfer';
 import { decodePath, encodePath, formatTime } from '@yuants/utils';
-import { defer, from, map, mergeMap, repeat, retry, shareReplay, toArray } from 'rxjs';
 import { createHash } from 'crypto';
 import { getDefaultCredential, isApiError } from './api/client';
 import {
@@ -208,14 +207,7 @@ if (isPublicOnly) {
               };
             });
 
-          return {
-            money: {
-              currency: 'USDT',
-              equity,
-              free,
-            },
-            positions,
-          };
+          return positions;
         },
         { auto_refresh_interval: 1000 },
       );
@@ -257,14 +249,7 @@ if (isPublicOnly) {
               return position;
             })
             .filter((position): position is IPosition => Boolean(position));
-          return {
-            money: {
-              currency: 'USDT',
-              equity: +(usdtAssets?.free || 0) + +(usdtAssets?.locked || 0),
-              free: +(usdtAssets?.free || 0),
-            },
-            positions,
-          };
+          return positions;
         },
         {
           auto_refresh_interval: 5_000,

--- a/apps/vendor-binance/src/services/accounts/spot.ts
+++ b/apps/vendor-binance/src/services/accounts/spot.ts
@@ -1,46 +1,27 @@
-import { IActionHandlerOfGetAccountInfo, IPosition } from '@yuants/data-account';
+import { IActionHandlerOfGetAccountInfo, IPosition, makeSpotPosition } from '@yuants/data-account';
 import { encodePath } from '@yuants/utils';
 import { isApiError } from '../../api/client';
 import { getSpotAccountInfo, ICredential } from '../../api/private-api';
 
-export const getSpotAccountInfoSnapshot: IActionHandlerOfGetAccountInfo<ICredential> = async (
-  credential,
-  _accountId,
-) => {
+export const getSpotAccountInfoSnapshot: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
   const res = await getSpotAccountInfo(credential, { omitZeroBalances: true });
   if (isApiError(res)) {
     throw new Error(res.msg);
   }
-  const usdtAsset = res.balances.find((balance) => balance.asset === 'USDT');
-  const free = +(usdtAsset?.free ?? 0);
-  const locked = +(usdtAsset?.locked ?? 0);
-  const equity = free + locked;
   const positions = res.balances
-    .filter((balance) => balance.asset !== 'USDT')
     .map((balance) => {
       const volume = +balance.free + +balance.locked;
       if (!volume) return undefined;
-      const position: IPosition = {
+      const position: IPosition = makeSpotPosition({
         position_id: `spot/${balance.asset}`,
         datasource_id: 'BINANCE',
         product_id: encodePath('spot', `${balance.asset}USDT`),
-        direction: 'LONG',
         volume,
         free_volume: +balance.free,
-        position_price: 0,
-        closable_price: 0,
-        floating_profit: 0,
-        valuation: 0,
-      };
+        closable_price: 0, // TODO: fetch price later
+      });
       return position;
     })
     .filter((position): position is IPosition => Boolean(position));
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-binance/src/services/accounts/unified.ts
+++ b/apps/vendor-binance/src/services/accounts/unified.ts
@@ -54,12 +54,5 @@ export const getUnifiedAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> 
           (+position.positionAmt === 0 ? 0 : +position.unrealizedProfit / +position.positionAmt)),
     }));
 
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-bitget/src/services/accounts/futures.ts
+++ b/apps/vendor-bitget/src/services/accounts/futures.ts
@@ -53,15 +53,7 @@ export const getFuturesAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> 
   if (positionsRes.msg !== 'success') {
     throw new Error(positionsRes.msg);
   }
-  const account = balanceRes.data[0];
-  return {
-    money: {
-      currency: 'USDT',
-      equity: +account.accountEquity,
-      free: +account.maxTransferOut,
-    },
-    positions: positionsRes.data.map(mapPosition),
-  };
+  return positionsRes.data.map(mapPosition);
 };
 
 export const listFuturePendingOrders = async (

--- a/apps/vendor-ctp/src/exchange.ts
+++ b/apps/vendor-ctp/src/exchange.ts
@@ -374,6 +374,19 @@ provideAccountInfoService(
     ]);
 
     const positions: IPosition[] = [];
+
+    positions.push({
+      datasource_id: DATASOURCE_ID,
+      position_id: encodePath('MONEY', 'CNY'),
+      product_id: 'CNY',
+      volume: money1.Balance,
+      free_volume: money1.Available,
+      position_price: 0,
+      closable_price: 1,
+      floating_profit: money1.Balance,
+      valuation: money1.Balance,
+    });
+
     for (const msg of positionsRes) {
       // Lazy Load Product: 避免一次性查询所有合约信息 (可能有上万个合约)
       const theProduct = await cacheOfProduct.query(`${msg.ExchangeID}-${msg.InstrumentID}`);
@@ -434,14 +447,7 @@ provideAccountInfoService(
       }
     }
 
-    return {
-      money: {
-        currency: money1.CurrencyID,
-        equity: money1.Balance,
-        free: money1.Available,
-      },
-      positions,
-    };
+    return positions;
   },
   {
     auto_refresh_interval: 5000,

--- a/apps/vendor-gate/src/services/accounts/future.ts
+++ b/apps/vendor-gate/src/services/accounts/future.ts
@@ -1,4 +1,4 @@
-import type { IPosition } from '@yuants/data-account';
+import type { IActionHandlerOfGetAccountInfo, IPosition } from '@yuants/data-account';
 import { firstValueFrom } from 'rxjs';
 import { getFuturePositions, getFuturesAccounts, ICredential } from '../../api/private-api';
 import { mapProductIdToUsdtFutureProduct$ } from '../markets/product';
@@ -37,23 +37,11 @@ export const loadFuturePositions = async (credential: ICredential): Promise<IPos
   });
 };
 
-export const getFutureAccountInfo = async (credential: ICredential, account_id: string) => {
+export const getFutureAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
   const [positions, rawAccount] = await Promise.all([
     loadFuturePositions(credential),
     getFuturesAccounts(credential, 'usdt'),
   ]);
 
-  const account = rawAccount?.available ? rawAccount : { available: '0', total: '0', unrealised_pnl: '0' };
-  const free = Number(account.available ?? 0);
-  const equity = Number(account.total ?? 0) + Number(account.unrealised_pnl ?? 0);
-
-  return {
-    account_id,
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-gate/src/services/accounts/spot.ts
+++ b/apps/vendor-gate/src/services/accounts/spot.ts
@@ -1,18 +1,18 @@
+import { IActionHandlerOfGetAccountInfo, makeSpotPosition } from '@yuants/data-account';
 import { getSpotAccounts, ICredential } from '../../api/private-api';
 
-export const getSpotAccountInfo = async (credential: ICredential, account_id: string) => {
+export const getSpotAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
   const res = await getSpotAccounts(credential);
   if (!Array.isArray(res)) {
     throw new Error('Failed to load spot balances');
   }
-  const balance = Number(res.find((item) => item.currency === 'USDT')?.available ?? '0');
-  return {
-    account_id,
-    money: {
-      currency: 'USDT',
-      equity: balance,
-      free: balance,
-    },
-    positions: [],
-  };
+  return res.map((item) => {
+    return makeSpotPosition({
+      position_id: item.currency,
+      product_id: `${item.currency}-USDT`,
+      volume: Number(item.available),
+      free_volume: Number(item.available),
+      closable_price: 1, // TODO: use real price
+    });
+  });
 };

--- a/apps/vendor-gate/src/services/accounts/unified.ts
+++ b/apps/vendor-gate/src/services/accounts/unified.ts
@@ -1,9 +1,9 @@
-import type { IPosition } from '@yuants/data-account';
-import { getSpotTickers } from '../../api/public-api';
+import type { IActionHandlerOfGetAccountInfo, IPosition } from '@yuants/data-account';
 import { getUnifiedAccounts, ICredential } from '../../api/private-api';
+import { getSpotTickers } from '../../api/public-api';
 import { loadFuturePositions } from './future';
 
-export const getUnifiedAccountInfo = async (credential: ICredential, account_id: string) => {
+export const getUnifiedAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
   const [futurePositions, unifiedAccount, spotTickers] = await Promise.all([
     loadFuturePositions(credential),
     getUnifiedAccounts(credential, {}),
@@ -39,16 +39,5 @@ export const getUnifiedAccountInfo = async (credential: ICredential, account_id:
     })
     .filter((item): item is IPosition => !!item);
 
-  const free = Number(balances['USDT']?.available || 0);
-  const equity = Number(unifiedAccount?.unified_account_total_equity || 0);
-
-  return {
-    account_id,
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions: [...futurePositions, ...spotPositions],
-  };
+  return [...futurePositions, ...spotPositions];
 };

--- a/apps/vendor-huobi/src/accounts/super-margin.ts
+++ b/apps/vendor-huobi/src/accounts/super-margin.ts
@@ -20,11 +20,6 @@ export const getSuperMarginAccountInfo: IActionHandlerOfGetAccountInfo<ICredenti
   const accountBalance = await getSpotAccountBalance(credential, superMarginAccountUid);
   const balanceList = accountBalance.data?.list || [];
 
-  // calculate usdt balance
-  const usdtBalance = balanceList
-    .filter((v) => v.currency === 'usdt')
-    .reduce((acc, cur) => acc + +cur.balance, 0);
-
   // get positions (non-usdt currencies)
   const positions: IPosition[] = [];
   const nonUsdtCurrencies = balanceList
@@ -64,15 +59,5 @@ export const getSuperMarginAccountInfo: IActionHandlerOfGetAccountInfo<ICredenti
     }
   }
 
-  // calculate equity
-  const equity = positions.reduce((acc, cur) => acc + cur.closable_price * cur.volume, 0) + usdtBalance;
-
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free: equity,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-huobi/src/accounts/swap.ts
+++ b/apps/vendor-huobi/src/accounts/swap.ts
@@ -83,12 +83,5 @@ export const getSwapAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = a
   //   page_index++;
   // }
 
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-hyperliquid/src/services/accounts/perp.ts
+++ b/apps/vendor-hyperliquid/src/services/accounts/perp.ts
@@ -1,6 +1,6 @@
 import { IPosition } from '@yuants/data-account';
 import { encodePath, formatTime } from '@yuants/utils';
-import { getUserOpenOrders, getUserPerpetualsAccountSummary } from '../../api/public-api';
+import { getUserPerpetualsAccountSummary } from '../../api/public-api';
 import { getAddressFromCredential, ICredential } from '../../api/types';
 
 /**
@@ -10,7 +10,6 @@ export const getPerpAccountInfo = async (credential: ICredential, account_id: st
   console.info(`[${formatTime(Date.now())}] Getting perp account info for ${account_id}`);
 
   const summary = await getUserPerpetualsAccountSummary({ user: getAddressFromCredential(credential) });
-  const orders = await getUserOpenOrders({ user: getAddressFromCredential(credential) });
 
   // Map positions
   const positions = summary.assetPositions.map(
@@ -41,24 +40,5 @@ export const getPerpAccountInfo = async (credential: ICredential, account_id: st
     return 'OPEN_LONG';
   };
 
-  const pending_orders = orders.map((order) => ({
-    order_id: `${order.oid}`,
-    account_id,
-    product_id: encodePath('PERPETUAL', `${order.coin?.trim()}-USD`),
-    order_type: 'LIMIT',
-    order_direction: mapOrderDirection(order.side),
-    volume: Number(order.sz) || 0,
-    price: Number(order.limitPx) || undefined,
-    submit_at: Number(order.timestamp ?? Date.now()),
-  }));
-
-  return {
-    money: {
-      currency: 'USD',
-      equity: +summary.crossMarginSummary.accountValue,
-      free: +summary.withdrawable,
-    },
-    positions,
-    pending_orders,
-  };
+  return positions;
 };

--- a/apps/vendor-hyperliquid/src/services/accounts/spot.ts
+++ b/apps/vendor-hyperliquid/src/services/accounts/spot.ts
@@ -1,4 +1,4 @@
-import { IPosition } from '@yuants/data-account';
+import { IPosition, makeSpotPosition } from '@yuants/data-account';
 import { encodePath, formatTime } from '@yuants/utils';
 import { getUserTokenBalances } from '../../api/public-api';
 import { getAddressFromCredential, ICredential } from '../../api/types';
@@ -13,30 +13,18 @@ export const getSpotAccountInfo = async (credential: ICredential, account_id: st
 
   // Map token balances to positions (using spot as "positions")
   const positions = balances.balances
-    .filter((balance: any) => Number(balance.total) > 0)
+    .filter((balance) => Number(balance.total) > 0)
     .map(
-      (balance: any): IPosition => ({
-        position_id: `${balance.coin}`,
-        datasource_id: 'HYPERLIQUID',
-        product_id: encodePath('SPOT', `${balance.coin}-USDC`),
-        direction: 'LONG',
-        volume: Number(balance.total),
-        free_volume: Number(balance.total) - Number(balance.hold),
-        position_price: 1, // USDC as quote currency
-        closable_price: 1,
-        floating_profit: 0,
-        valuation: Number(balance.total),
-        margin: 0,
-      }),
+      (balance): IPosition =>
+        makeSpotPosition({
+          position_id: `${balance.coin}`,
+          datasource_id: 'HYPERLIQUID',
+          product_id: encodePath('SPOT', `${balance.coin}-USDC`),
+          volume: Number(balance.total),
+          free_volume: Number(balance.total) - Number(balance.hold),
+          closable_price: 1,
+        }),
     );
 
-  return {
-    money: {
-      currency: 'USDC',
-      equity: positions.reduce((sum: number, pos: any) => sum + pos.valuation, 0),
-      free: positions.reduce((sum: number, pos: any) => sum + pos.free_volume, 0),
-    },
-    positions,
-    pending_orders: [], // Spot orders would need separate API call
-  };
+  return positions;
 };

--- a/apps/vendor-hyperliquid/src/services/legacy.ts
+++ b/apps/vendor-hyperliquid/src/services/legacy.ts
@@ -5,6 +5,7 @@ import { getAddressFromCredential, getDefaultCredential } from '../api/types';
 import { getPerpAccountInfo } from './accounts/perp';
 import { getSpotAccountInfo } from './accounts/spot';
 import { cancelOrderAction } from './orders/cancelOrder';
+import { listOrders } from './orders/listOrders';
 import { submitOrder } from './orders/submitOrder';
 
 const terminal = Terminal.fromNodeEnv();
@@ -21,11 +22,7 @@ provideAccountInfoService(
   defaultPerpAccountId,
   async () => {
     const info = await getPerpAccountInfo(credential, defaultPerpAccountId);
-    return {
-      money: info.money,
-      positions: info.positions,
-      orders: info.pending_orders,
-    };
+    return info;
   },
   { auto_refresh_interval: 1000 },
 );
@@ -33,23 +30,14 @@ provideAccountInfoService(
 providePendingOrdersService(
   terminal,
   defaultPerpAccountId,
-  async () => {
-    const info = await getPerpAccountInfo(credential, defaultPerpAccountId);
-    return info.pending_orders;
-  },
+  async () => listOrders(credential, defaultPerpAccountId),
   { auto_refresh_interval: 2000 },
 );
 
 provideAccountInfoService(
   terminal,
   defaultSpotAccountId,
-  async () => {
-    const info = await getSpotAccountInfo(credential, defaultSpotAccountId);
-    return {
-      money: info.money,
-      positions: info.positions,
-    };
-  },
+  async () => getSpotAccountInfo(credential, defaultSpotAccountId),
   { auto_refresh_interval: 5000 },
 );
 

--- a/apps/vendor-okx-web3/src/account.ts
+++ b/apps/vendor-okx-web3/src/account.ts
@@ -177,14 +177,7 @@ provideAccountInfoService(
     });
     console.info(formatTime(Date.now()), `TotalPositions ${positions.length}`);
 
-    return {
-      money: {
-        currency: 'USD',
-        equity: totalAssets,
-        free: 0,
-      },
-      positions,
-    };
+    return positions;
   },
   {
     auto_refresh_interval: process.env.ACCOUNT_AUTO_REFRESH_INTERVAL

--- a/apps/vendor-okx/src/account-actions-with-credential.ts
+++ b/apps/vendor-okx/src/account-actions-with-credential.ts
@@ -1,7 +1,5 @@
 import { provideAccountActionsWithCredential } from '@yuants/data-account';
 import { Terminal } from '@yuants/protocol';
-import { ICredential } from './api/private-api';
-import { getAccountIds } from './accountInfos/uid';
 import {
   getEarningAccountInfo,
   getFundingAccountInfo,
@@ -9,6 +7,8 @@ import {
   getStrategyAccountInfo,
   getTradingAccountInfo,
 } from './accountInfos';
+import { getAccountIds } from './accountInfos/uid';
+import { ICredential } from './api/private-api';
 
 provideAccountActionsWithCredential<ICredential>(
   Terminal.fromNodeEnv(),
@@ -33,15 +33,15 @@ provideAccountActionsWithCredential<ICredential>(
       if (!accountIds) throw new Error('Failed to get account IDs');
       switch (account_id) {
         case accountIds.trading:
-          return getTradingAccountInfo(credential);
+          return getTradingAccountInfo(credential, account_id);
         case accountIds.funding:
-          return getFundingAccountInfo(credential);
+          return getFundingAccountInfo(credential, account_id);
         case accountIds.earning:
-          return getEarningAccountInfo(credential);
+          return getEarningAccountInfo(credential, account_id);
         case accountIds.loan:
-          return getLoanAccountInfo(credential);
+          return getLoanAccountInfo(credential, account_id);
         case accountIds.strategy:
-          return getStrategyAccountInfo(credential);
+          return getStrategyAccountInfo(credential, account_id);
       }
       throw new Error(`Unsupported account_id: ${account_id}`);
     },

--- a/apps/vendor-okx/src/account.ts
+++ b/apps/vendor-okx/src/account.ts
@@ -33,31 +33,51 @@ defer(async () => {
   const tradingAccountId = await getTradingAccountId(credential);
   addAccountMarket(terminal, { account_id: tradingAccountId, market_id: 'OKX' });
 
-  provideAccountInfoService(terminal, tradingAccountId, () => getTradingAccountInfo(credential), {
-    auto_refresh_interval: 1000,
-  });
+  provideAccountInfoService(
+    terminal,
+    tradingAccountId,
+    () => getTradingAccountInfo(credential, tradingAccountId),
+    {
+      auto_refresh_interval: 1000,
+    },
+  );
 }).subscribe();
 
 defer(async () => {
   const fundingAccountId = await getFundingAccountId(credential);
 
-  provideAccountInfoService(terminal, fundingAccountId, () => getFundingAccountInfo(credential), {
-    auto_refresh_interval: 1000,
-  });
+  provideAccountInfoService(
+    terminal,
+    fundingAccountId,
+    () => getFundingAccountInfo(credential, fundingAccountId),
+    {
+      auto_refresh_interval: 1000,
+    },
+  );
 }).subscribe();
 
 defer(async () => {
   const earningAccountId = await getEarningAccountId(credential);
-  provideAccountInfoService(terminal, earningAccountId, () => getEarningAccountInfo(credential), {
-    auto_refresh_interval: 5000,
-  });
+  provideAccountInfoService(
+    terminal,
+    earningAccountId,
+    () => getEarningAccountInfo(credential, earningAccountId),
+    {
+      auto_refresh_interval: 5000,
+    },
+  );
 }).subscribe();
 
 defer(async () => {
   const loanAccountId = await getLoanAccountId(credential);
-  provideAccountInfoService(Terminal.fromNodeEnv(), loanAccountId, () => getLoanAccountInfo(credential), {
-    auto_refresh_interval: 1000,
-  });
+  provideAccountInfoService(
+    Terminal.fromNodeEnv(),
+    loanAccountId,
+    () => getLoanAccountInfo(credential, loanAccountId),
+    {
+      auto_refresh_interval: 1000,
+    },
+  );
 }).subscribe();
 
 // 导出 marketIndexTickerUSDT$ 供其他模块使用

--- a/apps/vendor-okx/src/accountInfos/funding.ts
+++ b/apps/vendor-okx/src/accountInfos/funding.ts
@@ -1,54 +1,19 @@
-import { IPosition } from '@yuants/data-account';
+import { IActionHandlerOfGetAccountInfo, makeSpotPosition } from '@yuants/data-account';
 import { encodePath } from '@yuants/utils';
-import { firstValueFrom } from 'rxjs';
 import { ICredential, getAssetBalances } from '../api/private-api';
-import { marketIndexTickerUSDT$ } from './trading';
-import { IAccountInfoCore } from './types';
+import { getSpotPrice } from './trading';
 
-export const getFundingAccountInfo = async (credential: ICredential): Promise<IAccountInfoCore> => {
-  const [assetBalances, marketIndexTickerUSDT] = await Promise.all([
-    getAssetBalances(credential, {}),
-    firstValueFrom(marketIndexTickerUSDT$),
-  ]);
+export const getFundingAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
+  const assetBalances = await getAssetBalances(credential, {});
 
-  const positions: IPosition[] = [];
-  let equity = 0;
-  let free = 0;
-
-  assetBalances.data.forEach((x) => {
-    if (x.ccy === 'USDT') {
-      const balance = +x.bal;
-      equity += balance;
-      free += balance;
-      return;
-    }
-
-    const price = marketIndexTickerUSDT.get(`${x.ccy}-USDT`) || 0;
-    const valuation = price * +x.bal || 0;
-    const productId = encodePath('SPOT', `${x.ccy}-USDT`);
-
-    positions.push({
+  return assetBalances.data.map((x) =>
+    makeSpotPosition({
       datasource_id: 'OKX',
-      position_id: productId,
-      product_id: productId,
-      direction: 'LONG',
+      position_id: encodePath('SPOT', `${x.ccy}-USDT`),
+      product_id: encodePath('SPOT', `${x.ccy}-USDT`),
       volume: +x.bal,
       free_volume: +x.bal,
-      position_price: price,
-      floating_profit: 0,
-      closable_price: price,
-      valuation,
-    });
-
-    equity += valuation;
-  });
-
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+      closable_price: getSpotPrice(x.ccy),
+    }),
+  );
 };

--- a/apps/vendor-okx/src/accountInfos/loan.ts
+++ b/apps/vendor-okx/src/accountInfos/loan.ts
@@ -1,15 +1,16 @@
-import { IPosition } from '@yuants/data-account';
+import { IActionHandlerOfGetAccountInfo, IPosition, makeSpotPosition } from '@yuants/data-account';
 import { encodePath } from '@yuants/utils';
 import { ICredential, getFlexibleLoanInfo } from '../api/private-api';
-import { IAccountInfoCore } from './types';
+import { getSpotPrice } from './trading';
 
-export const getLoanAccountInfo = async (credential: ICredential): Promise<IAccountInfoCore> => {
+export const getLoanAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
   const res = await getFlexibleLoanInfo(credential);
   const data = res.data[0];
+  if (!data) return [];
 
   const positions: IPosition[] = [];
 
-  const loanData = data?.loanData || [];
+  const loanData = data.loanData || [];
   for (const loan of loanData) {
     positions.push({
       datasource_id: 'OKX',
@@ -19,35 +20,24 @@ export const getLoanAccountInfo = async (credential: ICredential): Promise<IAcco
       position_id: encodePath('loan', loan.ccy),
       direction: 'SHORT',
       position_price: 0,
-      closable_price: 0,
-      floating_profit: 0,
-      valuation: 0,
+      closable_price: getSpotPrice(loan.ccy),
+      floating_profit: -getSpotPrice(loan.ccy) * +loan.amt,
+      valuation: getSpotPrice(loan.ccy) * +loan.amt,
     });
   }
-  const collateralData = data?.collateralData || [];
+  const collateralData = data.collateralData || [];
   for (const collateral of collateralData) {
-    positions.push({
-      datasource_id: 'OKX',
-      product_id: `SPOT/${collateral.ccy}-USDT`,
-      volume: +collateral.amt,
-      free_volume: +collateral.amt,
-      position_id: encodePath('collateral', collateral.ccy),
-      direction: 'LONG',
-      position_price: 0,
-      closable_price: 0,
-      floating_profit: 0,
-      valuation: 0,
-    });
+    positions.push(
+      makeSpotPosition({
+        position_id: encodePath('collateral', collateral.ccy),
+        datasource_id: 'OKX',
+        product_id: `SPOT/${collateral.ccy}-USDT`,
+        volume: +collateral.amt,
+        free_volume: +collateral.amt,
+        closable_price: getSpotPrice(collateral.ccy),
+      }),
+    );
   }
-  const equity = +data.collateralNotionalUsd - +data.loanNotionalUsd;
-  const free = equity - +data.collateralNotionalUsd;
 
-  return {
-    money: {
-      currency: 'USDT',
-      equity,
-      free,
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-okx/src/accountInfos/strategy.ts
+++ b/apps/vendor-okx/src/accountInfos/strategy.ts
@@ -1,9 +1,8 @@
-import { IPosition } from '@yuants/data-account';
+import { IActionHandlerOfGetAccountInfo, IPosition } from '@yuants/data-account';
 import { encodePath } from '@yuants/utils';
 import { ICredential, getGridOrdersAlgoPending, getGridPositions } from '../api/private-api';
-import { IAccountInfoCore } from './types';
 
-export const getStrategyAccountInfo = async (credential: ICredential): Promise<IAccountInfoCore> => {
+export const getStrategyAccountInfo: IActionHandlerOfGetAccountInfo<ICredential> = async (credential) => {
   // TODO: 需要分页获取所有的网格订单 (每页 100 条)
   const [gridAlgoOrders] = await Promise.all([
     getGridOrdersAlgoPending(credential, {
@@ -52,12 +51,5 @@ export const getStrategyAccountInfo = async (credential: ICredential): Promise<I
     }
   });
 
-  return {
-    money: {
-      currency: 'USDT',
-      equity: totalEquity,
-      free: 0, // TODO: 累计策略的可提取资金作为 free
-    },
-    positions,
-  };
+  return positions;
 };

--- a/apps/vendor-okx/src/strategy-account.ts
+++ b/apps/vendor-okx/src/strategy-account.ts
@@ -2,8 +2,8 @@ import { addAccountMarket, provideAccountInfoService } from '@yuants/data-accoun
 import { Terminal } from '@yuants/protocol';
 import { defer } from 'rxjs';
 import { getStrategyAccountInfo } from './accountInfos';
-import { getDefaultCredential, getGridPositions } from './api/private-api';
 import { getStrategyAccountId } from './accountInfos/uid';
+import { getDefaultCredential, getGridPositions } from './api/private-api';
 
 const terminal = Terminal.fromNodeEnv();
 const credential = getDefaultCredential();
@@ -41,7 +41,12 @@ defer(async () => {
     },
   );
 
-  provideAccountInfoService(terminal, strategyAccountId, () => getStrategyAccountInfo(credential), {
-    auto_refresh_interval: 5000,
-  });
+  provideAccountInfoService(
+    terminal,
+    strategyAccountId,
+    () => getStrategyAccountInfo(credential, strategyAccountId),
+    {
+      auto_refresh_interval: 5000,
+    },
+  );
 }).subscribe();

--- a/apps/vendor-solana/src/index.ts
+++ b/apps/vendor-solana/src/index.ts
@@ -1,4 +1,4 @@
-import { provideAccountInfoService } from '@yuants/data-account';
+import { makeSpotPosition, provideAccountInfoService } from '@yuants/data-account';
 import { Terminal } from '@yuants/protocol';
 import { formatTime } from '@yuants/utils';
 
@@ -53,14 +53,15 @@ solanaAddress.forEach((address) => {
       console.info(formatTime(Date.now()), 'INFO', info);
       const lamports = info.result.value.lamports;
       const sol = lamports / 1e9;
-      return {
-        money: {
-          currency: 'SOL',
-          equity: sol,
-          free: sol,
-        },
-        positions: [],
-      };
+      return [
+        makeSpotPosition({
+          position_id: 'SOL',
+          product_id: 'SOL',
+          volume: sol,
+          free_volume: sol,
+          closable_price: 1,
+        }),
+      ];
     },
     { auto_refresh_interval: 10_000 },
   );

--- a/common/changes/@yuants/data-account/2025-11-24-07-52.json
+++ b/common/changes/@yuants/data-account/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/data-account",
+      "comment": "simplify account info model",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@yuants/data-account"
+}

--- a/common/changes/@yuants/vendor-aster/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-aster/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-aster",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-aster"
+}

--- a/common/changes/@yuants/vendor-binance/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-binance/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-binance",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-binance"
+}

--- a/common/changes/@yuants/vendor-bitget/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-bitget/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-bitget",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-bitget"
+}

--- a/common/changes/@yuants/vendor-ctp/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-ctp/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-ctp",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-ctp"
+}

--- a/common/changes/@yuants/vendor-gate/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-gate/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-gate",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-gate"
+}

--- a/common/changes/@yuants/vendor-huobi/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-huobi/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-huobi",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-huobi"
+}

--- a/common/changes/@yuants/vendor-hyperliquid/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-hyperliquid/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-hyperliquid",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-hyperliquid"
+}

--- a/common/changes/@yuants/vendor-okx-web3/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-okx-web3/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-okx-web3",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-okx-web3"
+}

--- a/common/changes/@yuants/vendor-okx/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-okx/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-okx",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-okx"
+}

--- a/common/changes/@yuants/vendor-solana/2025-11-24-07-52.json
+++ b/common/changes/@yuants/vendor-solana/2025-11-24-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-solana",
+      "comment": "refactor",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-solana"
+}

--- a/libraries/data-account/etc/data-account.api.md
+++ b/libraries/data-account/etc/data-account.api.md
@@ -50,7 +50,7 @@ export interface IAccountMoney {
 }
 
 // @public
-export type IActionHandlerOfGetAccountInfo<T> = (credential: T, account_id: string) => Promise<Omit<IAccountInfoInput, 'account_id' | 'updated_at'>>;
+export type IActionHandlerOfGetAccountInfo<T> = (credential: T, account_id: string) => Promise<IPosition[]>;
 
 // @public
 export type IActionHandlerOfListAccounts<T> = (credential: T) => Promise<Array<{
@@ -91,6 +91,9 @@ export interface IPositionDiff {
 }
 
 // @public
+export const makeSpotPosition: (position: Omit<IPosition, 'position_price' | 'direction' | 'valuation' | 'floating_profit'>) => IPosition;
+
+// @public
 export const mergeAccountInfoPositions: (info: IAccountInfo) => Observable<IAccountInfo>;
 
 // @public
@@ -100,10 +103,7 @@ export const provideAccountActionsWithCredential: <T>(terminal: Terminal, type: 
 }) => void;
 
 // @public
-export const provideAccountInfoService: (terminal: Terminal, account_id: string, query: () => Promise<{
-    money: Pick<IAccountMoney, 'currency' | 'equity' | 'free'>;
-    positions: IPosition[];
-}>, options?: {
+export const provideAccountInfoService: (terminal: Terminal, account_id: string, query: () => Promise<IPosition[]>, options?: {
     auto_refresh_interval?: number;
 }) => {
     dispose$: Subject<void>;
@@ -118,7 +118,7 @@ export const publishAccountInfo: (terminal: Terminal, account_id: string, accoun
 export const useAccountInfo: (terminal: Terminal, account_id: string) => Observable<IAccountInfo>;
 
 // @public
-export const wrapAccountInfoInput: (data: IAccountInfoInput) => IAccountInfo;
+export const wrapAccountInfoInput: (updated_at: number, account_id: string, positions: IPosition[]) => IAccountInfo;
 
 // (No @packageDocumentation comment for this package)
 

--- a/libraries/data-account/src/account-actions-with-credential.ts
+++ b/libraries/data-account/src/account-actions-with-credential.ts
@@ -1,7 +1,7 @@
 import { ITypedCredential } from '@yuants/data-order';
 import { Terminal } from '@yuants/protocol';
 import { JSONSchema7 } from 'json-schema';
-import { IAccountInfo, IAccountInfoInput } from './interface';
+import { IAccountInfo, IPosition } from './interface';
 import { wrapAccountInfoInput } from './wrap-account-info-input';
 
 const makeCredentialSchema = (type: string, payloadSchema: JSONSchema7): JSONSchema7 => {
@@ -20,10 +20,7 @@ const makeCredentialSchema = (type: string, payloadSchema: JSONSchema7): JSONSch
  * Action handler for getting account information.
  * @public
  */
-export type IActionHandlerOfGetAccountInfo<T> = (
-  credential: T,
-  account_id: string,
-) => Promise<Omit<IAccountInfoInput, 'account_id' | 'updated_at'>>;
+export type IActionHandlerOfGetAccountInfo<T> = (credential: T, account_id: string) => Promise<IPosition[]>;
 
 /**
  * Action handler for listing accounts.
@@ -84,7 +81,7 @@ export const provideAccountActionsWithCredential = <T>(
         res: {
           code: 0,
           message: 'OK',
-          data: wrapAccountInfoInput({ ...data, account_id: msg.req.account_id, updated_at: Date.now() }),
+          data: wrapAccountInfoInput(Date.now(), msg.req.account_id, data),
         },
       };
     },

--- a/libraries/data-account/src/index.ts
+++ b/libraries/data-account/src/index.ts
@@ -6,5 +6,6 @@ export * from './interface';
 export * from './mergeAccountInfoPositions';
 export * from './provideAccountInfoService';
 export * from './publishAccountInfo';
+export * from './spot-position';
 export * from './useAccountInfo';
 export * from './wrap-account-info-input';

--- a/libraries/data-account/src/provideAccountInfoService.ts
+++ b/libraries/data-account/src/provideAccountInfoService.ts
@@ -1,7 +1,7 @@
 import { createCache } from '@yuants/cache';
 import { Terminal } from '@yuants/protocol';
 import { Subject, defer, retry, takeUntil, tap, timeout } from 'rxjs';
-import { IAccountInfo, IAccountMoney, IPosition } from './interface';
+import { IAccountInfo, IPosition } from './interface';
 import { publishAccountInfo } from './publishAccountInfo';
 import { wrapAccountInfoInput } from './wrap-account-info-input';
 
@@ -12,10 +12,7 @@ import { wrapAccountInfoInput } from './wrap-account-info-input';
 export const provideAccountInfoService = (
   terminal: Terminal,
   account_id: string,
-  query: () => Promise<{
-    money: Pick<IAccountMoney, 'currency' | 'equity' | 'free'>;
-    positions: IPosition[];
-  }>,
+  query: () => Promise<IPosition[]>,
   options?: {
     auto_refresh_interval?: number;
   },
@@ -25,7 +22,7 @@ export const provideAccountInfoService = (
   const cache = createCache<IAccountInfo>(
     async () => {
       const data = await query();
-      return wrapAccountInfoInput({ ...data, account_id, updated_at: Date.now() });
+      return wrapAccountInfoInput(Date.now(), account_id, data);
     },
     {
       writeLocal: async (_, data) => {

--- a/libraries/data-account/src/spot-position.ts
+++ b/libraries/data-account/src/spot-position.ts
@@ -1,0 +1,20 @@
+import { IPosition } from './interface';
+
+/**
+ * Simple factory to create a spot position
+ * @param position - Partial position information
+ * @returns Complete spot position
+ * @public
+ */
+export const makeSpotPosition = (
+  position: Omit<IPosition, 'position_price' | 'direction' | 'valuation' | 'floating_profit'>,
+): IPosition => {
+  // For spot positions, we set position_price to 0
+  const position_price = 0;
+  const closable_price = position.closable_price;
+  const volume = position.volume;
+  const valuation = volume * closable_price;
+  const direction = 'LONG';
+  const floating_profit = valuation;
+  return { ...position, position_price, closable_price, direction, valuation, floating_profit };
+};

--- a/libraries/data-account/src/wrap-account-info-input.ts
+++ b/libraries/data-account/src/wrap-account-info-input.ts
@@ -1,4 +1,4 @@
-import { IAccountInfo, IAccountInfoInput } from './interface';
+import { IAccountInfo, IPosition } from './interface';
 
 /**
  * Wrap account information input into complete account information.
@@ -6,20 +6,24 @@ import { IAccountInfo, IAccountInfoInput } from './interface';
  * @returns Wrapped account information with calculated fields
  * @public
  */
-export const wrapAccountInfoInput = (data: IAccountInfoInput): IAccountInfo => {
-  const positions = data.positions;
-  const profit = positions.reduce((acc, cur) => acc + (cur.floating_profit || 0), 0);
+export const wrapAccountInfoInput = (
+  updated_at: number,
+  account_id: string,
+  positions: IPosition[],
+): IAccountInfo => {
+  const equity = positions.reduce((acc, cur) => acc + (cur.floating_profit || 0), 0);
+
   // 立即推送最新的数据
   return {
-    updated_at: data.updated_at,
-    account_id: data.account_id,
+    updated_at: updated_at,
+    account_id: account_id,
     money: {
-      currency: data.money.currency,
-      equity: data.money.equity,
-      free: data.money.free,
-      profit: profit,
-      balance: data.money.equity - profit,
-      used: data.money.equity - data.money.free,
+      currency: '',
+      equity: equity,
+      free: equity,
+      profit: equity,
+      balance: 0,
+      used: 0,
     },
     positions: positions,
   };


### PR DESCRIPTION
- Updated `getSpotAccountInfo`, `getFutureAccountInfo`, `getUnifiedAccountInfo`, `getSuperMarginAccountInfo`, `getSwapAccountInfo`, `getPerpAccountInfo`, and `getSpotAccountInfo` methods to return an array of positions instead of a structured account info object.
- Introduced `makeSpotPosition` utility to standardize the creation of spot positions across different account info methods.
- Adjusted the `IActionHandlerOfGetAccountInfo` type to reflect the new return type of positions.
- Removed unnecessary calculations for equity and free balance in favor of directly returning positions.
- Updated related API calls and services to align with the new structure.