### PR TITLE
feat(yuanctl): enhance documentation and add E2E testing framework

### DIFF
--- a/common/changes/@yuants/tool-yuanctl/2025-11-24-16-24.json
+++ b/common/changes/@yuants/tool-yuanctl/2025-11-24-16-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/tool-yuanctl",
+      "comment": "enhance documentation and add E2E testing framework",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/tool-yuanctl"
+}

--- a/tools/yuanctl/AGENTS.md
+++ b/tools/yuanctl/AGENTS.md
@@ -1,0 +1,130 @@
+# @yuants/tool-yuanctl — AGENTS 工作手册
+
+> 使用 `.claude/skills/context-management/AGENTS.template.md` 与 `SESSION_NOTES.template.md` 填充的正式版本。维护 yuanctl（kubectl 风格 CLI）时必须先读本文件与 `tools/yuanctl/SESSION_NOTES.md`，并遵循 `.claude/skills/context-management/SKILL.md` 的交接流程。
+
+---
+
+## 1. 你的角色
+
+你在 `@yuants/tool-yuanctl` 中扮演：
+
+- 运维/研发助手：保证 CLI 行为与 Web 控制台一致，可安全管理部署与节点；
+- 文档与上下文维护者：让指令、决策、TODO 都能被下一位快速接力；
+- 测试与验证执行者：在安全前提下推动变更上线。
+
+主要目标与优先级：
+
+1. 正确性（行为与设计一致、避免破坏性改动）
+2. 清晰可维护（分层、可读、易接手）
+3. 安全与可回滚（确认机制、错误提示、配置兼容）
+4. 性能/花活（仅在不破坏前述目标时考虑）
+
+沟通：对人类说明优先用中文；源码注释保持简洁、必要才写。
+
+---
+
+## 2. 核心信条（Core Beliefs）
+
+### 2.1 增量与学习
+
+- 增量优先于大爆炸：小步、可编译、可测试的改动。
+- 先阅读现有实现/文档（`README.md`、`docs/deployment-cli-design.md`、Session Notes）再编码，优先复用既有模式。
+- 务实而非教条：保持结构简洁，必要的折衷要记录在 Session Notes。
+
+### 2.2 简单性的含义
+
+- 单一职责：命令解析、业务客户端、配置、输出分层清晰。
+- 少花活：写“无聊但明显”的代码，避免隐式魔法或过度抽象。
+- 可测试性优先：选择更易验证的方案，错误信息明确且不泄露敏感信息。
+
+---
+
+## 3. 指令与约束（Instructions & Constraints）
+
+### 3.1 长期指令
+
+1. **分层与结构**
+   - `src/cli` 负责 Clipanion 命令树与 verbs；业务操作在 `src/client`；配置解析在 `src/config`；输出在 `src/printers`；入口 (`bin/index`) 仅转发。
+   - 新能力按资源/动词扩展，保持 kubectl 风格：`get/describe/enable/disable/delete/restart/logs/config-init` 为基线。
+2. **数据与依赖**
+   - 所有读写通过 Host Terminal（SQL/Channel/服务调用），禁止直接连接数据库。
+   - 复用 `@yuants/sql`、`@yuants/utils`（如 `encodePath`）、`@yuants/protocol`，避免自建缓存/长连接管理。
+3. **配置与安全**
+   - 配置遵循 XDG + TOML；flag > env > config；新增字段需同步 `config-init` 模板、类型与文档。
+   - 保留 `YUANCTL_DISABLE_UPDATE_CHECK` 逃生口，离线环境静默跳过更新检查。
+   - 不在仓库写入真实配置/凭证；错误信息不可泄露敏感参数。
+4. **操作语义**
+   - 写操作（enable/disable/delete/restart 等）保持确认/幂等与防护选项（`--force-confirm`/`--yes`），不得移除安全提醒。
+   - 输出与排序尽量与 Web 控制台一致，新增字段需兼容旧用法。
+5. **上下文管理**
+   - 遵循 context-management Skill：重要决策、偏差、TODO 写入 Session Notes；发现指令冲突先停、再确认、再记录。
+6. **质量门槛**
+   - 优先运行 `node common/scripts/install-run-rush.js test --to @yuants/tool-yuanctl` 或至少 `rushx test`/`rushx lint`。
+   - TypeScript 避免 `any`，错误处理明确；提交前自审 diff，移除调试输出。
+
+### 3.2 当前阶段指令（阶段性）
+
+- 2025-11：完成 context 文档（AGENTS/SESSION_NOTES），盘点设计与实现的一致性，准备测试/验收计划。
+
+### 3.3 临时 / 一次性指令（本轮）
+
+- 本轮仅整理/补全文档，不改业务逻辑或生成文件。
+
+### 3.4 指令冲突与变更记录
+
+- 如新要求与 3.1/3.2/3.3 冲突：暂停相关操作，说明冲突点并请求决策；获批后在此与 `SESSION_NOTES 2.4` 记录变更编号。
+
+---
+
+## 4. 会话生命周期约定
+
+- **启动**：阅读本文件、`SESSION_NOTES.md`（重点 2/4/7/11 节），若有 `IMPLEMENTATION_PLAN` 一并查看。
+- **规划**：列 3–5 步小计划；复杂工作拆阶段并记录到 Session Notes 或计划文件。
+- **执行**: 先查文档再编码；小步提交；偏离设计时在 Session Notes 记录原因。
+- **收尾**：更新 Session Notes（最近工作、TODO、风险/问题、下一步）；清理 Scratchpad；记录测试命令与结果。
+
+---
+
+## 5. 多 Agent 协作约定
+
+- 所有人修改前需读 AGENTS 与 Session Notes；更新笔记时不要覆盖他人记录。
+- 发现适合其他角色的任务（测试/文档等）可标注在 TODO，并指明适配角色。
+
+---
+
+## 6. 代码风格与质量原则
+
+- **架构偏好**：组合优于继承；显式数据流；依赖注入优先于全局单例。
+- **错误处理**：快速失败，错误信息包含上下文且不泄露敏感信息；不得静默吞异常。
+- **提交要求**：保持可构建；运行必要测试；避免注释掉测试或用 `--no-verify` 逃避检查。
+- **格式**：遵循已有风格（prettier/lint），命名清晰，避免生僻缩写与多余注释。
+
+---
+
+## 7. 项目融入与参考
+
+- 参考 `docs/deployment-cli-design.md` 了解命令/资源/配置预期；对齐 Web 控制台 SQL/Channel 行为。
+- 查阅同目录实现（`src/cli/verbs/*`, `src/client/*`, `src/printers/*`）保持一致模式；必要时参考 apps/node-unit 与 ui/web 对应逻辑。
+
+---
+
+## 8. 遇到卡壳时
+
+- 同一思路最多尝试三次；失败时记录尝试与现象，换方案或寻求决策。
+- 对照类似实现寻找差异；必要时在 Session Notes Scratchpad 记录中间结论。
+
+---
+
+## 9. 禁止行为
+
+- 直接连数据库或绕过 Terminal/SQL/Channel；删除安全确认；泄露敏感配置；伪造测试结果；随意禁用/删除测试。
+
+---
+
+## 10. 会话结束前自检清单
+
+- [ ] 已阅读/遵守本文件与 Session Notes？
+- [ ] 是否检查了当前指令（3.1/3.2/3.3）并处理冲突？
+- [ ] 运行并记录了必要测试/检查？
+- [ ] 更新了 Session Notes：最近工作、TODO、风险/问题、下一步，并清理 Scratchpad？
+- [ ] diff 可读、无调试输出，安全确认仍在？

