### PR TITLE
feat(binance): implement token bucket rate limiting for private and p…

### DIFF
--- a/.legion/tasks/binance-private-api-host-tokenbucket/context.md
+++ b/.legion/tasks/binance-private-api-host-tokenbucket/context.md
@@ -1,0 +1,64 @@
+# Binance private-api 按 host 选择 tokenBucket 并按权重限流 - 上下文
+
+## 会话进展 (2025-12-24)
+
+### ✅ 已完成
+
+- 已记录前置条件：按你的说明，apps/vendor-binance/src/api/client.ts 会在模块初始化阶段创建 3 个 tokenBucket（api/fapi/papi）；private-api 仅获取既有 bucket（不再传 options）
+- 已在 .legion/tasks/binance-private-api-host-tokenbucket/plan.md 补充 host->bucket 映射规则、统一封装思路与可复制示例，并附带待确认的 REVIEW（编码前置条件）
+- 已按你的要求回滚我此前直接落盘的代码改动：`apps/vendor-binance/src/api/private-api.ts` 已恢复到改动前状态，且已删除我新增的测试文件
+- 根据你在 plan.md 的新 review（不要抽 wrapper），已更新设计：不再引入 requestPrivateWithRateLimit；tokenBucket/acquireSync/scopeError 逻辑直接写在每个具体 API 方法内
+- 更新 plan.md 示例：scopeError 仅包裹 acquireSync（避免把请求错误也包装为 BINANCE_API_RATE_LIMIT）
+- 已响应你新增的 review：不再抽 wrapper；不再添加 host guard；plan.md 示例已更新
+- 已在 apps/vendor-binance/src/api/client.ts 创建 3 个 tokenBucket（api/fapi/papi），确保后续 tokenBucket(host) 仅获取既有桶
+- 已在 apps/vendor-binance/src/api/private-api.ts 的每个具体 API 方法中：按 endpoint host 获取 bucket 并 acquireSync(权重)，然后再调用 requestPrivate；不抽 wrapper，不加 host guard
+- 已新增最小单测 apps/vendor-binance/src/api/private-api.rateLimit.test.ts（覆盖 host 路由与条件权重）
+- 已运行校验：`npx prettier -w ...`（root），`npx tsc --noEmit --project tsconfig.json`（apps/vendor-binance），`npx heft test --clean`（apps/vendor-binance）
+- 已实现 public-api 主动限流：apps/vendor-binance/src/api/public-api.ts 在各方法调用 requestPublic 前执行 tokenBucket(url.host).acquireSync(weight)
+- 已新增 public-api 最小单测 apps/vendor-binance/src/api/public-api.rateLimit.test.ts
+- 已运行校验（apps/vendor-binance）：`npx tsc --noEmit --project tsconfig.json`、`npx heft test --clean`（2 个 test suite 全部通过）
+
+### 🟡 进行中
+
+(暂无)
+
+### ⚠️ 阻塞/待定
+
+(暂无)
+
+---
+
+## 关键文件
+
+- `apps/vendor-binance/src/api/client.ts`: 已定义 3 个 tokenBucket（本次实现只会“获取既有 bucket”，不会重复传 options）
+- `.legion/tasks/binance-private-api-host-tokenbucket/plan.md`: host->bucket 映射规则、weight 获取方式、以及可复制示例（review 已闭环）
+- `apps/vendor-binance/src/api/private-api.ts`: private REST：每个方法在请求前按 `endpoint` 的 `url.host` 取桶并 `acquireSync(weight)`
+- `apps/vendor-binance/src/api/public-api.ts`: public REST：同上（在请求前 `acquireSync(weight)`）
+- `apps/vendor-binance/src/api/private-api.rateLimit.test.ts`: 最小验证（host 路由 + 条件权重）
+- `apps/vendor-binance/src/api/public-api.rateLimit.test.ts`: 最小验证（host 路由 + 条件权重）
+
+---
+
+## 关键决策
+
+| 决策                                                                                                            | 原因                                                                                                                         | 替代方案                                                                     | 日期       |
+| --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------- |
+| 任何代码改动必须在 plan.md 的 REVIEW 得到明确确认后再开始                                                       | 避免“先写代码后补设计”的协作失序，保证你先审阅映射规则与示例                                                                 | 先实现再回头调整（本次被明确禁止）                                           | 2025-12-24 |
+| 严格按 URL host 选择 tokenBucket（`tokenBucket(url.host)`），不做未知 host 兜底，不加 host guard                | 用户已穷举 endpoint host；按 host 路由最直观且与“IP 限流”一致；未知 host 由 tokenBucket/调用栈自然暴露错误，便于发现漏网调用 | 增加显式映射表并对未知 host throw；或提供默认 bucket（更容错但可能掩盖遗漏） | 2025-12-24 |
+| 不抽 requestPrivateWithRateLimit 等 wrapper；tokenBucket/acquireSync/scopeError 逻辑直接写在每个具体 API 方法里 | 按最新 review，避免抽象以免隐藏权重与调用点逻辑                                                                              | 抽 wrapper 统一实现（更 DRY，但不符合本次协作偏好）                          | 2025-12-24 |
+
+---
+
+## 快速交接
+
+**下次继续从这里开始：**
+
+1. 确认 futures fundingRate 的权重/限频口径（文档展示为 500/5min/IP），如需更严格可单独引入更小的 bucket 或提升 weight
+
+**注意事项：**
+
+- public-api 的实现同 private-api：不抽 wrapper，不加 host guard；tokenBucket 使用 url.host 直接取桶。
+
+---
+
+_最后更新: 2025-12-24 23:05 by Codex_

