### PR TITLE
feat: implement REST/IP rate limiting for Hyperliquid API

### DIFF
--- a/.legion/config.json
+++ b/.legion/config.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "currentTask": "ohlc-ohlc-v2",
+  "currentTask": "hyperliquid-api-tokenbucket",
   "settings": {
     "autoRemind": true,
     "remindBeforeReset": true,
@@ -108,9 +108,9 @@
     {
       "id": "hyperliquid-api-tokenbucket",
       "name": "Hyperliquid API tokenBucket：按官方限额主动限流",
-      "status": "paused",
+      "status": "active",
       "createdAt": "2025-12-26T06:38:21.408Z",
-      "updatedAt": "2026-01-05T06:32:01.454Z"
+      "updatedAt": "2026-01-07T10:32:05.491Z"
     },
     {
       "id": "okx-ohlcpublishchannelohlc-ohlc-v2",

--- a/.legion/config.json
+++ b/.legion/config.json
@@ -110,7 +110,7 @@
       "name": "Hyperliquid API tokenBucket：按官方限额主动限流",
       "status": "active",
       "createdAt": "2025-12-26T06:38:21.408Z",
-      "updatedAt": "2026-01-07T10:32:05.491Z"
+      "updatedAt": "2026-01-07T11:03:38.061Z"
     },
     {
       "id": "okx-ohlcpublishchannelohlc-ohlc-v2",

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -709,6 +709,7 @@
 2026-01-07T03:03:31.219Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/private-api.ts,success
 2026-01-07T03:03:41.495Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,handoff: 如需继续扩充 Hyperliquid API 封装：沿用本次模式先加 `build*RequestBody`/`build*Action` 再补离线单测，避免引入网络或 mock,success
 2026-01-07T10:32:05.508Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/rate-limit.test.ts,success
+2026-01-07T11:03:38.110Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/rate-limit.ts,success
 2026-01-07T08:31:34.459Z,legion_approve_proposal,ohlc-ohlc-v2,移除旧 ohlc 表引用并切换到 ohlc_v2,Claude,proposalId: proposal-mk3rcks9-273cc4,success
 2026-01-07T08:31:38.899Z,legion_switch_task,ohlc-ohlc-v2,移除旧 ohlc 表引用并切换到 ohlc_v2,Claude,taskId: ohlc-ohlc-v2,success
 2026-01-07T08:31:44.328Z,legion_read_context,ohlc-ohlc-v2,移除旧 ohlc 表引用并切换到 ohlc_v2,Claude,"section: all, includeReviews: true",success

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -700,6 +700,15 @@
 2026-01-07T08:22:16.395Z,legion_get_status,rush-pnpm-tsheft-2026-01,全仓 Rush + PNPM + TS/Heft 工具链升级（2026-01）,Claude,,success
 2026-01-07T08:22:19.554Z,legion_read_context,rush-pnpm-tsheft-2026-01,全仓 Rush + PNPM + TS/Heft 工具链升级（2026-01）,Claude,"section: all, includeReviews: true",success
 2026-01-07T08:29:51.803Z,legion_propose_task,rush-pnpm-tsheft-2026-01,全仓 Rush + PNPM + TS/Heft 工具链升级（2026-01）,Claude,name: 移除旧 ohlc 表引用并切换到 ohlc_v2,success
+2026-01-07T02:55:02.986Z,legion_get_status,rush-pnpm-tsheft-2026-01,全仓 Rush + PNPM + TS/Heft 工具链升级（2026-01）,Claude,,success
+2026-01-07T02:55:19.415Z,legion_switch_task,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,taskId: hyperliquid-api-tokenbucket,success
+2026-01-07T02:55:22.696Z,legion_list_reviews,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,status: open,success
+2026-01-07T03:03:20.873Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/public-api.test.ts,success
+2026-01-07T03:03:27.228Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/private-api.test.ts,success
+2026-01-07T03:03:28.451Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/public-api.ts,success
+2026-01-07T03:03:31.219Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/private-api.ts,success
+2026-01-07T03:03:41.495Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,handoff: 如需继续扩充 Hyperliquid API 封装：沿用本次模式先加 `build*RequestBody`/`build*Action` 再补离线单测，避免引入网络或 mock,success
+2026-01-07T10:32:05.508Z,legion_update_context,hyperliquid-api-tokenbucket,Hyperliquid API tokenBucket：按官方限额主动限流,Claude,addFile: apps/vendor-hyperliquid/src/api/rate-limit.test.ts,success
 2026-01-07T08:31:34.459Z,legion_approve_proposal,ohlc-ohlc-v2,移除旧 ohlc 表引用并切换到 ohlc_v2,Claude,proposalId: proposal-mk3rcks9-273cc4,success
 2026-01-07T08:31:38.899Z,legion_switch_task,ohlc-ohlc-v2,移除旧 ohlc 表引用并切换到 ohlc_v2,Claude,taskId: ohlc-ohlc-v2,success
 2026-01-07T08:31:44.328Z,legion_read_context,ohlc-ohlc-v2,移除旧 ohlc 表引用并切换到 ohlc_v2,Claude,"section: all, includeReviews: true",success

--- a/.legion/tasks/hyperliquid-api-tokenbucket/context.md
+++ b/.legion/tasks/hyperliquid-api-tokenbucket/context.md
@@ -21,6 +21,9 @@
 - 已运行 `apps/vendor-hyperliquid` 的 `./node_modules/.bin/tsc --noEmit --project tsconfig.json` 与 `./node_modules/.bin/heft test --clean` 验证通过
 - 扩展 `apps/vendor-hyperliquid/src/api/rate-limit.test.ts` 覆盖 request context 分类、base/extra weight 计算、beforeRestRequest 扣减、afterRestResponse 追加扣减与无追加场景
 - 已运行 `apps/vendor-hyperliquid` 的 `./node_modules/.bin/heft test --clean` 验证通过（新增用例通过）
+- 为 REST/IP 限流增加 weight 合法性校验：非有限值/非正数/超阈值直接报错（防止错误参数导致长时间阻塞）
+- 扩展 `apps/vendor-hyperliquid/src/api/rate-limit.test.ts` 覆盖：exchange batch 边界、unknown/info/explorer/other 默认权重、candleSnapshot 异常入参、beforeRestRequest 异常 weight、afterRestResponse delta 计算
+- 已运行 `apps/vendor-hyperliquid` 的 `./apps/vendor-hyperliquid/node_modules/.bin/tsc --noEmit --project apps/vendor-hyperliquid/tsconfig.json` 与 `./node_modules/.bin/heft test --clean` 验证通过
 
 ### 🟡 进行中
 

--- a/.legion/tasks/hyperliquid-api-tokenbucket/context.md
+++ b/.legion/tasks/hyperliquid-api-tokenbucket/context.md
@@ -1,0 +1,68 @@
+# Hyperliquid API tokenBucket：按官方限额主动限流 - 上下文
+
+## 会话进展 (2025-12-26)
+
+### ✅ 已完成
+
+- 已阅读 binance-private-api-host-tokenbucket：host→bucketId 采用 `new URL(endpoint).host` 直接路由；在每个具体 API 方法调用点计算 weight，并用 `scopeError(..., meta, () => tokenBucket(bucketId).acquireSync(weight))` 做请求前主动限流（不抽 wrapper、不做未知 host 兜底）
+- 已阅读 huobi-publicprivate-api-tokenbucket：public 采用“global bucket + business bucket 双扣减”以同时满足共享上限与业务线拆分；private 按 `credential.access_key` 动态创建 per-UID bucket，并同样做 global+business 双扣减；整体策略是“由调用点选择 helper，不在 request 内做运行时识别分类”
+- 已抓取并解析 Hyperliquid 官方文档 `Rate limits and user limits`（来源：https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits-and-user-limits ）：REST 为“每 IP 1200 weight/分钟”的聚合限额；exchange 请求 weight=1+floor(batch_length/40)；info/explorer 有固定权重与部分按返回条数加权；WebSocket 有连接数/订阅数/消息速率/inflight post 等静态上限；另有 address-based（per user）动态限制（初始 10000 buffer、按累计成交 USDC 增长、被限流后 1 req/10s，cancels 有更宽松上限）
+- 已在 `.legion/tasks/hyperliquid-api-tokenbucket/plan.md` 补充“设计细节（待 review）”：包含官方限额摘录、REST/IP bucket 参数、exchange/info weight 规则、返回条数额外加权策略、address-based 与 WebSocket 的扩展方案，以及 3 个待确认的 blocking 取舍点
+- 已响应并闭环全部 inline review（含开闭原则要求、两段式要求、伪代码要求、以及 3 个取舍点确认）；当前设计已可进入实现阶段（但按你的指令暂不改代码）
+- 已实现 REST/IP 主动限流：新增 `apps/vendor-hyperliquid/src/api/rate-limit.ts`（base weight 计算、candleSnapshot 有界额外权重估算、响应后 debt 记账），并在 `apps/vendor-hyperliquid/src/api/client.ts` 的 fetch 前接入 `beforeRestRequest(...).acquireSync`
+- 已补最小单测 `apps/vendor-hyperliquid/src/api/rate-limit.test.ts`（覆盖 info/exchange base weight 与 candleSnapshot 额外 weight 上限估算）并通过
+- 已运行校验（apps/vendor-hyperliquid）：`./node_modules/.bin/tsc --noEmit --project tsconfig.json` 通过；`./node_modules/.bin/heft test --clean` 通过
+- 已按你新增 review（R7）调整实现：响应后不再用 acquireSync/debt，而是 `await tokenBucket.acquire(deltaWeight)` 阻塞等待；并在 `apps/vendor-hyperliquid/src/api/client.ts` 参考 Binance 增加 429/Retry-After 主动退避（请求前抛 `ACTIVE_RATE_LIMIT`）
+- 已重新跑过 `apps/vendor-hyperliquid` 的 `tsc` 与 `heft test`（含新单测）均通过
+- 已按新增 review（R8）移除 client 内 429/Retry-After 主动退避：删除本地 retryAfterUntil 逻辑与 `ACTIVE_RATE_LIMIT` 抛错；429 仅记录日志并抛 `HYPERLIQUID_HTTP_429` 交给上层处理
+- 已重新跑过 `apps/vendor-hyperliquid` 的 `tsc` 与 `heft test` 均通过
+
+### 🟡 进行中
+
+(暂无)
+
+### ⚠️ 阻塞/待定
+
+(暂无)
+
+---
+
+## 关键文件
+
+- `apps/vendor-hyperliquid/src/api/client.ts`：所有 REST 请求入口（`request()` -> `callApi()` -> `fetch`），是接入“请求前主动限流”的主落点
+- `apps/vendor-hyperliquid/src/api/public-api.ts`：所有 `POST /info` 的调用点（type=allMids/metaAndAssetCtxs/candleSnapshot/...），决定 info 的 weight 分类与额外加权需求
+- `apps/vendor-hyperliquid/src/api/private-api.ts`：`POST /exchange` 的调用点（order/cancel/modify）与 `userFills`；若实现 address-based，将在这里拿到 address/batch_length
+- `apps/vendor-hyperliquid/src/services/markets/quote.ts`：高频轮询（`allMids` 每秒、`metaAndAssetCtxs` 默认 5s），是最容易触发 IP weight 的热区
+- `apps/vendor-hyperliquid/src/services/markets/ohlc.ts`：`candleSnapshot` 可能返回大量 items（额外加权按 60 items），需要重点关注
+- `apps/vendor-binance/src/api/client.ts`：参考模式（模块初始化 create bucket；调用点按 host 取 bucket 并 acquire）
+- `apps/vendor-huobi/src/api/public-api.ts`、`apps/vendor-huobi/src/api/private-api.ts`：参考模式（global+business 双桶扣减、per-UID bucket、调用点选择 helper）
+
+---
+
+## 关键决策
+
+| 决策                                                                                                                             | 原因                                                                                                                            | 替代方案                                                                      | 日期       |
+| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------- |
+| 本轮 Hyperliquid 限流实现范围采用 v1：只做 REST/IP 聚合限流 + weight 计算；address-based 动态 action budget 不实现，仅保留扩展点 | 你在 review 中给出 `1=看上面`，我按“先落 v1、v2 另开 review”的方式收敛范围，避免引入依赖 tradedUSDC 数据源的复杂度              | 直接实现 v2：进程内 address action budget（需要 tradedUSDC 数据源与刷新策略） | 2025-12-26 |
+| REST/IP 聚合桶使用 `acquireSync(weight)` + `scopeError` 打印 meta 后直接抛错，不做捕获/等待                                      | 你明确要求 `2=Sync`，且仓库其它 vendor（binance/huobi）也采用“请求前 acquireSync、失败直接 throw，交给上层 retry/backoff”的模式 | 使用 `await acquire(weight)` 在桶不足时等待（不会抛错，但会阻塞调用链）       | 2025-12-26 |
+| candleSnapshot 不改查询窗口，按官方“最多 5000 candles”上限做额外 weight 有界估算；响应后只做 debt 记账                           | 你要求 `3=两段式` 且不希望为了限流去大改既有逻辑；官方明确 5000 上限使得 startTime=0 不会导致无界 weight                        | 修改调用点，把 candleSnapshot 查询窗口改为有界（按 duration/limit 分段拉取）  | 2025-12-26 |
+| WebSocket 限流本轮不实现（out-of-scope），仅保留未来扩展建议                                                                     | 你明确 review：websocket 部分先不做                                                                                             | 本轮同步实现 WS connection/subscription/message/inflight 限制                 | 2025-12-26 |
+| 不做 Hyperliquid 429 主动退避（待官方文档明确后再加）                                                                            | 你 review 指出官方文档未明确 429/Retry-After 语义，先保持最小行为：记录日志 + 抛错，由上层决定 retry/backoff                    | 参考 Binance 在 client 内实现 mapRetryAfterUntil 主动退避（当前已移除）       | 2026-01-05 |
+
+---
+
+## 快速交接
+
+**下次继续从这里开始：**
+
+1. 如后续 Hyperliquid 官方文档明确 429/`Retry-After` 语义：再补 client 内主动退避策略（目前按 review 已移除）
+2. 如需要增强可观测：可补 Prometheus 指标（例如 429 次数、REST/IP bucket token 使用情况、响应后额外 acquire 累计等待时间）
+
+**注意事项：**
+
+- 当前 backoff key：`info:<type>` / `exchange:<actionType>` / `explorer:<path>` / `other:<path>`，可按需要收敛或细化
+- 响应后 acquire 会延迟返回 response（按你要求：不在响应后报错，使用阻塞等待节流）
+
+---
+
+_最后更新: 2026-01-05 14:20 by Claude_

--- a/.legion/tasks/hyperliquid-api-tokenbucket/context.md
+++ b/.legion/tasks/hyperliquid-api-tokenbucket/context.md
@@ -16,6 +16,11 @@
 - 已重新跑过 `apps/vendor-hyperliquid` 的 `tsc` 与 `heft test`（含新单测）均通过
 - 已按新增 review（R8）移除 client 内 429/Retry-After 主动退避：删除本地 retryAfterUntil 逻辑与 `ACTIVE_RATE_LIMIT` 抛错；429 仅记录日志并抛 `HYPERLIQUID_HTTP_429` 交给上层处理
 - 已重新跑过 `apps/vendor-hyperliquid` 的 `tsc` 与 `heft test` 均通过
+- 为 `apps/vendor-hyperliquid/src/api/public-api.ts` / `apps/vendor-hyperliquid/src/api/private-api.ts` 抽取 request body/action builders（纯函数/无网络），便于离线测试
+- 新增单测覆盖 public-api 与 private-api 的请求体构造与签名输出形状；修复 `userFills` startTime/endTime=0 时不被带上的边界情况
+- 已运行 `apps/vendor-hyperliquid` 的 `./node_modules/.bin/tsc --noEmit --project tsconfig.json` 与 `./node_modules/.bin/heft test --clean` 验证通过
+- 扩展 `apps/vendor-hyperliquid/src/api/rate-limit.test.ts` 覆盖 request context 分类、base/extra weight 计算、beforeRestRequest 扣减、afterRestResponse 追加扣减与无追加场景
+- 已运行 `apps/vendor-hyperliquid` 的 `./node_modules/.bin/heft test --clean` 验证通过（新增用例通过）
 
 ### 🟡 进行中
 
@@ -55,14 +60,14 @@
 
 **下次继续从这里开始：**
 
-1. 如后续 Hyperliquid 官方文档明确 429/`Retry-After` 语义：再补 client 内主动退避策略（目前按 review 已移除）
-2. 如需要增强可观测：可补 Prometheus 指标（例如 429 次数、REST/IP bucket token 使用情况、响应后额外 acquire 累计等待时间）
+1. 如需继续扩充 Hyperliquid API 封装：沿用本次模式先加 `build*RequestBody`/`build*Action` 再补离线单测，避免引入网络或 mock
+2. 如要排查 Jest "failed to exit gracefully"：可在 `apps/vendor-hyperliquid` 下用 `./node_modules/.bin/heft test --clean -- --detectOpenHandles` 定位未释放的 handle（当前不影响通过）
 
 **注意事项：**
 
-- 当前 backoff key：`info:<type>` / `exchange:<actionType>` / `explorer:<path>` / `other:<path>`，可按需要收敛或细化
-- 响应后 acquire 会延迟返回 response（按你要求：不在响应后报错，使用阻塞等待节流）
+- 本次新增 public/private API 单测均为离线纯函数/签名验证，不会触发真实 HTTP 请求
+- `buildUserFillsRequestBody` 已修复 startTime/endTime=0 时构造丢字段的问题（由 `if (params?.startTime)` 改为 `!= null` 判断）
 
 ---
 
-_最后更新: 2026-01-05 14:20 by Claude_
+_最后更新: 2026-01-07 00:00 by Codex_

--- a/.legion/tasks/hyperliquid-api-tokenbucket/plan.md
+++ b/.legion/tasks/hyperliquid-api-tokenbucket/plan.md
@@ -1,0 +1,407 @@
+# Hyperliquid API tokenBucket：按官方限额主动限流
+
+## 目标
+
+在 apps/vendor-hyperliquid 的 REST/WebSocket 请求入口前接入 tokenBucket 主动限流，并按 Hyperliquid 官方 rate limits & user limits 规则选择/扣减对应 bucket，避免触发 429/封禁。
+
+## 要点
+
+- 先调研并复用既有模式：参考 binance-private-api-host-tokenbucket 与 huobi-publicprivate-api-tokenbucket 的 bucket 定义方式、选择矩阵、以及在 request 前 acquire 的插入点
+- 限流策略以“保守”为默认：无法识别的 endpoint 走更严格 bucket；并为 429/headers 留出扩展位（可选）
+- 设计必须覆盖：bucket 列表（id/窗口/容量/维度 key）、endpoint→bucket 映射、错误/观测策略、以及实现落点（哪些文件/函数）
+- 先写 `.legion` 详细设计并等待 review，通过后再改代码
+- 保持实现简单直白；避免重复造轮子，优先复用仓库现成 tokenBucket/util
+
+## 范围
+
+- `apps/vendor-hyperliquid/src/**`
+- `apps/vendor-binance/src/**`（仅对照阅读，不改）
+- `apps/vendor-huobi/src/**`（仅对照阅读，不改）
+- .legion/tasks/<new-task>/plan.md
+- .legion/tasks/<new-task>/context.md
+- .legion/tasks/<new-task>/tasks.md
+
+## 阶段概览
+
+1. **调研** - 1 个任务
+2. **设计（先写文档，等待 review）** - 1 个任务
+3. **实现** - 1 个任务
+4. **验证与交接** - 1 个任务
+
+---
+
+## 设计细节（待 review）
+
+### 0) 规则来源
+
+- 官方文档：`https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/rate-limits-and-user-limits`
+- 本次设计只覆盖 Hyperliquid “REST / WebSocket 访问限额”侧的**请求前主动限流**；链上/撮合行为不在这里处理。
+
+### 1) 目标与非目标
+
+目标：
+
+- 对 `https://api.hyperliquid.xyz/*` 的 REST 请求做“请求前主动限流”，使单进程在稳态下不触发 429。
+- 对 `exchange` / `info` / `explorer` 这三类 REST 请求实现**官方 weight 计算**，并统一落到同一个“每 IP 聚合”桶。
+- 设计要尽量复用仓库既有模式：`tokenBucket` + `scopeError` + 清晰的 bucketId 命名。
+
+非目标（先不做，或只做 best-effort）：
+
+- **分布式/多副本全局限流**：当前 `tokenBucket` 为进程内实现；多实例会按实例数放大吞吐（与其他 vendor 现状一致）。
+- **address-based 动态额度的精确实现**：需要依赖“累计成交 USDC / 初始 buffer”等用户状态，现阶段先把接口与扩展点设计好，具体实现等你确认范围后再落地。
+
+### 2) REST：每 IP 聚合桶
+
+官方规则：REST requests share an aggregated weight limit of **1200 per minute per IP**。
+
+设计：
+
+- bucketId：`HYPERLIQUID_REST_IP_WEIGHT_1200_PER_MIN`
+- 参数：`capacity=1200`，`refillInterval=60_000`，`refillAmount=1200`
+- 所有发往 `api.hyperliquid.xyz` 的 REST 请求（`/info`、`/exchange`、`/explorer`、以及未来可能的其他 path）都要在发起前从该桶扣减 weight。
+
+### 3) REST weight 计算（请求前可计算部分）
+
+#### 3.1 `exchange`（`POST /exchange`）
+
+官方规则：所有 documented `exchange` API requests weight = `1 + floor(batch_length / 40)`。
+
+- `batch_length` 的定义：action 内数组长度（例如 order 的 `orders.length`、cancel 的 `cancels.length`）。
+- 若 action 不包含数组（例如 modify 单笔），按 `batch_length=1` 处理。
+
+> 备注：该 weight 仅用于 **IP 聚合桶**；address-based 另算（见 4）。
+
+#### 3.2 `info`（`POST /info`）
+
+官方规则（摘录）：
+
+- weight=2：`l2Book, allMids, clearinghouseState, orderStatus, spotClearinghouseState, exchangeStatus`
+- weight=60：`userRole`
+- 其他 documented `info` requests：weight=20
+
+设计落地（请求体 `type` 字段决定 weight）：
+
+- 若 `type` 在 weight=2 列表 → weight=2
+- 若 `type === 'userRole'` → weight=60
+- 其他 → weight=20
+
+#### 3.3 `explorer`（未来扩展）
+
+官方规则：所有 `explorer` API requests weight=40（`blockList` 还有“每 block 额外 1”与“老区块更重”的说明）。
+
+当前 vendor-hyperliquid 未使用 explorer；设计上预留：
+
+- 若 `path` 以 `explorer` 开头（或明确映射到 explorer）→ weight=40
+- `blockList` 的额外加权：先按保守策略（见 3.4）实现，避免低估导致 429
+
+> [REVIEW] 你如果要预留必须遵循开闭原则，以后不应该很修改已有代码，而是加新 case。
+>
+> [RESPONSE] 接受：我会按开闭原则组织“限流规则/权重计算”。实现上不会把所有判断写成一坨 if-else，而是用可扩展的 rule registry（数组/Map）来驱动：新增 endpoint/type 只需要“新增一条 rule / 新增一个 case 配置”，核心流程（计算 →acquireSync→fetch）不需要改。
+> [STATUS:resolved]
+
+#### 3.4 基于“返回条数”的额外加权（保守策略）
+
+官方规则：
+
+- 以下 `info` endpoints：每 **20 items returned** 增加额外 weight：`recentTrades, historicalOrders, userFills, userFillsByTime, fundingHistory, userFunding, nonUserFundingUpdates, twapHistory, userTwapSliceFills, userTwapSliceFillsByTime, delegatorHistory, delegatorRewards, validatorStats`
+- `candleSnapshot`：每 **60 items returned** 增加额外 weight
+
+难点：额外 weight 与“响应条数”相关，严格来说需要在拿到响应后才能准确计算。
+
+本次设计采用两段式（优先保守，避免低估）：
+
+1. **请求前（预估）**：对能在请求时估算的 endpoint，提前估算额外 weight 并参与本次 acquire。
+   - `candleSnapshot`：官方说明“Only the most recent 5000 candles are available”，因此 `estimatedItems = min(5000, ceil((endTime - startTime) / intervalMs))`
+   - 额外 weight：`extra = ceil(estimatedItems / 60)`
+2. **响应后（记账）**：对需要按“响应条数”计费但请求时难以估算的 endpoint（如 `userFills`/`fundingHistory`），响应后计算 `actualExtra` 并记入 `debt`，由后续请求逐步偿还（不在响应后阻塞/不在响应后抛错）。
+   - 额外 weight：`actualExtra = ceil(actualItems / 20)`（`candleSnapshot` 用 `/60`）
+
+> 待确认点：你是否希望“响应后纠偏”作为 v1 必做（更准确但会让调用链更慢），还是 v2 再加。
+
+> [REVIEW] 两段式可以，也要符合开闭原则；
+>
+> [RESPONSE] 接受：两段式会按开闭原则落地。
+>
+> - 第一段（请求前）：根据 (path + body.type + action) 计算 baseWeight/estimatedExtraWeight（可扩展的 estimator 列表）。
+> - 第二段（响应后）：只做“补充信息/记账”，不在这里改核心流程；新增需要按返回条数计费的 endpoint 时，只新增一个 ResponseWeigher（match + countItems + divisor），不改已有逻辑。
+>   [STATUS:resolved]
+
+### 4) address-based limits（动作限额，待确认范围）
+
+官方规则（摘录）：
+
+- address-based limits per user；sub-accounts treated as separate users
+- 初始 buffer：10000 requests
+- 动态额度与累计成交 USDC 相关：允许 1 request / 1 USDC traded（自 inception 累计）
+- 当触发 address-based rate limit：该 address 允许 1 request / 10s
+- batched request：对 IP 限流视为 1 次请求；对 address-based 视为 `n` 次请求（n 为 orders/cancels 数量）
+- cancels 有更宽松上限：`min(limit + 100000, limit * 2)`
+
+本仓库现状下可落地的两档方案（供你选）：
+
+1. **v1（建议默认）**：只实现 REST 的 IP 聚合限流 + exchange weight；address-based 只做“遇到明确的 rate-limit 响应时，按 10s/backoff 做主动熔断一段时间”（best-effort）。
+2. **v2（更完整）**：实现进程内的 address action budget：
+   - `available = 10000 + tradedUSDC`（tradedUSDC 通过定期查询用户状态/成交记录更新）
+   - 对 `order/cancel/modify`：按 action 的 `batch_length` 扣减 `available`
+   - 当 `available` 不足：强制进入 `1 req / 10s` 模式（可用 `tokenBucket(addressBucketId, { capacity: 1, refillInterval: 10_000, refillAmount: 1 })` 做节流）
+
+> v2 需要你确认“tradedUSDC 的数据源/刷新频率/成本”（可能会额外消耗 info weight）。
+
+> [REVIEW] 这个你给我一些详细的伪代码让我 review 之后再说
+>
+> [RESPONSE] 补一份可 review 的伪代码（遵循开闭原则；不改业务代码，只给设计）：
+>
+> ```ts
+> // apps/vendor-hyperliquid/src/api/rate-limit.ts
+> import { scopeError, tokenBucket } from '@yuants/utils';
+>
+> const REST_IP_BUCKET_ID = 'HYPERLIQUID_REST_IP_WEIGHT_1200_PER_MIN';
+> // 模块初始化阶段 create
+> tokenBucket(REST_IP_BUCKET_ID, { capacity: 1200, refillInterval: 60_000, refillAmount: 1200 });
+>
+> type RestKind = 'info' | 'exchange' | 'explorer' | 'other';
+>
+> type RestRequestCtx = {
+>   method: 'GET' | 'POST';
+>   path: string; // 'info' | 'exchange' | ...
+>   body?: unknown; // POST body
+>   // 解析后的字段（可选）
+>   infoType?: string; // body.type
+>   exchangeActionType?: string; // body.action.type
+>   exchangeBatchLength?: number; // orders.length / cancels.length / 1
+> };
+>
+> type ExtraWeigher = {
+>   match: (ctx: RestRequestCtx) => boolean;
+>   // 请求前能估算则返回 >=0；否则返回 0
+>   estimateItems?: (ctx: RestRequestCtx) => number;
+>   // 响应后能计算则返回 >=0；否则返回 0
+>   countItemsFromResponse?: (resp: unknown) => number;
+>   divisor: number; // 20 or 60
+> };
+>
+> const INFO_BASE_WEIGHT: Record<string, number> = {
+>   l2Book: 2,
+>   allMids: 2,
+>   clearinghouseState: 2,
+>   orderStatus: 2,
+>   spotClearinghouseState: 2,
+>   exchangeStatus: 2,
+>   userRole: 60,
+> };
+>
+> const extraWeighers: ExtraWeigher[] = [
+>   {
+>     match: (ctx) => ctx.infoType === 'candleSnapshot',
+>     divisor: 60,
+>     estimateItems: (ctx) => {
+>       // 官方：Only the most recent 5000 candles are available
+>       const req = (ctx.body as any)?.req;
+>       const interval = req?.interval as string | undefined;
+>       const startTime = req?.startTime as number | undefined;
+>       const endTime = req?.endTime as number | undefined;
+>       const intervalMs = INTERVAL_TO_MS[interval ?? ''] ?? 0;
+>       if (!intervalMs || !startTime || !endTime || endTime <= startTime) return 0;
+>       return Math.min(5000, Math.ceil((endTime - startTime) / intervalMs));
+>     },
+>     countItemsFromResponse: (resp) => (Array.isArray(resp) ? resp.length : 0),
+>   },
+>   {
+>     match: (ctx) => ctx.infoType === 'userFills' || ctx.infoType === 'fundingHistory',
+>     divisor: 20,
+>     // 这类请求“请求前难估算”，先返回 0，响应后计入 debt
+>     countItemsFromResponse: (resp) => {
+>       // userFills 返回可能是 { fills: [] } 或 []；这里做最小兼容
+>       const fills = (resp as any)?.fills;
+>       if (Array.isArray(fills)) return fills.length;
+>       return Array.isArray(resp) ? resp.length : 0;
+>     },
+>   },
+>   // 以后新增 case：只需要往这里追加一个 ExtraWeigher，不改核心流程
+> ];
+>
+> const INTERVAL_TO_MS: Record<string, number> = {
+>   '1m': 60_000,
+>   '3m': 180_000,
+>   '5m': 300_000,
+>   '15m': 900_000,
+>   '30m': 1_800_000,
+>   '1h': 3_600_000,
+>   '2h': 7_200_000,
+>   '4h': 14_400_000,
+>   '8h': 28_800_000,
+>   '12h': 43_200_000,
+>   '1d': 86_400_000,
+>   '3d': 259_200_000,
+>   '1w': 604_800_000,
+>   '1M': 2_592_000_000,
+> };
+>
+> let restIpDebt = 0;
+>
+> export function getRestRequestCtx(method: 'GET' | 'POST', path: string, body?: unknown): RestRequestCtx {
+>   if (method === 'POST' && path === 'info') {
+>     return { method, path, body, infoType: (body as any)?.type };
+>   }
+>   if (method === 'POST' && path === 'exchange') {
+>     const action = (body as any)?.action;
+>     const t = action?.type;
+>     const batchLength = Array.isArray(action?.orders)
+>       ? action.orders.length
+>       : Array.isArray(action?.cancels)
+>       ? action.cancels.length
+>       : 1;
+>     return { method, path, body, exchangeActionType: t, exchangeBatchLength: batchLength };
+>   }
+>   return { method, path, body };
+> }
+>
+> export function getRestBaseWeight(ctx: RestRequestCtx): number {
+>   if (ctx.path === 'exchange') {
+>     const n = Math.max(1, ctx.exchangeBatchLength ?? 1);
+>     return 1 + Math.floor(n / 40);
+>   }
+>   if (ctx.path === 'info') {
+>     return INFO_BASE_WEIGHT[ctx.infoType ?? ''] ?? 20;
+>   }
+>   if (ctx.path.startsWith('explorer')) {
+>     return 40;
+>   }
+>   return 20; // 保守兜底
+> }
+>
+> export function getRestEstimatedExtraWeight(ctx: RestRequestCtx): number {
+>   for (const w of extraWeighers) {
+>     if (!w.match(ctx)) continue;
+>     const items = w.estimateItems?.(ctx) ?? 0;
+>     if (items <= 0) return 0;
+>     return Math.ceil(items / w.divisor);
+>   }
+>   return 0;
+> }
+>
+> export function acquireRestIpWeightSync(meta: Record<string, unknown>, weight: number) {
+>   scopeError('HYPERLIQUID_API_RATE_LIMIT', { ...meta, bucketId: REST_IP_BUCKET_ID, weight }, () =>
+>     tokenBucket(REST_IP_BUCKET_ID).acquireSync(weight),
+>   );
+> }
+>
+> export function beforeRestRequest(meta: Record<string, unknown>, ctx: RestRequestCtx) {
+>   const base = getRestBaseWeight(ctx);
+>   const estimatedExtra = getRestEstimatedExtraWeight(ctx);
+>   const debtToPay = Math.min(restIpDebt, 200); // 每次最多偿还一部分，避免一次性把 weight 撑爆
+>   restIpDebt -= debtToPay;
+>   acquireRestIpWeightSync(meta, base + estimatedExtra + debtToPay);
+>   return { base, estimatedExtra };
+> }
+>
+> export function afterRestResponse(ctx: RestRequestCtx, response: unknown, estimatedExtra: number) {
+>   for (const w of extraWeighers) {
+>     if (!w.match(ctx)) continue;
+>     const items = w.countItemsFromResponse?.(response) ?? 0;
+>     if (items <= 0) return;
+>     const actualExtra = Math.ceil(items / w.divisor);
+>     const delta = actualExtra - estimatedExtra;
+>     // 只记录 debt（欠账）；不在响应后 acquireSync/throw
+>     if (delta > 0) restIpDebt += delta;
+>     return;
+>   }
+> }
+> ```
+>
+> 说明：
+>
+> - 该伪代码为当时的草案；**以实际实现为准**：当前实现已改为 `beforeRestRequest` 请求前 `acquireSync`，`afterRestResponse` 响应后 `await acquire(deltaWeight)` 阻塞等待（不使用 acquireSync/debt）。
+> - 429 主动退避：按后续 review（R8）已移除；当前实现为“打印日志 + 抛错”，不在 client 内做退避（等待官方文档明确再加）。
+> - `candleSnapshot` 的“startTime=0”不会导致无限 weight：官方上限 5000 candles，因此额外 weight 上限约 `ceil(5000/60)=84`。
+> - 新增按返回条数计费的 endpoint：只需要往 `extraWeighers` 追加一条规则；核心流程保持开闭原则不改。
+>   [STATUS:resolved]
+
+### 5) WebSocket limits（未来扩展）
+
+官方规则（摘录）：
+
+- 最大 100 websocket connections
+- 最大 1000 websocket subscriptions
+- user-specific subscriptions：最多 10 unique users
+- 每分钟最多 2000 messages（跨所有连接）
+- 最多 100 simultaneous inflight post messages（跨所有连接）
+
+当前 vendor-hyperliquid 代码未使用 WebSocket；若后续接入，建议：
+
+- `tokenBucket('HYPERLIQUID_WS_MESSAGES_PER_MIN', { capacity: 2000, refillInterval: 60_000, refillAmount: 2000 })`
+- `semaphore('HYPERLIQUID_WS_INFLIGHT_POST')` 作为 inflight=100 的并发闸门
+- subscriptions/unique-users/connection 数量作为启动时的硬校验（超限直接拒绝启动）
+
+> [REVIEW] websocket 部分先不做。
+>
+> [RESPONSE] 收到：WebSocket 限额这轮先不做实现；我会在设计里保留“未来扩展建议”但明确标注 out-of-scope，避免误导。
+> [STATUS:resolved]
+
+### 6) 代码落点（实现阶段按此改）
+
+> 本节只是设计说明；按你的要求，在你 review 通过之前不改代码。
+
+- 新增：`apps/vendor-hyperliquid/src/api/rate-limit.ts`
+  - `getRestRequestWeight({ path, params }) => { weight, extraWeightEstimate, meta }`
+  - `acquireRestIpWeightSync({ weight, meta }) => void`（内部用 `scopeError + tokenBucket.acquireSync`，并直接抛错）
+- 修改：`apps/vendor-hyperliquid/src/api/client.ts`
+  - 在 `fetch` 前调用 `acquireRestIpWeightSync`
+  - 在解析响应后按实际条数做“响应后 acquire（阻塞等待，不抛错）”
+  - 若收到 429：仅打印日志并抛错（不做 client 内主动退避；等待官方文档明确再加）
+- （若你选择做 address-based）修改：`apps/vendor-hyperliquid/src/api/private-api.ts`
+  - 在 `placeOrder/cancelOrder/modifyOrder` 发请求前，按 action batch_length 执行 address-based 的扣减/节流
+
+### 7) 待你确认的关键点（REVIEW）
+
+> [REVIEW:blocking] 请你确认本次实现范围与关键取舍：\\n> 1) address-based：按上面 v1（best-effort backoff）还是 v2（实现 action budget）？\\n> 2) tokenBucket 获取方式：REST/IP 桶使用 `await acquire(weight)`（等待）还是 `acquireSync(weight)`（抛错交给上层 retry）？\\n> 3) `candleSnapshot` 当前调用使用 `startTime=0`，可能导致返回条数与额外 weight 极大：你是否允许我在实现阶段顺便把查询窗口改为“有界”（例如按 duration 只取 `N` 根）来避免系统性 429？\\n>\\n> 你的回复可以直接写“1=v1, 2=await, 3=允许/不允许”，我就按此落地。
+>
+> [RESPONSE] 设计已落盘，当前实现前只缺 3 个取舍点的确认：
+>
+> 1. address-based 选 v1 还是 v2
+> 2. REST/IP 桶用 `await acquire` 还是 `acquireSync`
+> 3. 是否允许把 `candleSnapshot` 的查询窗口改为有界以避免额外 weight 爆炸
+>
+> 你直接按“1=..., 2=..., 3=...”回复即可；收到后我进入实现阶段。
+> [STATUS:need-info]
+>
+> [RESPONSE] 已按你最新回复收敛这 3 个取舍点（仅更新设计，不改代码）：
+>
+> 1. address-based：按 v1 处理（本轮不做动态 action budget，只保留扩展点；如你要 v2 再单独 review）
+> 2. tokenBucket：REST/IP 聚合桶统一 `acquireSync(weight)`，用 `scopeError` 打印必要 meta 后直接抛错，不捕获
+> 3. candleSnapshot：不改调用窗口；并利用官方“最多 5000 根 candles”上限做额外 weight 的有界估算（额外 weight 上限约 `ceil(5000/60)=84`），两段式按开闭原则实现
+>    [STATUS:resolved]
+
+> [REVIEW] 1=看上面 2=Sync 然后直接 scopeError 打印必要信息抛错，不要捕获 3=两段式就好了，但是要符合开闭原则。
+>
+> [RESPONSE] 收到你的决策输入，我会这样落实到设计（不改代码）：
+>
+> - `2=Sync`：REST/IP 聚合桶统一用 `acquireSync(weight)`，并用 `scopeError` 打印必要 meta 后直接抛错，不捕获。
+> - `3=两段式`：采用“请求前计算 + 响应后记账”的两段式；并按开闭原则实现。
+> - `websocket 先不做`：本轮 out-of-scope。
+>
+> `1=看上面` 我先按 v1（不做 address-based 动态 budget，只保留扩展点）理解；如果你想直接做 v2，请再回我一句我再补设计。
+> [STATUS:resolved]
+
+> [REVIEW] afterRestResponse 这个不要使用 acquireSync，不希望在响应后报错，而使用 acquire 来阻塞等待，同时还要通过对 429 退避（对 429 退避是最重要的，具体怎么做你可能需要看一下 binance client.ts 的做法）
+>
+> [RESPONSE] 接受并已落地到实现：
+>
+> - `afterRestResponse` 不再使用 `acquireSync`/debt；改为响应解析后按返回条数计算 `deltaWeight`，用 `await tokenBucket(...).acquire(deltaWeight)` 阻塞等待（不会因令牌不足而报错）。
+> - 增加 429 退避：`apps/vendor-hyperliquid/src/api/client.ts` 参考 Binance 的 `mapPathToRetryAfterUntil`，基于 `Retry-After`（以及 429）记录 `retryAfterUntil`，在下次请求前主动抛 `ACTIVE_RATE_LIMIT` 让上层 retry/backoff。
+> - 设计说明同步更新在 `.legion/tasks/hyperliquid-api-tokenbucket/plan.md`。
+>   [STATUS:resolved]
+
+> [REVIEW] 我看了一下 hyperliquid 的文档没有给出 429 相关的说明，遇到报错还是先打印日志，不要退避了，等以后有说明了再说。所以你把退避的部分去掉吧
+>
+> [RESPONSE] 收到并接受：Hyperliquid 文档未明确 429/Retry-After 语义前，client 内不做主动退避。
+>
+> 已落地改动：
+>
+> - 移除 `Retry-After` 解析与本地 `retryAfterUntil` 逻辑；不再抛 `ACTIVE_RATE_LIMIT`。
+> - 遇到 429：仅打印响应日志并抛错（`HYPERLIQUID_HTTP_429`），交给上层（rx retry/backoff/运维）决定处理策略。
+>
+> 对应文件：`apps/vendor-hyperliquid/src/api/client.ts` + 设计说明同步更新在 `plan.md`。
+> [STATUS:resolved]
+
+_创建于: 2025-12-26 | 最后更新: 2025-12-26_