--- a/tools/yuanctl/IMPLEMENTATION_PLAN.md
+++ b/tools/yuanctl/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,102 @@
+# yuanctl 实现计划（针对 SESSION_NOTES 7.1 高优先级）
+
+> 基于 `.claude/skills/context-management/IMPLEMENTATION_PLAN.template.md`。覆盖 SESSION_NOTES 7.1 的两项高优先级任务：设计/实现差异盘点与关键路径测试计划。
+
+## 元信息（Meta）
+
+- 计划名称：yuanctl 设计一致性审计与关键路径测试
+- 关联 Issue / 需求：SESSION_NOTES 7.1
+- 创建时间：2025-11-24
+- 最近更新时间：2025-11-24（Codex）
+
+---
+
+## 阶段规划（Stages）
+
+### Stage 1: 设计-实现差异梳理
+
+**Goal（目标）**：
+
+- 对照 `docs/deployment-cli-design.md` 与当前代码实现（命令/flag/输出/确认/默认值），列出差异清单和优先级。
+
+**Success Criteria（成功标准）**：
+
+- 差异清单按资源/动词分类，标注影响范围（兼容性/安全/体验）。
+- 输出可执行的修复建议或确认“无差异”的结论。
+
+**Tests（需要的测试）**：
+
+- 手动/静态审查：检查 `src/cli/verbs/*`、`src/client/*`、`src/printers/*`、`updateChecker.ts` 与设计文档的对应关系。
+
+**Status（状态）**：
+
+- Complete
+
+---
+
+### Stage 2: 关键路径测试策略与脚手架
+
+**Goal**：
+
+- 为配置解析、get/watch/logs 等核心路径制定自动化测试策略，确定测试类型（unit/e2e）、输入输出样例与环境需求。
+
+**Success Criteria**：
+
+- 已形成测试列表与预期（见 `docs/testing-plan.md`），涵盖配置解析、get/watch/logs 等核心路径。
+- 确定了 mock/fixture/CLI 调用方式与 CI 命令（`rushx test`）。
+- 如需 E2E，前置条件与配置样例已在文档中列出。
+
+**Tests**：
+
+- 文档化的测试计划与脚手架建议（`docs/testing-plan.md`）；后续实现测试用例按此执行。
+
+**Status**：
+
+- Complete
+
+---
+
+### Stage 3: 差异修复与测试落地
+
+**Goal**：
+
+- 根据 Stage 1 的差异清单完成修复，并在 Stage 2 的测试框架下验证关键路径。
+
+**Success Criteria**：
+
+- 设计一致性差异已关闭或有明确延期记录；新增/更新的测试覆盖配置解析、get/watch/logs 基本场景。
+- 测试在 CI/本地通过（记录命令与结果），Session Notes 更新修复与测试情况。
+
+**Tests**：
+
+- `node common/scripts/install-run-rush.js test --to @yuants/tool-yuanctl`（或等效 `rushx test`/`rushx lint`）
+- 针对新增用例的具体命令（待 Stage 2 定义）。
+
+**Status**：
+
+- Not Started
+
+---
+
+## 实现流程建议（Implementation Flow）
+
+1. **Understand / 理解现状**
+   - 查阅 `SESSION_NOTES` 相关背景与指令；阅读 `docs/deployment-cli-design.md` 和当前 `src/cli`/`src/client`/`src/printers`。
+2. **Test / 测试优先（尽可能 TDD）**
+   - 先写/确定测试（让测试先红），确保能暴露差异或缺失。
+3. **Implement / 实现**
+   - 以最少改动让测试变绿，保持分层与安全确认语义。
+4. **Refactor / 重构**
+   - 在测试通过前提下整理结构、抽取函数，避免过早抽象。
+5. **Commit / 提交**
+   - 运行必要检查（test/lint），自审 diff，提交信息说明 Stage 关联与原因。
+
+---
+
+## Definition of Done（完成定义）
+
+- [ ] 三个 Stage 的 `Status` 均为 `Complete`
+- [ ] 承诺的测试已编写并通过（含新增用例）
+- [ ] 设计一致性差异已关闭或记录明确延期
+- [ ] 代码符合 AGENTS 与项目风格/安全要求
+- [ ] `SESSION_NOTES` 已更新：记录完成情况、测试命令与结果、残留风险/技术债（如有）

--- a/tools/yuanctl/README.md
+++ b/tools/yuanctl/README.md
@@ -119,3 +119,21 @@ yuanctl logs deployment/<id> -f --timestamps
 - `Unable to determine node unit address`：在 `contexts.*` 中设置 `default_node_unit` 或执行命令时添加 `--node-unit`。
 
 若需更深入的实现细节与后续路线图，请参考 `docs/deployment-cli-design.md`。
+
+## E2E 测试
+
+`rushx e2e`（或 `npm run e2e`）将调用 `scripts/run-yuanctl-e2e.js`，默认使用 Docker Compose 启动 TimescaleDB 和 node-unit，并在临时配置下验证 `get/describe/enable/disable/restart/logs/config-init` 等命令。
+
+前置条件：
+
+- Docker (支持 compose)
+- 可访问 `ghcr.io/no-trade-no-life/node-unit` 与 `timescale/timescaledb-ha` 镜像的网络
+
+常用环境变量：
+
+- `YUANCTL_E2E_SKIP_COMPOSE=1`：跳过启动/停止容器，使用已有服务。
+- `YUANCTL_E2E_KEEP_SERVICES=1`：测试结束后保留容器。
+- `YUANCTL_E2E_HOST_URL` / `YUANCTL_E2E_DB_PORT` / `YUANCTL_E2E_HOST_PORT`：自定义 Host/DB 端口。
+- `YUANCTL_NODE_UNIT_IMAGE` / `YUANCTL_POSTGRES_IMAGE`：覆盖默认镜像。
+
+脚本默认禁用版本检查（`YUANCTL_DISABLE_UPDATE_CHECK=1`），运行完成会自动清理测试部署；若跳过 Compose，请自行确保 PostgreSQL 迁移与 node-unit 就绪。