--- a/.legion/tasks/binance-private-api-host-tokenbucket/plan.md
+++ b/.legion/tasks/binance-private-api-host-tokenbucket/plan.md
@@ -1,0 +1,121 @@
+# Binance private-api 按 host 选择 tokenBucket 并按权重限流
+
+## 目标
+
+在 apps/vendor-binance 的 private-api 与 public-api 发起请求前，根据 URL host 选择对应的 tokenBucket，并按接口权重调用 acquireSync 做限流。
+
+## 要点
+
+- 复用 apps/vendor-binance/src/api/client.ts 中已定义的 3 个 tokenBucket（首次 create，后续仅用 bucketId 获取，不再传 options）
+- 在 private-api / public-api 里对每次请求解析 URL host，使用 `tokenBucket(url.host)` 获取对应 bucket
+- 请求前 `bucket.acquireSync(weight)`；weight 来自方法文档注释中的“权重”
+- 用 `scopeError` 包装 acquireSync 并记录 metadata（host、path、method、weight、bucketId），token 不够时自动 throw，不捕获
+- public-api 同样落地相同的限流逻辑；修改尽量局部并保持可读性
+- 补一个最小单测：给不同 host 的 URL 断言选择不同 bucketId + weight 被传入（可用 spy/mock）
+
+## 范围
+
+- apps/vendor-binance/src/api/private-api.ts
+- apps/vendor-binance/src/api/public-api.ts
+- apps/vendor-binance/src/api/client.ts
+- apps/vendor-binance/src/api/private-api.rateLimit.test.ts
+- apps/vendor-binance/src/api/public-api.rateLimit.test.ts
+
+## 阶段概览
+
+1. **调研** - 1 个任务
+2. **设计（先让你 review）** - 1 个任务
+3. **实现** - 1 个任务
+4. **验证** - 1 个任务
+
+---
+
+## 设计细节（已确认）
+
+### 0) 前置条件（不动代码的前提）
+
+- `apps/vendor-binance/src/api/client.ts` 已在模块初始化阶段创建以下 3 个 bucket（即你说的“第一次调用是 create”）：
+  - `tokenBucket('api.binance.com', ...)`
+  - `tokenBucket('fapi.binance.com', ...)`
+  - `tokenBucket('papi.binance.com', ...)`
+- private-api 侧仅会再次调用 `tokenBucket(url.host)` 获取既有 bucket（不再传 options）。
+
+> 注：如果你当前工作区里 `client.ts` 还没落地这 3 个 bucket，后续实现阶段第一步需要先补上（这会改代码，必须等你允许再做）。
+
+### 1) host -> bucket 映射规则
+
+- `api.binance.com`：使用 bucketId=`api.binance.com`（spotAPIBucket）
+- `fapi.binance.com`：使用 bucketId=`fapi.binance.com`（futureAPIBucket）
+- `papi.binance.com`：使用 bucketId=`papi.binance.com`（unifiedAPIBucket）
+
+说明：
+
+- 选择规则只看 `new URL(endpoint).host`，不看 path（例如 `https://api.binance.com/papi/*` 仍然归到 `api.binance.com`）。
+- private-api 内不会重复初始化桶：只会 `tokenBucket(bucketId)` 获取已存在的 bucket 实例（create 已在 `apps/vendor-binance/src/api/client.ts` 发生）。
+- 不需要补充 host guard：你已确认 endpoint host 已穷举覆盖，不会遗漏。
+
+### 2) 权重来源与落地方式
+
+- 每个导出的 API 方法在调用 `requestPrivate` 前，显式传入该方法注释中的“权重”数值（如权重包含条件分支，则在方法内判定）。
+- 按你的 review：不抽 `requestPrivateWithRateLimit` 这类 wrapper；所有 `tokenBucket + acquireSync + scopeError` 都直接写在每个具体的 API 方法里。
+  - `acquireSync(weight)` 的 `weight` 必须由具体方法在调用点传入/计算（因为只有方法自己知道这次调用对应的权重）。
+
+### 3) 示例（你可以直接照抄的调用方式）
+
+```ts
+import { requestPrivate, type ICredential } from './client';
+import { scopeError, tokenBucket } from '@yuants/utils';
+
+// 例：Spot openOrders，权重: 带 symbol 6 / 不带 80
+export const getSpotOpenOrders = (credential: ICredential, params?: { symbol?: string }) => {
+  const endpoint = 'https://api.binance.com/api/v3/openOrders';
+  const url = new URL(endpoint);
+  const weight = params?.symbol ? 6 : 80;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    {
+      method: 'GET',
+      host: url.host,
+      path: url.pathname,
+      bucketId: url.host,
+      weight,
+      hasSymbol: !!params?.symbol,
+    },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
+  return requestPrivate<unknown>(credential, 'GET', endpoint, params);
+};
+```
+
+> [REVIEW] 请你确认上述 host->bucket 映射是否符合你的预期：尤其是 `https://api.binance.com/papi/*` 这类 endpoint 是否也应该按 host=`api.binance.com` 归到 spot bucket？还是你希望 path 里含 `/papi/` 也强制走 unified bucket？
+>
+> 目前按你的 review 结论：严格按 URL host 路由（`new URL(endpoint).host`），不看 path；并且不做未知 host 兜底。
+>
+> [STATUS:resolved]
+
+> [REVIEW:blocking] 若以上设计无误，请回复“OK，可以开始实现”；如还要补充 host 列表或权重规则，也请直接写在这里。
+>
+> [RESPONSE] 已收到你在本轮对话中的确认：“你解决完之后可以自行工作了”。我将其视为允许开始实现；接下来会进入阶段 3 改代码，并在完成后补最小校验与更新交接。
+> [STATUS:resolved]
+
+> [REVIEW] 不需要补充这个 guard 了，因为我看了一下代码，所有的调用的 host 都是我穷举过的，所以不会有遗漏的情况。
+>
+> [RESPONSE] 接受：已按你的补充 review 移除 host guard（不再对 url.host 做显式校验/throw）；文档与示例改为直接使用 `tokenBucket(url.host)`，依赖你已穷举的 host 列表保证不会遗漏。
+> [STATUS:resolved]
+
+> [REVIEW] 所有的 callApi 都要走限流，因为限流是按照 IP 限流的，然后我看了一下，我应该穷举了所有的调用的 api host 了，所以不会有遗漏的情况，你不需要弄一个 pickBucketIdByHost 去兜底未知 host 的情况。直接用 host 去 pick 就行了，然后你要在每个 request 里进行请求 bucket 然后限流 cal，比如 getUnifiedAccountInfo 请求 20 个 weight，因为在每个 request 里你才知道要 acquire 多大的 weight。
+>
+> [RESPONSE] 接受：所有 private-api 请求在调用 requestPrivate 前都 `tokenBucket(url.host).acquireSync(weight)`；weight 由每个具体 API 方法在调用点传入/计算；不做 wrapper/兜底（host 按你已穷举的列表覆盖）。实现会等你在 R2（blocking）确认后再开始。
+> [STATUS:resolved]
+
+> [REVIEW] 你不要抽这个 requestPrivateWithRateLimit 了，所有 tokenBucket 相关的工作都直接在具体的 api 完成。
+>
+> [RESPONSE] 接受：已移除“抽 wrapper”方案；plan.md 示例改为在具体 API 方法中直接执行 `tokenBucket(url.host).acquireSync(weight)` 并用 `scopeError` 注入 metadata。后续实现会按此方式逐个方法落地。
+> [STATUS:resolved]
+
+> [REVIEW] public-api 也需要限流，按照一样的方式继续实现。
+>
+> [RESPONSE] 接受：将 public-api 也按同样方式做主动限流（在每个具体 public API 方法里：解析 endpoint 的 url.host，`tokenBucket(url.host).acquireSync(weight)`，再调用 requestPublic；不抽 wrapper）。我会先把这一点补进 plan.md 的范围/要点与实现清单，然后开始改 `apps/vendor-binance/src/api/public-api.ts` 并补最小测试/校验。
+> [STATUS:resolved]
+
+_创建于: 2025-12-24 | 最后更新: 2025-12-24_