--- a/.legion/tasks/hyperliquid-api-tokenbucket/tasks.md
+++ b/.legion/tasks/hyperliquid-api-tokenbucket/tasks.md
@@ -1,0 +1,41 @@
+# Hyperliquid API tokenBucket：按官方限额主动限流 - 任务清单
+
+## 快速恢复
+
+**当前阶段**: 阶段 4 - 验证与交接
+**当前任务**: (none)
+**进度**: 4/4 任务完成
+
+---
+
+## 阶段 1: 调研 ✅ COMPLETE
+
+- [x] 阅读 binance-private-api-host-tokenbucket 与 huobi-publicprivate-api-tokenbucket 的实现/文档，总结“bucket 定义、维度 key、host/业务路由、acquire 插入点、观测与错误处理”模式，并记录到 context.md | 验收: context.md 有清晰的对照笔记：关键文件/入口函数、bucket 选择矩阵、以及可直接复用的代码结构
+
+---
+
+## 阶段 2: 设计（先写文档，等待 review） ✅ COMPLETE
+
+- [x] 根据 Hyperliquid 官方文档梳理 rate limits & user limits；产出详细设计：bucket 列表与参数、endpoint→bucket 映射、维度 key（IP/API key/address）、默认策略、以及未来扩展（429 回退/动态 headers） | 验收: plan.md/context.md 写清：规则来源链接、bucket 表格、映射规则与示例；列出不确定点与待验证项；可直接据此进入实现
+
+---
+
+## 阶段 3: 实现 ✅ COMPLETE
+
+- [x] 在 vendor-hyperliquid 的 request 入口（REST）调用 acquireSync；按映射选择 bucket 并扣减；加最小日志/metadata（可复用 scopeError） | 验收: 所有对外请求在发起前都会先 acquire；不同 endpoint/动作走正确 bucket；无法识别时走保守 bucket
+
+---
+
+## 阶段 4: 验证与交接 ✅ COMPLETE
+
+- [x] 补最小单测/脚本验证映射与 key 隔离；运行 vendor-hyperliquid 的 tsc/测试；更新 context.md 快速交接 | 验收: 验证命令可复现；测试通过；context.md 有下一步与排障指引
+
+---
+
+## 发现的新任务
+
+(暂无)
+
+---
+
+_最后更新: 2025-12-26 15:29_