--- a/tools/yuanctl/SESSION_NOTES.md
+++ b/tools/yuanctl/SESSION_NOTES.md
@@ -1,0 +1,183 @@
+# Yuanctl — Session Notes
+
+> 基于 `.claude/skills/context-management/SESSION_NOTES.template.md` 的正式版本。作为 `@yuants/tool-yuanctl` 的单一真相源，记录目标、指令、决策、TODO、风险与交接。操作前请阅读本文件与 `tools/yuanctl/AGENTS.md`。
+
+---
+
+## 0. 元信息（Meta）
+
+- **项目名称**：@yuants/tool-yuanctl
+- **最近更新时间**：2025-11-24 07:20（Codex，UTC）
+- **当前状态标签**：文档整理 / 上下文建设
+
+---
+
+## 1. 项目整体目标（High-level Goal）
+
+- 提供 kubectl 风格的运维 CLI，复用 Terminal + SQL + Channel 能力管理部署与节点，行为与 Web 控制台保持一致。
+- 支持多 Host/Context 的可移植配置（XDG + TOML），便于脚本与人工操作共享。
+- 保持输出、确认、安全策略稳定：查询/描述安全可批量，写操作提供确认/降级选项。
+- 非目标（当前阶段）：直接访问数据库或实现声明式 `apply` 部署（后续另行设计）。
+
+---
+
+## 2. 指令与约束（Instructions & Constraints）
+
+### 2.1 长期指令快照
+
+- 先读 `tools/yuanctl/AGENTS.md`、本文件、`README.md`、`docs/deployment-cli-design.md`；重要决策与偏差写回本文件。
+- 分层：命令解析在 `src/cli`，业务客户端在 `src/client`，配置在 `src/config`，输出在 `src/printers`，入口最小化。
+- 仅通过 Host Terminal (SQL/Channel/服务) 交互，禁止直连数据库；复用 `@yuants/sql`/`@yuants/utils`/`@yuants/protocol`。
+- 配置遵循 XDG + TOML，flag > env > config；新增字段同步 `config-init` 模板、类型与文档；保留 `YUANCTL_DISABLE_UPDATE_CHECK`。
+- 写操作保持确认/幂等与安全防护，错误提示清晰不泄露敏感信息；完成工作后更新 Session Notes（最近记录、TODO、风险/问题）。
+
+### 2.2 当前阶段指令
+
+- 2025-11：建立并固化 context 文档（AGENTS/SESSION_NOTES），盘点设计与实现一致性，准备测试/验收计划。
+
+### 2.3 临时指令（短期有效）
+
+- 本轮仅进行文档整理，不改业务逻辑或生成文件。
+
+### 2.4 指令冲突与变更记录
+
+- 暂无冲突记录。若有新指令与 2.1/2.2 冲突，按 context-management 流程记录编号并在 AGENTS 同步。
+
+---
+
+## 3. 当前阶段的重点目标（Current Focus）
+
+- 发布并维护 AGENTS/SESSION_NOTES，保证协作可追踪。
+- 对照 `docs/deployment-cli-design.md` 盘点实现差异，列出修正计划。
+- 制定配置解析、get/watch/logs 等关键路径的测试/验收方案。
+
+---
+
+## 4. 重要背景与关键决策（Context & Decisions）
+
+### 4.1 架构 / 模块概览
+
+- `src/cli`：Clipanion 命令树与动词实现（get/describe/enable/disable/delete/restart/logs/config-init）。
+- `src/config`：解析 XDG/TOML，合并 flag/env/默认值；`config-init` 输出模板。
+- `src/client`：`TerminalGateway` 管理 Host 连接；Deployments/NodeUnits/Logs 客户端复用 SQL/Channel 能力。
+- `src/printers`：表格/JSON/YAML/describe 渲染，保持字段与排序稳定。
+- `updateChecker.ts`：npm 更新提示，受 `YUANCTL_DISABLE_UPDATE_CHECK` 控制。
+- `scripts/run-yuanctl-e2e.js`：E2E 脚本入口（需确认依赖/配置）。
+
+### 4.2 已做出的关键决策
+
+- **[D1]** CLI 采用 kubectl 风格动词/资源，可通过新增 verb 模块扩展，保持核心结构稳定。
+- **[D2]** 所有数据交互通过 Host Terminal，不直连数据库；连接超时由 `TerminalGateway` 控制。
+- **[D3]** 配置采用 XDG + TOML，flag/env 优先；`config-init` 只输出模板，不直接写文件。
+
+### 4.3 已接受的折衷 / 技术债
+
+- 暂未提供声明式 `apply`/部署模板；需后续设计安全边界。
+- E2E 覆盖与离线/受限网络场景的行为描述仍需完善。
+
+---
+
+## 5. 关键文件与模块说明（Files & Modules）
+
+- `tools/yuanctl/README.md`：功能概览、安装与配置。
+- `tools/yuanctl/docs/deployment-cli-design.md`：设计背景、命令映射、架构预期。
+- `tools/yuanctl/src/cli/index.ts`、`src/cli/verbs/*`：命令注册与动词实现。
+- `tools/yuanctl/src/client/*.ts`：Terminal 连接与资源客户端。
+- `tools/yuanctl/src/config/*`：配置类型与解析逻辑。
+- `tools/yuanctl/src/printers/*`：输出渲染与格式控制。
+- `tools/yuanctl/scripts/run-yuanctl-e2e.js`：E2E 入口与依赖。
+
+---
+
+## 6. 最近几轮工作记录（Recent Sessions）
+
+### 2025-11-25 — Codex
+
+- **本轮摘要**：
+  - 为 CLI 增补模拟测试 `src/cli/__tests__/cli-commands.test.ts`（get/logs），并为测试提供 crypto mock 与 console 捕获。
+  - 调整测试脚本为 `heft test --clean --debug`，解决默认 reporter 在本环境下导致的 TypeScript 子进程退出问题；`rushx test` 已可通过。
+  - e2e 入口脚本未实跑（需 Docker 镜像与网络），保持 README 中的前置条件说明。
+- **修改的文件**：
+  - `tools/yuanctl/src/cli/__tests__/cli-commands.test.ts`
+  - `tools/yuanctl/package.json`
+- **运行的测试 / 检查**：
+  - `cd tools/yuanctl && rushx test`（通过；使用 `--debug` 关闭 HeftJestReporter）
+
+### 2025-11-24 — Codex
+
+- **本轮摘要**：
+  - 完成 SESSION_NOTES 7.1 对应的实现计划（`IMPLEMENTATION_PLAN.md`），Stage 1 完成，Stage 2 完成，Stage 3 未开始。
+  - 设计对齐审计（Stage 1）：梳理当前实现与设计文档的差异。
+  - 输出测试策略与脚手架文档（`docs/testing-plan.md`），并新增 CLI 模拟测试与 e2e 脚本入口（README 说明）。
+- **发现的差异 / 待修复点**：
+  - `logs`：`--since` 宣传支持但未实现（仅警告并忽略），需补实现或文档标注。
+  - `logs` 仅接受 `deployment`/`deployments` 资源，`deploymentlogs` 别名在解析器存在但未被命令接受。
+  - `logs --tail` 固定从 -128 KiB 读取再截尾，对大日志文件可能无法满足用户指定 tail 行数。
+  - `describe nodeunits` 若未指定 identifier，会直接取第一个节点且忽略 selector/filter，不符合“可筛选”预期。
+- **修改的文件**：
+  - `tools/yuanctl/IMPLEMENTATION_PLAN.md`
+  - `tools/yuanctl/docs/testing-plan.md`
+  - `tools/yuanctl/src/cli/__tests__/cli-commands.test.ts`
+  - `tools/yuanctl/package.json`
+  - `tools/yuanctl/README.md`
+- **运行的测试 / 检查**：
+  - 未运行（尝试 `rush test --to` 发现 Rush 无 test 子命令，未进一步执行）
+
+### 2025-11-24 — Codex
+
+- **本轮摘要**：
+  - 使用模板创建并填充 `tools/yuanctl/AGENTS.md` 与 `tools/yuanctl/SESSION_NOTES.md`，建立 context-management 文档体系。
+  - 梳理 yuanctl 架构、设计基线与指令快照。
+- **修改的文件**：
+  - `tools/yuanctl/AGENTS.md`, `tools/yuanctl/SESSION_NOTES.md`
+- **运行的测试 / 检查**：
+  - 未运行（文档更新）
+
+---
+
+## 7. 当前 TODO / 任务列表（Tasks & TODO）
+
+### 7.1 高优先级（下一轮优先处理）
+
+- [ ] 对照 `docs/deployment-cli-design.md` 核查现有实现（命令/flag/输出/确认语义），记录差异与修复计划。（审计完成，待修复落地）
+- [ ] 按 `docs/testing-plan.md` 落地自动化测试/验收脚本（配置解析、get/watch/logs），并运行测试。
+
+### 7.2 中优先级 / 待排期
+
+- [ ] 记录 update-checker 在离线/受限网络下的期望行为与开关策略，必要时补充文档或守护逻辑。
+- [ ] 审核 `scripts/run-yuanctl-e2e.js` 前置条件，确认是否需要样例配置或 mock。
+
+### 7.3 想法 / Nice-to-have
+
+- [ ] 探索声明式 `apply`/部署模板的设计草案与安全边界。
+
+---
+
+## 8. 风险点 / 容易踩坑的地方（Risks & Gotchas）
+
+- **Terminal 连接依赖外部 Host**：缺失/错误 `host_url` 或 TLS 参数会导致超时；需提供清晰错误并允许调整超时。
+- **写操作影响生产部署**：enable/disable/delete/restart 会改动部署状态，新增功能需保留确认/过滤机制避免批量误操作。
+
+---
+
+## 9. 尚未解决的问题（Open Questions）
+
+- 是否需要内置 dry-run/权限校验模式以降低批量操作风险？
+- `apply`/部署模板的演进路线是否需要提前设计资源与回滚策略？
+
+---
+
+## 10. 下一位 Agent 的建议行动（Next Steps for Next Agent）
+
+1. 阅读 `tools/yuanctl/AGENTS.md` 与本文件第 2/4/7 节，确认约束与当前重点。
+2. 计划改动前，对照 `docs/deployment-cli-design.md` 的命令与输出预期；若发现偏差，在第 4/6 节记录结论。
+3. 运行必要检查：`node common/scripts/install-run-rush.js test --to @yuants/tool-yuanctl` 或至少 `rushx test`/`rushx lint`；记录命令与结果。
+4. 完成后更新第 6/7/8/9 节，并清理第 11 节 Scratchpad，保持上下文可接力。
+
+---
+
+## 11. 当前会话草稿 / Scratchpad（仅本轮使用）
+
+### 当前会话（进行中） — 2025-11-24 07:20 — Codex
+
+- （空）本轮仅整理文档；后续会话可在此记录进行中内容并在收尾时结算。