--- a/.legion/tasks/binance-private-api-host-tokenbucket/tasks.md
+++ b/.legion/tasks/binance-private-api-host-tokenbucket/tasks.md
@@ -1,0 +1,41 @@
+# Binance private-api 按 host 选择 tokenBucket 并按权重限流 - 任务清单
+
+## 快速恢复
+
+**当前阶段**: 阶段 4 - 验证
+**当前任务**: (none)
+**进度**: 4/4 任务完成
+
+---
+
+## 阶段 1: 调研 ✅ COMPLETE
+
+- [x] 阅读 apps/vendor-binance/src/api/client.ts 中 3 个 tokenBucket 的定义（bucketId/用途/参数），梳理 private-api 发请求的统一入口与 URL 生成方式，并确认方法注释里“权重”的表达形式 | 验收: context.md 记录：3 个 bucket 的 bucketId 与对应 host 范围；private-api 的请求入口位置；权重从注释到代码的映射方式
+
+---
+
+## 阶段 2: 设计（先让你 review） ✅ COMPLETE
+
+- [x] 在 plan.md 写清 host->bucket 的映射规则、以及 acquireSync 的调用方式；并给出一个可复制的使用示例（你要求的例子会写在 plan.md） | 验收: plan.md 包含一个最小代码示例：给定 url/weight，如何 `tokenBucket(url.host).acquireSync(weight)`；并留一个 REVIEW block 让你确认映射是否正确（你确认后再标记完成）
+
+---
+
+## 阶段 3: 实现 ✅ COMPLETE
+
+- [x] 在 private-api / public-api 的请求发送前插入“选择 bucket + acquireSync(weight)”逻辑；用 scopeError 记录 metadata；确保调用 tokenBucket 时不重复传 options | 验收: 不同 host 的请求会命中不同 bucket；token 不足会 throw（不捕获）；metadata 中能看到 host/weight/bucketId
+
+---
+
+## 阶段 4: 验证 ✅ COMPLETE
+
+- [x] 补充/更新最小测试或脚本验证：不同 host 选择不同桶；weight 透传到 acquireSync；并运行相关 test/lint/tsc（取仓库现有最小可运行路径） | 验收: 新增测试通过；prettier 格式化无噪音；无明显类型错误（已新增 private/public 两个 rateLimit test suite）
+
+---
+
+## 发现的新任务
+
+(暂无)
+
+---
+
+_最后更新: 2025-12-24 23:05_