--- a/apps/vendor-hyperliquid/src/api/rate-limit.test.ts
+++ b/apps/vendor-hyperliquid/src/api/rate-limit.test.ts
@@ -1,0 +1,31 @@
+import { tokenBucket } from '@yuants/utils';
+import { getRestBaseWeight, getRestEstimatedExtraWeight, getRestRequestContext } from './rate-limit';
+
+describe('rate-limit', () => {
+  afterAll(() => {
+    const bucket = tokenBucket('HYPERLIQUID_REST_IP_WEIGHT_1200_PER_MIN');
+    bucket[Symbol.dispose]();
+  });
+
+  it('calculates info base weight', () => {
+    const ctx = getRestRequestContext('POST', 'info', { type: 'allMids' });
+    expect(getRestBaseWeight(ctx)).toBe(2);
+  });
+
+  it('calculates exchange base weight from batch length', () => {
+    const ctx = getRestRequestContext('POST', 'exchange', {
+      action: { type: 'order', orders: new Array(79).fill({}) },
+    });
+    expect(getRestBaseWeight(ctx)).toBe(2);
+  });
+
+  it('estimates candleSnapshot extra weight with 5000 cap', () => {
+    const intervalMs = 60_000;
+    const candles = 10_000;
+    const ctx = getRestRequestContext('POST', 'info', {
+      type: 'candleSnapshot',
+      req: { interval: '1m', startTime: 0, endTime: candles * intervalMs },
+    });
+    expect(getRestEstimatedExtraWeight(ctx)).toBe(Math.ceil(5000 / 60));
+  });
+});