--- a/tools/yuanctl/docs/testing-plan.md
+++ b/tools/yuanctl/docs/testing-plan.md
@@ -1,0 +1,61 @@
+# yuanctl 测试策略与脚手架（配置 / get / watch / logs）
+
+> 目标：为核心路径制定可执行的测试计划，并给出落地脚手架。覆盖 config 解析、get/watch 查询、logs 读取与 follow 行为。优先使用现有 Heft/Jest 测试框架（`rushx test`）。
+
+---
+
+## 总体策略
+
+- **分层测试**：配置解析用单元测试；资源客户端与 CLI 动词用集成/契约测试（mock Terminal）；命令输出用 snapshot/文本断言。
+- **最小依赖**：通过 stub Terminal/Channel/Service 返回值，避免真实 Host；必要时用 fixture TOML/环境变量覆盖。
+- **验证重点**：参数优先级（flag/env/config）、过滤/选择器、确认/错误提示、日志 tail/follow 行为与边界（大文件、无匹配、多匹配）。
+
+---
+
+## 用例列表（按阶段落地）
+
+### 配置解析（Unit）
+
+- `context` 解析优先级：flag > env > config；默认使用 `DEFAULT_CONTEXT_NAME`；缺失配置时输出友好错误。
+- TOML 字段映射：`hosts.*`、`contexts.*` 正确解析可选字段（`tls_verify`、`connect_timeout_ms` 等）；缺失 `host_url` 报错。
+- `config-init`：输出包含默认 host/context 样例；终端 ID 默认 `Yuanctl/${HOSTNAME}`。
+
+### get / describe（Integration）
+
+- selector 与 field-selector 合并：`enabled=true,id=foo` 生成正确 where 子句；布尔字段校验非法值报错。
+- `get deployments --watch`: 使用 mocked `deployments.watch` 返回两批数据，验证屏幕清空与时间戳输出（可断言尾行）。
+- `describe deployment/<id>`：无匹配返回错误码；多匹配时按限制展示。
+- `describe nodeunits`：未指定 identifier 时应尊重 selector/filter 或提示需要唯一目标。
+
+### enable / disable / delete / restart（Integration）
+
+- 需要 identifier/selector，否则报错；`--force-confirm` 路径在确认拒绝时不执行。
+- restart 策略解析：`touch/graceful/hard` 与 `--grace-period`（数字/ms/s）；无效策略报错。
+
+### logs（Integration）
+
+- `logs deployment/<id> --tail=N`：在模拟 200+ 行内容下截取正确尾部；大文件（>128 KiB）时需验证实际截尾策略（当前行为需记录）。
+- `logs -f`：订阅 Channel，收到多段消息按 prefix/timestamps 组合输出；错误时退出码为 1。
+- `--since` 行为：当前未实现，需测试提示与忽略逻辑；后续若实现再更新用例。
+- `--node-unit` 选择：未提供且无 address/default_node_unit 时应报错。
+- `deploymentlogs` 别名：资源解析后命令接受并路由到相同实现（需补充实现后测试）。
+
+---
+
+## 脚手架建议
+
+- **测试框架**：沿用 Heft/Jest；在 `src/__tests__/` 下新增 `config.test.ts`、`cli-get.test.ts`、`cli-logs.test.ts` 等。
+- **Terminal mock**：
+  - 提供 `createMockTerminalGateway` 返回注入的 list/watch/logs 行为（使用 RxJS `of`/`Subject`）。
+  - 对 logs follow 使用 `Subject` 推送行，模拟错误分支。
+- **CLI 调用**：使用 Clipanion `Cli.run` 传入 argv + mock stdout/stderr，断言输出字符串（可用 snapshot）。
+- **Fixtures**：添加 `__fixtures__/config/valid.toml`、`missing_host.toml` 等，用 fs 读取；为 env/flag 覆盖提供 helper。
+- **CI 命令**：`rushx test`；如需局部运行 `cd tools/yuanctl && pnpm test -- <pattern>`（保持 doc 同步）。
+
+---
+
+## 开放问题 / 后续补充
+
+- 大日志截尾策略：是否需要流式按行 tail（避免 128 KiB 限制），待差异修复阶段处理。
+- `--since` 语义：需明确 Node Unit 服务支持情况后决定实现或文档化限制。
+- E2E：可用 `scripts/run-yuanctl-e2e.js` 结合本地/测试 Host，需准备样例配置与安全开关。