--- a/apps/vendor-binance/SESSION_NOTES.md
+++ b/apps/vendor-binance/SESSION_NOTES.md
@@ -101,6 +101,23 @@
 
 > 仅记录已结束的会话;进行中的内容放在第 11 节,收尾后再搬运;最新记录置顶。
 
+### 2025-12-24 — Codex
+
+- **本轮摘要**：
+  - private-api 每个请求在调用 `requestPrivate` 前按 endpoint host 获取 `tokenBucket` 并 `acquireSync(权重)`，权重取自接口注释（条件权重在方法内判定）；不抽 wrapper，不加 host guard。
+  - public-api 同步做主动限流：每个请求在调用 `requestPublic` 前执行 `tokenBucket(url.host).acquireSync(weight)`。
+  - client.ts 新增 3 个 tokenBucket（`api.binance.com`/`fapi.binance.com`/`papi.binance.com`）作为首次 create，private-api 侧仅获取既有桶。
+  - 新增最小单测覆盖 host 路由与条件权重（private/public 各一套）。
+- **修改的文件**：
+  - `apps/vendor-binance/src/api/client.ts`
+  - `apps/vendor-binance/src/api/private-api.ts`
+  - `apps/vendor-binance/src/api/public-api.ts`
+  - `apps/vendor-binance/src/api/private-api.rateLimit.test.ts`
+  - `apps/vendor-binance/src/api/public-api.rateLimit.test.ts`
+- **运行的测试 / 检查**：
+  - `npx tsc --noEmit --project tsconfig.json`（workdir: apps/vendor-binance）
+  - `npx heft test --clean`（workdir: apps/vendor-binance）
+
 ### 2025-12-04 — Codex
 
 - **本轮摘要**：

--- a/apps/vendor-binance/src/api/client.ts
+++ b/apps/vendor-binance/src/api/client.ts
@@ -1,5 +1,5 @@
 import { GlobalPrometheusRegistry, Terminal } from '@yuants/protocol';
-import { encodeHex, formatTime, HmacSHA256, newError } from '@yuants/utils';
+import { encodeHex, formatTime, HmacSHA256, newError, tokenBucket } from '@yuants/utils';
 
 const MetricBinanceApiUsedWeight = GlobalPrometheusRegistry.gauge('binance_api_used_weight', '');
 const MetricBinanceApiCounter = GlobalPrometheusRegistry.counter('binance_api_request_total', '');
@@ -18,6 +18,24 @@ export interface IApiError {
   code: number;
   msg: string;
 }