--- a/apps/vendor-hyperliquid/src/api/rate-limit.test.ts
+++ b/apps/vendor-hyperliquid/src/api/rate-limit.test.ts
@@ -37,16 +37,34 @@ describe('rate-limit', () => {
     expect(getRestBaseWeight(ctx)).toBe(2);
   });
 
-  it('calculates exchange base weight from batch length', () => {
-    const ctx = getRestRequestContext('POST', 'exchange', {
-      action: { type: 'order', orders: new Array(79).fill({}) },
-    });
-    expect(getRestBaseWeight(ctx)).toBe(2);
+  it('defaults base weight for unknown info type', () => {
+    const ctx = getRestRequestContext('POST', 'info', { type: 'unknownType' });
+    expect(getRestBaseWeight(ctx)).toBe(20);
+  });
 
-    const ctxBoundary = getRestRequestContext('POST', 'exchange', {
-      action: { type: 'order', orders: new Array(80).fill({}) },
-    });
-    expect(getRestBaseWeight(ctxBoundary)).toBe(3);
+  it('assigns base weight for explorer and other requests', () => {
+    const explorerCtx = getRestRequestContext('GET', 'explorer/tx/0x', undefined);
+    expect(getRestBaseWeight(explorerCtx)).toBe(40);
+
+    const otherCtx = getRestRequestContext('GET', 'status', undefined);
+    expect(getRestBaseWeight(otherCtx)).toBe(20);
+  });
+
+  it('calculates exchange base weight across batch sizes', () => {
+    const cases = [
+      { batchLength: 0, expected: 1 },
+      { batchLength: 1, expected: 1 },
+      { batchLength: 40, expected: 2 },
+      { batchLength: 41, expected: 2 },
+      { batchLength: 80, expected: 3 },
+    ];
+
+    for (const { batchLength, expected } of cases) {
+      const ctx = getRestRequestContext('POST', 'exchange', {
+        action: { type: 'order', orders: new Array(batchLength).fill({}) },
+      });
+      expect(getRestBaseWeight(ctx)).toBe(expected);
+    }
   });
 
   it('estimates candleSnapshot extra weight with 5000 cap', () => {
@@ -57,6 +75,23 @@ describe('rate-limit', () => {
       req: { interval: '1m', startTime: 0, endTime: candles * intervalMs },
     });
     expect(getRestEstimatedExtraWeight(ctx)).toBe(Math.ceil(5000 / 60));
+  });
+
+  it('returns zero extra weight for invalid candleSnapshot inputs', () => {
+    const invalidIntervalCtx = getRestRequestContext('POST', 'info', {
+      type: 'candleSnapshot',
+      req: { interval: '2m', startTime: 0, endTime: 60_000 },
+    });
+    expect(getRestEstimatedExtraWeight(invalidIntervalCtx)).toBe(0);
+
+    const sameTimeCtx = getRestRequestContext('POST', 'info', {
+      type: 'candleSnapshot',
+      req: { interval: '1m', startTime: 0, endTime: 0 },
+    });
+    expect(getRestEstimatedExtraWeight(sameTimeCtx)).toBe(0);
+
+    const missingReqCtx = getRestRequestContext('POST', 'info', { type: 'candleSnapshot' });
+    expect(getRestEstimatedExtraWeight(missingReqCtx)).toBe(0);
   });
 
   it('consumes base and estimated weight before request', () => {
@@ -72,6 +107,29 @@ describe('rate-limit', () => {
     expect(after).toBe(before - baseWeight - estimatedExtraWeight);
   });
 
+  it('throws on invalid or excessive weights before request', () => {
+    const invalidCtx = {
+      method: 'POST',
+      path: 'exchange',
+      kind: 'exchange',
+      exchangeBatchLength: Number.NaN,
+    } as ReturnType<typeof getRestRequestContext>;
+    expect(() => beforeRestRequest({ requestKey: 'test' }, invalidCtx)).toThrow(
+      /HYPERLIQUID_REST_WEIGHT_INVALID/,
+    );
+
+    const maxWeight = 1200 * 10;
+    const excessiveCtx = {
+      method: 'POST',
+      path: 'exchange',
+      kind: 'exchange',
+      exchangeBatchLength: (maxWeight + 1) * 40,
+    } as ReturnType<typeof getRestRequestContext>;
+    expect(() => beforeRestRequest({ requestKey: 'test' }, excessiveCtx)).toThrow(
+      /HYPERLIQUID_REST_WEIGHT_EXCESSIVE/,
+    );
+  });
+
   it('applies extra weight based on response size', async () => {
     const ctx = getRestRequestContext('POST', 'info', { type: 'userFills' });
     const response = { fills: new Array(41).fill({}) };
@@ -80,6 +138,16 @@ describe('rate-limit', () => {
     await afterRestResponse({ requestKey: 'test' }, ctx, response, 0);
     const after = readBucket();
     expect(before - after).toBe(Math.ceil(41 / 20));
+  });
+
+  it('applies delta extra weight for candleSnapshot responses', async () => {
+    const ctx = getRestRequestContext('POST', 'info', { type: 'candleSnapshot' });
+    const response = new Array(120).fill({});
+
+    const before = readBucket();
+    await afterRestResponse({ requestKey: 'test' }, ctx, response, 1);
+    const after = readBucket();
+    expect(before - after).toBe(1);
   });
 
   it('skips extra acquire when response weight is within estimate', async () => {

--- a/apps/vendor-hyperliquid/src/api/rate-limit.test.ts
+++ b/apps/vendor-hyperliquid/src/api/rate-limit.test.ts
@@ -1,10 +1,35 @@
 import { tokenBucket } from '@yuants/utils';
-import { getRestBaseWeight, getRestEstimatedExtraWeight, getRestRequestContext } from './rate-limit';
+import {
+  afterRestResponse,
+  beforeRestRequest,
+  getRestBaseWeight,
+  getRestEstimatedExtraWeight,
+  getRestRequestContext,
+} from './rate-limit';
 
 describe('rate-limit', () => {
+  const bucketId = 'HYPERLIQUID_REST_IP_WEIGHT_1200_PER_MIN';
+  const readBucket = () => tokenBucket(bucketId).read();
+
   afterAll(() => {
-    const bucket = tokenBucket('HYPERLIQUID_REST_IP_WEIGHT_1200_PER_MIN');
+    const bucket = tokenBucket(bucketId);
     bucket[Symbol.dispose]();
+  });
+
+  it('parses rest request context', () => {
+    const infoCtx = getRestRequestContext('POST', 'info', { type: 'allMids' });
+    expect(infoCtx.kind).toBe('info');
+    expect(infoCtx.infoType).toBe('allMids');
+
+    const exchangeCtx = getRestRequestContext('POST', 'exchange', {
+      action: { type: 'order', orders: [{}, {}] },
+    });
+    expect(exchangeCtx.kind).toBe('exchange');
+    expect(exchangeCtx.exchangeActionType).toBe('order');
+    expect(exchangeCtx.exchangeBatchLength).toBe(2);
+
+    const explorerCtx = getRestRequestContext('GET', 'explorer/tx/0x', undefined);
+    expect(explorerCtx.kind).toBe('explorer');
   });
 
   it('calculates info base weight', () => {
@@ -17,6 +42,11 @@ describe('rate-limit', () => {
       action: { type: 'order', orders: new Array(79).fill({}) },
     });
     expect(getRestBaseWeight(ctx)).toBe(2);
+
+    const ctxBoundary = getRestRequestContext('POST', 'exchange', {
+      action: { type: 'order', orders: new Array(80).fill({}) },
+    });
+    expect(getRestBaseWeight(ctxBoundary)).toBe(3);
   });
 
   it('estimates candleSnapshot extra weight with 5000 cap', () => {
@@ -27,5 +57,38 @@ describe('rate-limit', () => {
       req: { interval: '1m', startTime: 0, endTime: candles * intervalMs },
     });
     expect(getRestEstimatedExtraWeight(ctx)).toBe(Math.ceil(5000 / 60));
+  });
+
+  it('consumes base and estimated weight before request', () => {
+    const ctx = getRestRequestContext('POST', 'info', {
+      type: 'candleSnapshot',
+      req: { interval: '1m', startTime: 0, endTime: 120 * 60_000 },
+    });
+    const before = readBucket();
+    const { baseWeight, estimatedExtraWeight } = beforeRestRequest({ requestKey: 'test' }, ctx);
+    const after = readBucket();
+    expect(baseWeight).toBe(20);
+    expect(estimatedExtraWeight).toBe(2);
+    expect(after).toBe(before - baseWeight - estimatedExtraWeight);
+  });
+
+  it('applies extra weight based on response size', async () => {
+    const ctx = getRestRequestContext('POST', 'info', { type: 'userFills' });
+    const response = { fills: new Array(41).fill({}) };
+
+    const before = readBucket();
+    await afterRestResponse({ requestKey: 'test' }, ctx, response, 0);
+    const after = readBucket();
+    expect(before - after).toBe(Math.ceil(41 / 20));
+  });
+
+  it('skips extra acquire when response weight is within estimate', async () => {
+    const ctx = getRestRequestContext('POST', 'info', { type: 'userFills' });
+    const response = { fills: [{}] };
+
+    const before = readBucket();
+    await afterRestResponse({ requestKey: 'test' }, ctx, response, 1);
+    const after = readBucket();
+    expect(after).toBe(before);
   });
 });

--- a/apps/vendor-hyperliquid/src/api/rate-limit.ts
+++ b/apps/vendor-hyperliquid/src/api/rate-limit.ts
@@ -1,0 +1,230 @@
+import { scopeError, tokenBucket } from '@yuants/utils';
+
+type HttpMethod = 'GET' | 'POST';
+
+type RestRequestContext = Readonly<{
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+  kind: 'info' | 'exchange' | 'explorer' | 'other';
+  infoType?: string;
+  exchangeActionType?: string;
+  exchangeBatchLength?: number;
+}>;
+
+type ExtraWeigher = Readonly<{
+  match: (ctx: RestRequestContext) => boolean;
+  divisor: 20 | 60;
+  estimateItems?: (ctx: RestRequestContext) => number;
+  countItemsFromResponse?: (response: unknown) => number;
+}>;
+
+const REST_IP_BUCKET_ID = 'HYPERLIQUID_REST_IP_WEIGHT_1200_PER_MIN';
+const REST_IP_BUCKET_CAPACITY = 1200;
+
+tokenBucket(REST_IP_BUCKET_ID, {
+  capacity: REST_IP_BUCKET_CAPACITY,
+  refillInterval: 60_000,
+  refillAmount: 1200,
+});
+
+const INFO_TYPE_TO_BASE_WEIGHT: Readonly<Record<string, number>> = {
+  l2Book: 2,
+  allMids: 2,
+  clearinghouseState: 2,
+  orderStatus: 2,
+  spotClearinghouseState: 2,
+  exchangeStatus: 2,
+  userRole: 60,
+};
+
+const INTERVAL_TO_MS: Readonly<Record<string, number>> = {
+  '1m': 60_000,
+  '3m': 180_000,
+  '5m': 300_000,
+  '15m': 900_000,
+  '30m': 1_800_000,
+  '1h': 3_600_000,
+  '2h': 7_200_000,
+  '4h': 14_400_000,
+  '8h': 28_800_000,
+  '12h': 43_200_000,
+  '1d': 86_400_000,
+  '3d': 259_200_000,
+  '1w': 604_800_000,
+  '1M': 2_592_000_000,
+};
+
+const getObject = (value: unknown): Record<string, unknown> | undefined => {
+  if (typeof value !== 'object' || value === null) return;
+  return value as Record<string, unknown>;
+};
+
+const getString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return;
+  return value;
+};
+
+const getNumber = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return;
+  return value;
+};
+
+const getArray = (value: unknown): unknown[] | undefined => {
+  if (!Array.isArray(value)) return;
+  return value;
+};
+
+export const getRestRequestContext = (
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): RestRequestContext => {
+  if (method === 'POST' && path === 'info') {
+    const obj = getObject(body);
+    const infoType = getString(obj?.type);
+    return { method, path, body, kind: 'info', infoType };
+  }
+  if (method === 'POST' && path === 'exchange') {
+    const obj = getObject(body);
+    const action = getObject(obj?.action);
+    const exchangeActionType = getString(action?.type);
+    const orders = getArray(action?.orders);
+    const cancels = getArray(action?.cancels);
+    const exchangeBatchLength = Math.max(1, orders?.length ?? cancels?.length ?? 1);
+    return { method, path, body, kind: 'exchange', exchangeActionType, exchangeBatchLength };
+  }
+  if (path.startsWith('explorer')) {
+    return { method, path, body, kind: 'explorer' };
+  }
+  return { method, path, body, kind: 'other' };
+};
+
+export const getRestBaseWeight = (ctx: RestRequestContext): number => {
+  if (ctx.kind === 'exchange') {
+    const batchLength = Math.max(1, ctx.exchangeBatchLength ?? 1);
+    return 1 + Math.floor(batchLength / 40);
+  }
+  if (ctx.kind === 'info') {
+    return INFO_TYPE_TO_BASE_WEIGHT[ctx.infoType ?? ''] ?? 20;
+  }
+  if (ctx.kind === 'explorer') {
+    return 40;
+  }
+  return 20;
+};
+
+const estimateCandleSnapshotItems = (ctx: RestRequestContext): number => {
+  if (ctx.kind !== 'info' || ctx.infoType !== 'candleSnapshot') return 0;
+  const bodyObj = getObject(ctx.body);
+  const reqObj = getObject(bodyObj?.req);
+  const interval = getString(reqObj?.interval);
+  const startTime = getNumber(reqObj?.startTime);
+  const endTime = getNumber(reqObj?.endTime);
+  if (!interval || startTime === undefined || endTime === undefined || endTime <= startTime) return 0;
+
+  const intervalMs = INTERVAL_TO_MS[interval] ?? 0;
+  if (!intervalMs) return 0;
+
+  // Hyperliquid docs: Only the most recent 5000 candles are available
+  const estimated = Math.ceil((endTime - startTime) / intervalMs);
+  return Math.min(5000, Math.max(0, estimated));
+};
+
+const countArrayResponseItems = (response: unknown): number => {
+  const arr = getArray(response);
+  return arr?.length ?? 0;
+};
+
+const countUserFillsItems = (response: unknown): number => {
+  const obj = getObject(response);
+  const fills = getArray(obj?.fills);
+  return fills?.length ?? 0;
+};
+
+const extraWeighers: ReadonlyArray<ExtraWeigher> = [
+  {
+    match: (ctx) => ctx.kind === 'info' && ctx.infoType === 'candleSnapshot',
+    divisor: 60,
+    estimateItems: estimateCandleSnapshotItems,
+    countItemsFromResponse: countArrayResponseItems,
+  },
+  {
+    match: (ctx) =>
+      ctx.kind === 'info' &&
+      (ctx.infoType === 'recentTrades' ||
+        ctx.infoType === 'historicalOrders' ||
+        ctx.infoType === 'userFills' ||
+        ctx.infoType === 'userFillsByTime' ||
+        ctx.infoType === 'fundingHistory' ||
+        ctx.infoType === 'userFunding' ||
+        ctx.infoType === 'nonUserFundingUpdates' ||
+        ctx.infoType === 'twapHistory' ||
+        ctx.infoType === 'userTwapSliceFills' ||
+        ctx.infoType === 'userTwapSliceFillsByTime' ||
+        ctx.infoType === 'delegatorHistory' ||
+        ctx.infoType === 'delegatorRewards' ||
+        ctx.infoType === 'validatorStats'),
+    divisor: 20,
+    countItemsFromResponse: (response) => countUserFillsItems(response) || countArrayResponseItems(response),
+  },
+];
+
+export const getRestEstimatedExtraWeight = (ctx: RestRequestContext): number => {
+  for (const weigher of extraWeighers) {
+    if (!weigher.match(ctx)) continue;
+    const items = weigher.estimateItems?.(ctx) ?? 0;
+    if (items <= 0) return 0;
+    return Math.ceil(items / weigher.divisor);
+  }
+  return 0;
+};
+
+export const acquireRestIpWeightSync = (meta: Record<string, unknown>, weight: number) => {
+  scopeError('HYPERLIQUID_API_RATE_LIMIT', { ...meta, bucketId: REST_IP_BUCKET_ID, weight }, () =>
+    tokenBucket(REST_IP_BUCKET_ID).acquireSync(weight),
+  );
+};
+
+const acquireRestIpWeight = async (meta: Record<string, unknown>, weight: number) => {
+  let remaining = Math.max(0, Math.floor(weight));
+  while (remaining > 0) {
+    const chunk = Math.min(REST_IP_BUCKET_CAPACITY, remaining);
+    await scopeError(
+      'HYPERLIQUID_API_RATE_LIMIT',
+      { ...meta, bucketId: REST_IP_BUCKET_ID, weight: chunk, remaining },
+      () => tokenBucket(REST_IP_BUCKET_ID).acquire(chunk),
+    );
+    remaining -= chunk;
+  }
+};
+
+export const beforeRestRequest = (
+  meta: Record<string, unknown>,
+  ctx: RestRequestContext,
+): Readonly<{ baseWeight: number; estimatedExtraWeight: number }> => {
+  const baseWeight = getRestBaseWeight(ctx);
+  const estimatedExtraWeight = getRestEstimatedExtraWeight(ctx);
+  acquireRestIpWeightSync(meta, baseWeight + estimatedExtraWeight);
+  return { baseWeight, estimatedExtraWeight };
+};
+
+export const afterRestResponse = async (
+  meta: Record<string, unknown>,
+  ctx: RestRequestContext,
+  response: unknown,
+  estimatedExtraWeight: number,
+) => {
+  for (const weigher of extraWeighers) {
+    if (!weigher.match(ctx)) continue;
+    const items = weigher.countItemsFromResponse?.(response) ?? 0;
+    if (items <= 0) return;
+    const actualExtraWeight = Math.ceil(items / weigher.divisor);
+    const delta = actualExtraWeight - estimatedExtraWeight;
+    if (delta > 0) {
+      // 不使用 acquireSync：响应后只阻塞等待，不报错
+      await acquireRestIpWeight(meta, delta);
+    }
+    return;
+  }
+};

--- a/common/changes/@yuants/vendor-hyperliquid/2026-01-05-06-25.json
+++ b/common/changes/@yuants/vendor-hyperliquid/2026-01-05-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-hyperliquid",
+      "comment": "add rate limit to hyperliquid based on doc",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-hyperliquid"
+}


### PR DESCRIPTION
- Added a token bucket mechanism to manage rate limits based on Hyperliquid's documentation.
- Implemented request context handling to calculate base and extra weights for different API calls.
- Integrated rate limiting checks in the API client to prevent exceeding rate limits.
- Added unit tests for rate limit calculations and request context generation.
- Updated session notes and documentation to reflect the new rate limiting features.