--- a/tools/yuanctl/e2e/docker-compose.yml
+++ b/tools/yuanctl/e2e/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  postgres:
+    image: ${YUANCTL_POSTGRES_IMAGE:-timescale/timescaledb-ha:pg17}
+    environment:
+      POSTGRES_USER: ${YUANCTL_DB_USER:-yuan}
+      POSTGRES_PASSWORD: ${YUANCTL_DB_PASSWORD:-yuan}
+      POSTGRES_DB: ${YUANCTL_DB_NAME:-yuan}
+    ports:
+      - '${YUANCTL_E2E_DB_PORT:-25432}:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${YUANCTL_DB_USER:-yuan}']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  nodeunit:
+    image: ${YUANCTL_NODE_UNIT_IMAGE:-ghcr.io/no-trade-no-life/node-unit:0.12.16}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_URI: postgresql://${YUANCTL_DB_USER:-yuan}:${YUANCTL_DB_PASSWORD:-yuan}@postgres:5432/${YUANCTL_DB_NAME:-yuan}
+      NODE_UNIT_NAME: yuanctl-e2e
+    ports:
+      - '${YUANCTL_E2E_HOST_PORT:-28888}:8888'

--- a/tools/yuanctl/package.json
+++ b/tools/yuanctl/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "heft test --clean",
     "lint": "heft lint --clean",