+
+export const spotAPIBucket = tokenBucket('api.binance.com', {
+  capacity: 6000,
+  refillInterval: 60_000,
+  refillAmount: 6000,
+});
+
+export const futureAPIBucket = tokenBucket('fapi.binance.com', {
+  capacity: 2400,
+  refillInterval: 60_000,
+  refillAmount: 2400,
+});
+
+export const unifiedAPIBucket = tokenBucket('papi.binance.com', {
+  capacity: 1200,
+  refillInterval: 60_000,
+  refillAmount: 1200,
+});
 
 // 每个接口单独进行主动限流控制
 const mapPathToRetryAfterUntil: Record<string, number> = {};

--- a/apps/vendor-binance/src/api/private-api.ts
+++ b/apps/vendor-binance/src/api/private-api.ts
@@ -1,3 +1,5 @@
+import { scopeError, tokenBucket } from '@yuants/utils';
+
 import { getDefaultCredential, IApiError, ICredential, requestPrivate } from './client';
 export type { ICredential };
 
@@ -237,12 +239,17 @@ export interface IUMIncomeRecord {
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/account/Account-Information
  */
-export const getUnifiedAccountInfo = (credential: ICredential): Promise<IUnifiedAccountInfo | IApiError> =>
-  requestPrivate<IUnifiedAccountInfo | IApiError>(
-    credential,
-    'GET',
-    'https://papi.binance.com/papi/v1/account',
+export const getUnifiedAccountInfo = (credential: ICredential): Promise<IUnifiedAccountInfo | IApiError> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/account';
+  const url = new URL(endpoint);
+  const weight = 20;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedAccountInfo | IApiError>(credential, 'GET', endpoint);
+};
 
 /**
  * 获取UM账户信息
@@ -253,12 +260,17 @@ export const getUnifiedAccountInfo = (credential: ICredential): Promise<IUnified
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/account/Get-UM-Account-Detail
  */
-export const getUnifiedUmAccount = (credential: ICredential): Promise<IUnifiedUmAccount | IApiError> =>
-  requestPrivate<IUnifiedUmAccount | IApiError>(
-    credential,
-    'GET',
-    'https://papi.binance.com/papi/v1/um/account',
+export const getUnifiedUmAccount = (credential: ICredential): Promise<IUnifiedUmAccount | IApiError> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/um/account';
+  const url = new URL(endpoint);
+  const weight = 5;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedUmAccount | IApiError>(credential, 'GET', endpoint);
+};
 
 /**
  * 查看当前全部UM挂单(USER_DATA)
@@ -274,13 +286,25 @@ export const getUnifiedUmOpenOrders = (
   params?: {
     symbol?: string;
   },
-): Promise<IUnifiedUmOpenOrder[]> =>
-  requestPrivate<IUnifiedUmOpenOrder[]>(
-    credential,
-    'GET',
-    'https://papi.binance.com/papi/v1/um/openOrders',
-    params,
+): Promise<IUnifiedUmOpenOrder[]> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/um/openOrders';
+  const url = new URL(endpoint);
+  const weight = params?.symbol ? 1 : 40;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    {
+      method: 'GET',
+      endpoint,
+      host: url.host,
+      path: url.pathname,
+      bucketId: url.host,
+      weight,
+      hasSymbol: !!params?.symbol,
+    },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedUmOpenOrder[]>(credential, 'GET', endpoint, params);
+};
 
 /**
  * 查询账户余额(USER_DATA)
@@ -296,13 +320,17 @@ export const getUnifiedAccountBalance = (
   params?: {
     assets?: string;
   },
-): Promise<IUnifiedAccountBalanceEntry[] | IApiError> =>
-  requestPrivate<IUnifiedAccountBalanceEntry[] | IApiError>(
-    credential,
-    'GET',
-    'https://papi.binance.com/papi/v1/balance',
-    params,
+): Promise<IUnifiedAccountBalanceEntry[] | IApiError> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/balance';
+  const url = new URL(endpoint);
+  const weight = 20;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedAccountBalanceEntry[] | IApiError>(credential, 'GET', endpoint, params);
+};
 
 /**
  * 账户信息 (USER_DATA)
@@ -316,13 +344,17 @@ export const getSpotAccountInfo = (
   params?: {
     omitZeroBalances?: boolean;
   },
-): Promise<ISpotAccountInfo | IApiError> =>
-  requestPrivate<ISpotAccountInfo | IApiError>(
-    credential,
-    'GET',
-    'https://api.binance.com/api/v3/account',
-    params,
+): Promise<ISpotAccountInfo | IApiError> => {
+  const endpoint = 'https://api.binance.com/api/v3/account';
+  const url = new URL(endpoint);
+  const weight = 20;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<ISpotAccountInfo | IApiError>(credential, 'GET', endpoint, params);
+};
 
 /**
  * Current open orders (USER_DATA)
@@ -336,13 +368,25 @@ export const getSpotOpenOrders = (
   params?: {
     symbol?: string;
   },
-): Promise<ISpotOrder[] | IApiError> =>
-  requestPrivate<ISpotOrder[] | IApiError>(
-    credential,
-    'GET',
-    'https://api.binance.com/api/v3/openOrders',
-    params,
+): Promise<ISpotOrder[] | IApiError> => {
+  const endpoint = 'https://api.binance.com/api/v3/openOrders';
+  const url = new URL(endpoint);
+  const weight = params?.symbol ? 6 : 80;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    {
+      method: 'GET',
+      endpoint,
+      host: url.host,
+      path: url.pathname,
+      bucketId: url.host,
+      weight,
+      hasSymbol: !!params?.symbol,
+    },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<ISpotOrder[] | IApiError>(credential, 'GET', endpoint, params);
+};
 
 /**
  * New order (TRADE)
@@ -373,13 +417,17 @@ export const postSpotOrder = (
     pegOffsetValue?: number;
     pegOffsetType?: string;
   },
-): Promise<ISpotNewOrderResponse | IApiError> =>
-  requestPrivate<ISpotNewOrderResponse | IApiError>(
-    credential,
-    'POST',
-    'https://api.binance.com/api/v3/order',
-    params,
+): Promise<ISpotNewOrderResponse | IApiError> => {
+  const endpoint = 'https://api.binance.com/api/v3/order';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<ISpotNewOrderResponse | IApiError>(credential, 'POST', endpoint, params);
+};
 
 /**
  * Cancel order (TRADE)
@@ -397,13 +445,17 @@ export const deleteSpotOrder = (
     newClientOrderId?: string;
     cancelRestrictions?: string;
   },
-): Promise<ISpotOrder | IApiError> =>
-  requestPrivate<ISpotOrder | IApiError>(
-    credential,
-    'DELETE',
-    'https://api.binance.com/api/v3/order',
-    params,
+): Promise<ISpotOrder | IApiError> => {
+  const endpoint = 'https://api.binance.com/api/v3/order';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'DELETE', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<ISpotOrder | IApiError>(credential, 'DELETE', endpoint, params);
+};
 
 /**
  * 用户万向划转(USER_DATA)
@@ -425,13 +477,17 @@ export const postAssetTransfer = (
     fromSymbol?: string;
     toSymbol?: string;
   },
-): Promise<IAssetTransferResponse | IApiError> =>
-  requestPrivate<IAssetTransferResponse | IApiError>(
-    credential,
-    'POST',
-    'https://api.binance.com/sapi/v1/asset/transfer',
-    params,
+): Promise<IAssetTransferResponse | IApiError> => {
+  const endpoint = 'https://api.binance.com/sapi/v1/asset/transfer';
+  const url = new URL(endpoint);
+  const weight = 900;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IAssetTransferResponse | IApiError>(credential, 'POST', endpoint, params);
+};
 
 /**
  * 统一账户资金归集(TRADE)
@@ -444,8 +500,17 @@ export const postAssetTransfer = (
  *
  * ISSUE(2024-07-18): 目前这是唯一能够将资金从原 U 本位合约账户转入统一账户的接口。
  */
-export const postUnifiedAccountAutoCollection = (credential: ICredential): Promise<{ msg: string }> =>
-  requestPrivate<{ msg: string }>(credential, 'POST', 'https://papi.binance.com/papi/v1/auto-collection');
+export const postUnifiedAccountAutoCollection = (credential: ICredential): Promise<{ msg: string }> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/auto-collection';
+  const url = new URL(endpoint);
+  const weight = 750;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
+  return requestPrivate<{ msg: string }>(credential, 'POST', endpoint);
+};
 
 /**
  * 获取充值地址(支持多网络)(USER_DATA)
@@ -463,13 +528,17 @@ export const getDepositAddress = (
     network?: string;
     amount?: number;
   },
-): Promise<IDepositAddress> =>
-  requestPrivate<IDepositAddress>(
-    credential,
-    'GET',
-    'https://api.binance.com/sapi/v1/capital/deposit/address',
-    params,
+): Promise<IDepositAddress> => {
+  const endpoint = 'https://api.binance.com/sapi/v1/capital/deposit/address';
+  const url = new URL(endpoint);
+  const weight = 10;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IDepositAddress>(credential, 'GET', endpoint, params);
+};
 
 /**
  * 查询子账户列表(适用主账户)
@@ -486,13 +555,17 @@ export const getSubAccountList = (
     page?: number;
     limit?: number;
   },
-): Promise<ISubAccountListResponse | IApiError> =>
-  requestPrivate<ISubAccountListResponse | IApiError>(
-    credential,
-    'GET',
-    'https://api.binance.com/sapi/v1/sub-account/list',
-    params,
+): Promise<ISubAccountListResponse | IApiError> => {
+  const endpoint = 'https://api.binance.com/sapi/v1/sub-account/list';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<ISubAccountListResponse | IApiError>(credential, 'GET', endpoint, params);
+};
 
 /**
  * 提币(USER_DATA)
@@ -514,13 +587,17 @@ export const postWithdraw = (
     name?: string;
     walletType?: number;
   },
-): Promise<{ id: string } | IApiError> =>
-  requestPrivate<{ id: string } | IApiError>(
-    credential,
-    'POST',
-    'https://api.binance.com/sapi/v1/capital/withdraw/apply',
-    params,
+): Promise<{ id: string } | IApiError> => {
+  const endpoint = 'https://api.binance.com/sapi/v1/capital/withdraw/apply';
+  const url = new URL(endpoint);
+  const weight = 600;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<{ id: string } | IApiError>(credential, 'POST', endpoint, params);
+};
 
 /**
  * 获取提币历史(支持多网络)(USER_DATA)
@@ -545,13 +622,17 @@ export const getWithdrawHistory = (
     startTime?: number;
     endTime?: number;
   },
-): Promise<IWithdrawRecord[]> =>
-  requestPrivate<IWithdrawRecord[]>(
-    credential,
-    'GET',
-    'https://api.binance.com/sapi/v1/capital/withdraw/history',
-    params,
+): Promise<IWithdrawRecord[]> => {
+  const endpoint = 'https://api.binance.com/sapi/v1/capital/withdraw/history';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IWithdrawRecord[]>(credential, 'GET', endpoint, params);
+};
 
 /**
  * 获取充值历史(支持多网络)
@@ -572,13 +653,17 @@ export const getDepositHistory = (
     limit?: number;
     txId?: string;
   },
-): Promise<IDepositRecord[]> =>
-  requestPrivate<IDepositRecord[]>(
-    credential,
-    'GET',
-    'https://api.binance.com/sapi/v1/capital/deposit/hisrec',
-    params,
+): Promise<IDepositRecord[]> => {
+  const endpoint = 'https://api.binance.com/sapi/v1/capital/deposit/hisrec';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IDepositRecord[]>(credential, 'GET', endpoint, params);
+};
 
 /**
  * UM下单(TRADE)
@@ -603,13 +688,17 @@ export const postUmOrder = (
     selfTradePreventionMode?: string;
     goodTillDate?: number;
   },
-): Promise<IUnifiedUmOrderResponse | IApiError> =>
-  requestPrivate<IUnifiedUmOrderResponse | IApiError>(
-    credential,
-    'POST',
-    'https://papi.binance.com/papi/v1/um/order',
-    params,
+): Promise<IUnifiedUmOrderResponse | IApiError> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/um/order';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedUmOrderResponse | IApiError>(credential, 'POST', endpoint, params);
+};
 
 export const deleteUmOrder = (
   credential: ICredential,
@@ -618,13 +707,17 @@ export const deleteUmOrder = (
     orderId?: string | number;
     origClientOrderId?: string;
   },
-): Promise<IUnifiedUmOrderResponse | IApiError> =>
-  requestPrivate<IUnifiedUmOrderResponse | IApiError>(
-    credential,
-    'DELETE',
-    'https://papi.binance.com/papi/v1/um/order',
-    params,
+): Promise<IUnifiedUmOrderResponse | IApiError> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/um/order';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'DELETE', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedUmOrderResponse | IApiError>(credential, 'DELETE', endpoint, params);
+};
 
 /**
  * 获取UM损益资金流水(USER_DATA)
@@ -644,8 +737,17 @@ export const getUMIncome = (
     limit?: number;
     timestamp?: number;
   },
-): Promise<IUMIncomeRecord[]> =>
-  requestPrivate<IUMIncomeRecord[]>(credential, 'GET', 'https://api.binance.com/papi/v1/um/income', params);
+): Promise<IUMIncomeRecord[]> => {
+  const endpoint = 'https://api.binance.com/papi/v1/um/income';
+  const url = new URL(endpoint);
+  const weight = 30;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
+  return requestPrivate<IUMIncomeRecord[]>(credential, 'GET', endpoint, params);
+};
 
 /**
  * Cancel an Existing Order and Send a New Order (TRADE)
@@ -680,13 +782,17 @@ export const postSpotOrderCancelReplace = (
     pegOffsetValue?: number;
     pegOffsetType?: string;
   },
-): Promise<ISpotNewOrderResponse | IApiError> =>
-  requestPrivate<ISpotNewOrderResponse | IApiError>(
-    credential,
-    'POST',
-    'https://api.binance.com/api/v3/order/cancelReplace',
-    params,
+): Promise<ISpotNewOrderResponse | IApiError> => {
+  const endpoint = 'https://api.binance.com/api/v3/order/cancelReplace';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<ISpotNewOrderResponse | IApiError>(credential, 'POST', endpoint, params);
+};
 
 /**
  * Modify Order (TRADE)
@@ -708,13 +814,17 @@ export const putUmOrder = (
     recvWindow?: number;
     timestamp?: number;
   },
-): Promise<IUnifiedUmOrderResponse | IApiError> =>
-  requestPrivate<IUnifiedUmOrderResponse | IApiError>(
-    credential,
-    'PUT',
-    'https://papi.binance.com/papi/v1/um/order',
-    params,
+): Promise<IUnifiedUmOrderResponse | IApiError> => {
+  const endpoint = 'https://papi.binance.com/papi/v1/um/order';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'PUT', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IUnifiedUmOrderResponse | IApiError>(credential, 'PUT', endpoint, params);
+};
 export interface IMarginPair {
   id: string;
   symbol: string;
@@ -734,12 +844,15 @@ export interface IMarginPair {
  */
 export const getMarginAllPairs = (params?: { symbol?: string }): Promise<IMarginPair[]> => {
   const credential = getDefaultCredential();
-  return requestPrivate<IMarginPair[]>(
-    credential,
-    'GET',
-    'https://api.binance.com/sapi/v1/margin/allPairs',
-    params,
+  const endpoint = 'https://api.binance.com/sapi/v1/margin/allPairs';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
   );
+  return requestPrivate<IMarginPair[]>(credential, 'GET', endpoint, params);
 };
 
 /**
@@ -757,12 +870,20 @@ export const getMarginNextHourlyInterestRate = (params: {
   }[]
 > => {
   const credential = getDefaultCredential();
+  const endpoint = 'https://api.binance.com/sapi/v1/margin/next-hourly-interest-rate';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
   return requestPrivate<
     {
       asset: string;
       nextHourlyInterestRate: string;
     }[]
-  >(credential, 'GET', 'https://api.binance.com/sapi/v1/margin/next-hourly-interest-rate', params);
+  >(credential, 'GET', endpoint, params);
 };
 
 /**
@@ -785,6 +906,14 @@ export const getMarginInterestRateHistory = (params: {
   }[]
 > => {
   const credential = getDefaultCredential();
+  const endpoint = 'https://api.binance.com/sapi/v1/margin/interestRateHistory';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
   return requestPrivate<
     {
       asset: string;
@@ -792,7 +921,7 @@ export const getMarginInterestRateHistory = (params: {
       timestamp: number;
       vipLevel: number;
     }[]
-  >(credential, 'GET', 'https://api.binance.com/sapi/v1/margin/interestRateHistory', params);
+  >(credential, 'GET', endpoint, params);
 };
 
 /**
@@ -811,6 +940,14 @@ export const getUserAsset = (
     recvWindow?: number;
   },
 ) => {
+  const endpoint = 'https://api.binance.com/sapi/v3/asset/getUserAsset';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
   return requestPrivate<
     | {
         asset: string;
@@ -822,7 +959,7 @@ export const getUserAsset = (
         btcValuation: string;
       }[]
     | IApiError
-  >(credential, 'POST', 'https://api.binance.com/sapi/v3/asset/getUserAsset', params);
+  >(credential, 'POST', endpoint, params);
 };
 
 /**
@@ -841,6 +978,14 @@ export const getFundingAsset = (
     recvWindow?: number;
   },
 ) => {
+  const endpoint = 'https://api.binance.com/sapi/v1/asset/get-funding-asset';
+  const url = new URL(endpoint);
+  const weight = 1;
+  scopeError(
+    'BINANCE_API_RATE_LIMIT',
+    { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: url.host, weight },
+    () => tokenBucket(url.host).acquireSync(weight),
+  );
   return requestPrivate<
     | {
         asset: string;
@@ -852,5 +997,5 @@ export const getFundingAsset = (
         btcValuation: string;
       }[]
     | IApiError
-  >(credential, 'POST', 'https://api.binance.com/sapi/v1/asset/get-funding-asset', params);
+  >(credential, 'POST', endpoint, params);
 };

--- a/common/changes/@yuants/vendor-binance/2025-12-24-15-18.json
+++ b/common/changes/@yuants/vendor-binance/2025-12-24-15-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-binance",
+      "comment": "implement token bucket",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-binance"
+}


### PR DESCRIPTION
…ublic APIs

- Added token bucket implementation for rate limiting based on host in private-api and public-api.
- Introduced new token buckets for `api.binance.com`, `fapi.binance.com`, and `papi.binance.com` with specified capacities and refill rates.
- Updated request methods in private-api to acquire tokens before sending requests, ensuring compliance with rate limits.
- Enhanced public-api methods to include token bucket logic for rate limiting, adjusting weights based on parameters.
- Added comprehensive task documentation for the implementation process and verification steps.