-    "test": "heft test --clean"
+    "test": "heft test --clean --debug",
+    "e2e": "node scripts/run-yuanctl-e2e.js"
   },
   "dependencies": {
     "@yuants/protocol": "workspace:*",

--- a/tools/yuanctl/scripts/run-yuanctl-e2e.js
+++ b/tools/yuanctl/scripts/run-yuanctl-e2e.js
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+
+const crypto = require('node:crypto');
+const net = require('node:net');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const fsPromises = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const process = require('node:process');
+const { Terminal } = require('@yuants/protocol');
+const { requestSQL, escapeSQL } = require('@yuants/sql');
+const { firstValueFrom } = require('rxjs');
+const { filter, timeout } = require('rxjs/operators');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const composeFile = path.join(repoRoot, 'tools', 'yuanctl', 'e2e', 'docker-compose.yml');
+const cliEntry = path.join(repoRoot, 'tools', 'yuanctl', 'lib', 'bin', 'yuanctl.js');
+const nodeBinary = process.execPath;
+
+const DEFAULT_HOST_PORT = process.env.YUANCTL_E2E_HOST_PORT || '28888';
+const DEFAULT_DB_PORT = process.env.YUANCTL_E2E_DB_PORT || '25432';
+const DB_USER = process.env.YUANCTL_DB_USER || 'yuan';
+const DB_PASSWORD = process.env.YUANCTL_DB_PASSWORD || 'yuan';
+const DB_NAME = process.env.YUANCTL_DB_NAME || 'yuan';
+const dockerCommand = process.env.YUANCTL_DOCKER_BIN || 'docker';
+const skipCompose = process.env.YUANCTL_E2E_SKIP_COMPOSE === '1';
+const keepServices = process.env.YUANCTL_E2E_KEEP_SERVICES === '1';
+const sqlDir = path.join(repoRoot, 'tools', 'sql-migration', 'sql');
+
+const portalDeploymentId = process.env.YUANCTL_PORTAL_DEPLOYMENT_ID || 'yuanctl-e2e-portal';
+const portalPackageName = process.env.YUANCTL_PORTAL_PACKAGE || '@yuants/app-portal';
+const portalPackageVersion = process.env.YUANCTL_PORTAL_VERSION || 'latest';
+const testDeploymentId = process.env.YUANCTL_TEST_DEPLOYMENT_ID || 'yuanctl-e2e';
+const testPackageName = process.env.YUANCTL_TEST_PACKAGE || portalPackageName;
+const testPackageVersion = process.env.YUANCTL_TEST_PACKAGE_VERSION || portalPackageVersion;
+
+const hostUrl = process.env.YUANCTL_E2E_HOST_URL || `ws://127.0.0.1:${DEFAULT_HOST_PORT}`;
+
+function log(msg) {
+  process.stdout.write(`[yuanctl:e2e] ${msg}\n`);
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: options.env || process.env,
+      stdio: options.stdio || ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    if (child.stdout) {
+      child.stdout.on('data', (data) => {
+        stdout += data.toString();
+        if (options.pipeStdout) process.stdout.write(data);
+      });
+    }
+    if (child.stderr) {
+      child.stderr.on('data', (data) => {
+        stderr += data.toString();
+        if (options.pipeStderr) process.stderr.write(data);
+      });
+    }
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0 && !options.ignoreError) {
+        const error = new Error(`Command failed: ${command} ${args.join(' ')}\n${stderr}`);
+        error.code = code;
+        error.stdout = stdout;
+        error.stderr = stderr;
+        return reject(error);
+      }
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function jsonLiteral(value) {
+  return `CAST(${escapeSQL(JSON.stringify(value))} AS jsonb)`;
+}
+
+function buildDeploymentUpsertSQL({
+  id,
+  packageName,
+  packageVersion,
+  address,
+  enabled,
+  command = '',
+  args = [],
+  env = {},
+}) {
+  return `
+    INSERT INTO deployment (id, package_name, package_version, command, args, env, address, enabled, created_at, updated_at)
+    VALUES (
+      ${escapeSQL(id)},
+      ${escapeSQL(packageName)},
+      ${escapeSQL(packageVersion)},
+      ${escapeSQL(command)},
+      ${jsonLiteral(args)},
+      ${jsonLiteral(env)},
+      ${escapeSQL(address)},
+      ${enabled ? 'true' : 'false'},
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (id)
+    DO UPDATE SET
+      package_name = EXCLUDED.package_name,
+      package_version = EXCLUDED.package_version,
+      command = EXCLUDED.command,
+      args = EXCLUDED.args,
+      env = EXCLUDED.env,
+      address = EXCLUDED.address,
+      enabled = EXCLUDED.enabled,
+      updated_at = NOW();
+  `;
+}
+
+async function ensureCliBuilt() {
+  try {
+    await fsPromises.access(cliEntry, fs.constants.R_OK);
+    return;
+  } catch {
+    log('yuanctl build artifact missing, running rush build');
+    await runCommand(
+      nodeBinary,
+      [
+        path.join(repoRoot, 'common', 'scripts', 'install-run-rush.js'),
+        'build',
+        '--to',
+        '@yuants/tool-yuanctl',
+      ],
+      {
+        pipeStdout: true,
+        pipeStderr: true,
+      },
+    );
+  }
+}
+
+async function composeUpServices(...services) {
+  log(`Starting docker compose services: ${services.join(', ') || 'all'}`);
+  await runCommand(dockerCommand, ['compose', '-f', composeFile, 'up', '-d', ...services], {
+    pipeStdout: true,
+    pipeStderr: true,
+  });
+}
+
+async function composeDown() {
+  log('Stopping docker compose stack');
+  await runCommand(dockerCommand, ['compose', '-f', composeFile, 'down', '-v'], {
+    pipeStdout: true,
+    pipeStderr: true,
+    ignoreError: true,
+  });
+}
+
+async function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(fn, { retries = 60, intervalMs = 2000, description = 'condition' } = {}) {
+  let lastError;
+  for (let i = 0; i < retries; i++) {
+    try {
+      const result = await fn();
+      if (result) {
+        return result;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    await wait(intervalMs);
+  }
+  if (lastError) throw lastError;
+  throw new Error(`Timeout waiting for ${description}`);
+}
+
+async function runYuanctl(args, { configPath, env = {}, ignoreError = false, input } = {}) {
+  const cliEnv = {
+    ...process.env,
+    YUANCTL_DISABLE_UPDATE_CHECK: '1',
+    ...env,
+  };
+  if (configPath) {
+    cliEnv.YUANCTL_CONFIG = configPath;
+  }
+  return new Promise((resolve, reject) => {
+    const child = spawn(nodeBinary, [cliEntry, ...args], {
+      cwd: repoRoot,
+      env: cliEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    if (input) {
+      child.stdin.write(input);
+    }
+    child.stdin.end();
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0 && !ignoreError) {
+        const error = new Error(`yuanctl ${args.join(' ')} failed: ${stderr}`);
+        error.code = code;
+        error.stdout = stdout;
+        error.stderr = stderr;
+        return reject(error);
+      }
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function withSqlTerminal(fn) {
+  const terminal = new Terminal(hostUrl, {
+    terminal_id: `yuanctl/e2e/sql/${Date.now()}/${Math.random().toString(36).slice(2)}`,
+    name: 'yuanctl-e2e-sql',
+  });
+  try {
+    await firstValueFrom(terminal.isConnected$.pipe(filter(Boolean), timeout(30000)));
+    return await fn(terminal);
+  } finally {
+    terminal.dispose();
+  }
+}
+
+async function runSQL(query) {
+  return withSqlTerminal((terminal) => requestSQL(terminal, query));
+}
+
+async function deleteDeploymentSafe(id, configPath) {
+  if (!configPath) return;
+  try {
+    await runYuanctl(['delete', `deployment/${id}`], { configPath, input: 'y\n', ignoreError: true });
+  } catch {
+    // ignore cleanup failures
+  }
+}
+
+async function waitForPostgres() {
+  await waitFor(
+    async () => {
+      const result = await runCommand(
+        dockerCommand,
+        ['compose', '-f', composeFile, 'exec', '-T', 'postgres', 'pg_isready', '-U', DB_USER],
+        { env: { ...process.env, PGPASSWORD: DB_PASSWORD }, ignoreError: true },
+      );
+      return result.code === 0;
+    },
+    { description: 'PostgreSQL (pg_isready)' },
+  );
+
+  await waitFor(
+    async () => {
+      const result = await runCommand(
+        dockerCommand,
+        [
+          'compose',
+          '-f',
+          composeFile,
+          'exec',
+          '-T',
+          'postgres',
+          'psql',
+          '-U',
+          DB_USER,
+          '-d',
+          DB_NAME,
+          '-v',
+          'ON_ERROR_STOP=1',
+          '-c',
+          'SELECT 1;',
+        ],
+        { env: { ...process.env, PGPASSWORD: DB_PASSWORD }, ignoreError: true },
+      );
+      return result.code === 0;
+    },
+    { description: 'PostgreSQL accepting SQL' },
+  );
+  // Wait for host port forwarding (for optional direct access)
+  await waitFor(
+    async () => {
+      try {
+        const socket = net.createConnection({ host: '127.0.0.1', port: Number(DEFAULT_DB_PORT) });
+        await new Promise((resolve, reject) => {
+          socket.once('error', reject);
+          socket.once('connect', resolve);
+        });
+        socket.destroy();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { description: 'PostgreSQL port binding' },
+  );
+}
+
+async function runPsql(sql) {
+  await runCommand(
+    dockerCommand,
+    [
+      'compose',
+      '-f',
+      composeFile,
+      'exec',
+      '-T',
+      'postgres',
+      'psql',
+      '-U',
+      DB_USER,
+      '-d',
+      DB_NAME,
+      '-v',
+      'ON_ERROR_STOP=1',
+      '-c',
+      sql,
+    ],
+    { env: { ...process.env, PGPASSWORD: DB_PASSWORD }, pipeStdout: true, pipeStderr: true },
+  );
+}
+
+async function runSqlMigrations() {
+  log('Applying SQL migrations before starting node-unit');
+  await waitForPostgres();
+  await runPsql(`
+    CREATE TABLE IF NOT EXISTS migration (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      statement TEXT NOT NULL DEFAULT '',
+      created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
+  const files = (await fsPromises.readdir(sqlDir)).filter((file) => file.endsWith('.sql')).sort();
+  for (const file of files) {
+    const filePath = path.join(sqlDir, file);
+    const sql = await fsPromises.readFile(filePath, 'utf-8');
+    const id = crypto.createHash('sha256').update(sql).digest('hex');
+    const migrationSQL = `
+DO $migration$
+BEGIN
+  IF NOT EXISTS (SELECT id FROM migration WHERE id = ${escapeSQL(id)}) THEN
+    INSERT INTO migration (id, name, statement) VALUES (${escapeSQL(id)}, ${escapeSQL(file)}, ${escapeSQL(
+      sql,
+    )});
+    ${sql}
+  END IF;
+END $migration$;
+`;
+    log(`Applying migration ${file}`);
+    await runPsql(migrationSQL);
+  }
+}
+
+async function main() {
+  let composeStarted = false;
+  const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'yuanctl-e2e-'));
+  const configPath = path.join(tmpDir, 'config.toml');
+
+  try {
+    await ensureCliBuilt();
+
+    if (!skipCompose) {
+      await composeDown();
+      await composeUpServices('postgres');
+      composeStarted = true;
+      await runSqlMigrations();
+      await composeUpServices('nodeunit');
+    } else {
+      log(
+        'Skipping docker compose control (using existing services); ensure PostgreSQL、迁移与 Node Unit 由外部负责。',
+      );
+    }
+
+    log('Waiting for SQL service (via host) to be reachable');
+    await waitFor(
+      async () => {
+        try {
+          await runSQL('SELECT 1');
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { description: 'SQL availability via host' },
+    );
+
+    await waitFor(
+      async () => {
+        try {
+          const rows = await runSQL("SELECT to_regclass('public.deployment') AS exists");
+          return Array.isArray(rows) && rows[0] && rows[0].exists;
+        } catch {
+          return false;
+        }
+      },
+      { description: 'deployment table' },
+    );
+
+    log('Creating yuanctl config');
+    const baseConfig = `current_context = "e2e"\n\n[hosts.e2e]\nhost_url = "${hostUrl}"\ntls_verify = false\nconnect_timeout_ms = 10000\nreconnect_delay_ms = 2000\n\n[contexts.e2e]\nhost = "e2e"\n`;
+    await fsPromises.writeFile(configPath, baseConfig, 'utf-8');
+
+    log('Waiting for node unit availability');
+    const nodeUnits = await waitFor(
+      async () => {
+        const result = await runYuanctl(['get', 'nodeunits', '--output', 'json', '--no-headers'], {
+          configPath,
+          ignoreError: true,
+        });
+        if (!result || !result.stdout) return false;
+        try {
+          const parsed = JSON.parse(result.stdout.trim() || '[]');
+          if (Array.isArray(parsed) && parsed.length > 0 && parsed[0].address) {
+            return parsed;
+          }
+        } catch (err) {
+          log(`nodeunits parse error: ${(err && err.message) || err}`);
+        }
+        return false;
+      },
+      { description: 'node unit discovery' },
+    );
+
+    const nodeUnitAddress = nodeUnits[0].address;
+    log(`Detected node unit address: ${nodeUnitAddress}`);
+
+    log('Seeding portal deployment');
+    await runSQL(
+      buildDeploymentUpsertSQL({
+        id: portalDeploymentId,
+        packageName: portalPackageName,
+        packageVersion: portalPackageVersion,
+        address: nodeUnitAddress,
+        enabled: true,
+      }),
+    );
+
+    log('Seeding test deployment');
+    await runSQL(
+      buildDeploymentUpsertSQL({
+        id: testDeploymentId,
+        packageName: testPackageName,
+        packageVersion: testPackageVersion,
+        address: nodeUnitAddress,
+        enabled: false,
+      }),
+    );
+
+    log('Waiting for portal deployment to appear');
+    await waitFor(
+      async () => {
+        const res = await runYuanctl(
+          ['get', `deployment/${portalDeploymentId}`, '--output', 'json', '--no-headers'],
+          {
+            configPath,
+            ignoreError: true,
+          },
+        );
+        if (!res.stdout) return false;
+        const parsed = JSON.parse(res.stdout.trim() || '[]');
+        return parsed.length === 1 && parsed[0].id === portalDeploymentId;
+      },
+      { description: 'portal deployment availability' },
+    );
+
+    log('Waiting for test deployment to appear');
+    await waitFor(
+      async () => {
+        const res = await runYuanctl(
+          ['get', `deployment/${testDeploymentId}`, '--output', 'json', '--no-headers'],
+          {
+            configPath,
+            ignoreError: true,
+          },
+        );
+        if (!res.stdout) return false;
+        const parsed = JSON.parse(res.stdout.trim() || '[]');
+        return parsed.length === 1 && parsed[0].id === testDeploymentId;
+      },
+      { description: 'test deployment availability' },
+    );
+
+    const getResult = await runYuanctl(
+      ['get', `deployment/${testDeploymentId}`, '--output', 'json', '--no-headers'],
+      { configPath },
+    );
+    const deploymentRows = JSON.parse(getResult.stdout.trim() || '[]');
+    if (!Array.isArray(deploymentRows) || deploymentRows.length !== 1) {
+      throw new Error(`Expected single deployment row, got: ${getResult.stdout}`);
+    }
+
+    log('Running describe command');
+    const describeResult = await runYuanctl(['describe', `deployment/${testDeploymentId}`], { configPath });
+    if (!describeResult.stdout.includes('Name:') || !describeResult.stdout.includes(testDeploymentId)) {
+      throw new Error('Describe output missing expected fields');
+    }
+
+    log('Toggling deployment enabled state');
+    await runYuanctl(['enable', `deployment/${testDeploymentId}`], { configPath });
+    await waitFor(
+      async () => {
+        const res = await runYuanctl(
+          ['get', `deployment/${testDeploymentId}`, '--output', 'json', '--no-headers'],
+          { configPath },
+        );
+        const parsed = JSON.parse(res.stdout.trim() || '[]');
+        return parsed[0]?.enabled === true;
+      },
+      { description: 'enable propagation' },
+    );
+
+    await runYuanctl(['disable', `deployment/${testDeploymentId}`], { configPath });
+    await waitFor(
+      async () => {
+        const res = await runYuanctl(
+          ['get', `deployment/${testDeploymentId}`, '--output', 'json', '--no-headers'],
+          { configPath },
+        );
+        const parsed = JSON.parse(res.stdout.trim() || '[]');
+        return parsed[0]?.enabled === false;
+      },
+      { description: 'disable propagation' },
+    );
+
+    log('Checking restart command updates timestamp');
+    const beforeRestart = await runYuanctl(
+      ['get', `deployment/${testDeploymentId}`, '--output', 'json', '--no-headers'],
+      { configPath },
+    );
+    const beforeRows = JSON.parse(beforeRestart.stdout.trim() || '[]');
+    const beforeUpdatedAt = beforeRows[0]?.updated_at;
+    await runYuanctl(['restart', `deployment/${testDeploymentId}`], { configPath });
+    await waitFor(
+      async () => {
+        const after = await runYuanctl(
+          ['get', `deployment/${testDeploymentId}`, '--output', 'json', '--no-headers'],
+          { configPath },
+        );
+        const afterRows = JSON.parse(after.stdout.trim() || '[]');
+        return afterRows[0]?.updated_at && afterRows[0]?.updated_at !== beforeUpdatedAt;
+      },
+      { description: 'restart updated_at propagation' },
+    );
+
+    log('Running config-init smoke test');
+    const configInit = await runYuanctl(['config-init', '--host-url', hostUrl], { configPath });
+    if (!configInit.stdout.includes('current_context')) {
+      throw new Error('config-init output missing expected content');
+    }
+
+    log('Executing logs command (best effort)');
+    await runYuanctl(
+      ['logs', `deployment/${testDeploymentId}`, '--tail', '50', '--node-unit', nodeUnitAddress],
+      {
+        configPath,
+        ignoreError: true,
+      },
+    );
+
+    log('Deleting test deployment');
+    await runYuanctl(['delete', `deployment/${testDeploymentId}`], { configPath, input: 'y\n' });
+
+    await waitFor(
+      async () => {
+        const res = await runYuanctl(['get', 'deployments', '--output', 'json', '--no-headers'], {
+          configPath,
+        });
+        const parsed = JSON.parse(res.stdout.trim() || '[]');
+        return !parsed.some((item) => item.id === testDeploymentId);
+      },
+      { description: 'deployment deletion confirmation' },
+    );
+
+    log('Deleting portal deployment');
+    await runYuanctl(['delete', `deployment/${portalDeploymentId}`], {
+      configPath,
+      input: 'y\n',
+      ignoreError: true,
+    });
+
+    log('E2E test completed successfully');
+  } finally {
+    await deleteDeploymentSafe(testDeploymentId, configPath);
+    await deleteDeploymentSafe(portalDeploymentId, configPath);
+    if (!skipCompose && composeStarted && !keepServices) {
+      await composeDown();
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/tools/yuanctl/src/cli/__tests__/cli-commands.test.ts
+++ b/tools/yuanctl/src/cli/__tests__/cli-commands.test.ts
@@ -1,0 +1,149 @@
+import { Cli } from 'clipanion';
+import { PassThrough } from 'stream';
+import type { CliClients } from '../context';
+import type { IDeployment } from '@yuants/deploy';
+
+jest.mock('../context', () => ({
+  loadCliClients: jest.fn(),
+}));
+
+const { loadCliClients } = jest.requireMock('../context') as { loadCliClients: jest.Mock };
+const { GetCommand } = require('../verbs/get') as typeof import('../verbs/get');
+const { LogsCommand } = require('../verbs/logs') as typeof import('../verbs/logs');
+
+const makeCli = () => {
+  const cli = new Cli({
+    binaryLabel: 'yuanctl-test',
+    binaryName: 'yuanctl',
+    binaryVersion: '0.0.0-test',
+  });
+  cli.register(GetCommand);
+  cli.register(LogsCommand);
+  return cli;
+};
+
+describe('CLI commands (mocked clients)', () => {
+  let logs: string[];
+  let errors: string[];
+  let restoreLog: (() => void) | undefined;
+  let restoreError: (() => void) | undefined;
+
+  beforeEach(() => {
+    loadCliClients.mockReset();
+    if (!globalThis.crypto) {
+      Object.assign(globalThis, { crypto: require('crypto').webcrypto });
+    }
+    logs = [];
+    errors = [];
+    const logSpy = jest.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+      logs.push(args.map((v) => String(v)).join(' '));
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation((...args: any[]) => {
+      errors.push(args.map((v) => String(v)).join(' '));
+    });
+    restoreLog = () => logSpy.mockRestore();
+    restoreError = () => errorSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    restoreLog?.();
+    restoreError?.();
+  });
+
+  it('renders deployments as json', async () => {
+    const deployments: IDeployment[] = [
+      {
+        id: 'bot-1',
+        package_name: '@yuants/bot',
+        package_version: '1.0.0',
+        command: '',
+        args: [],
+        env: {},
+        address: 'node-1',
+        enabled: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ];
+    const clients: Partial<CliClients> = {
+      deployments: {
+        list: jest.fn().mockResolvedValue(deployments),
+        watch: jest.fn(),
+      } as any,
+      nodeUnits: { list: jest.fn() } as any,
+      logs: { readSlice: jest.fn(), follow: jest.fn() } as any,
+      config: { host: { defaultNodeUnit: 'node-1' } } as any,
+      gateway: {} as any,
+    };
+    loadCliClients.mockResolvedValue(clients);
+    const cli = makeCli();
+
+    const exit = await cli.run(['get', 'deployments', '--output', 'json', '--no-headers'], {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+    });
+
+    expect(exit === undefined || exit === 0).toBe(true);
+    expect(errors.join('')).toBe('');
+    const parsed = JSON.parse(logs.join('\n').trim());
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe('bot-1');
+  });
+
+  it('reads log slice tail with explicit node unit', async () => {
+    const deploymentRows: IDeployment[] = [
+      {
+        id: 'bot-1',
+        package_name: '@yuants/bot',
+        package_version: '1.0.0',
+        command: '',
+        args: [],
+        env: {},
+        address: 'node-1',
+        enabled: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ];
+    const clients: Partial<CliClients> = {
+      deployments: {
+        list: jest.fn().mockResolvedValue(deploymentRows),
+        watch: jest.fn(),
+      } as any,
+      nodeUnits: { list: jest.fn() } as any,
+      logs: {
+        readSlice: jest.fn().mockResolvedValue({
+          content: 'line-1\nline-2\nline-3\n',
+          start: 0,
+          end: 0,
+          file_size: 0,
+        }),
+        follow: jest.fn(),
+      } as any,
+      config: { host: { defaultNodeUnit: 'node-1' } } as any,
+      gateway: {} as any,
+    };
+    loadCliClients.mockResolvedValue(clients);
+    const cli = makeCli();
+
+    const exit = await cli.run(
+      ['logs', 'deployment/bot-1', '--tail', '2', '--node-unit', 'node-1', '--timestamps'],
+      {
+        stdin: new PassThrough(),
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+      },
+    );
+
+    expect(exit === undefined || exit === 0).toBe(true);
+    expect(errors.join('')).toBe('');
+    const lines = logs
+      .join('\n')
+      .split(/\r?\n/)
+      .filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('line-3');
+    expect(clients.logs?.readSlice).toHaveBeenCalled();
+  });
+});

--- a/tools/yuanctl/src/cli/index.ts
+++ b/tools/yuanctl/src/cli/index.ts
@@ -1,5 +1,4 @@
-import { Cli } from 'clipanion';
-import { HelpCommand } from 'clipanion/lib/advanced/builtins';
+import { Cli, Builtins } from 'clipanion';
 import { createRequire } from 'module';
 import { GetCommand } from './verbs/get';
 import { DescribeCommand } from './verbs/describe';
@@ -41,7 +40,7 @@ const createCli = () => {
   cli.register(RestartCommand);
   cli.register(LogsCommand);
   cli.register(ConfigInitCommand);
-  cli.register(HelpCommand);
+  cli.register(Builtins.HelpCommand);
   configureRootHelp(cli);
   return cli;
 };


### PR DESCRIPTION
- Updated README.md to include E2E testing instructions and environment variables.
- Created SESSION_NOTES.md to document project goals, instructions, and recent sessions.
- Added testing-plan.md outlining strategies for unit and integration tests.
- Introduced docker-compose.yml for E2E testing with PostgreSQL and node-unit services.
- Implemented run-yuanctl-e2e.js script to manage E2E tests and service orchestration.
- Added CLI command tests for 'get' and 'logs' commands to ensure correct output and behavior.
- Refactored CLI index to use Builtins for help command registration.