### PR TITLE
feat: refactor node-unit deployment failover strategy

### DIFF
--- a/.legion/tasks/node-unit-deployment-failover-rfc/context.md
+++ b/.legion/tasks/node-unit-deployment-failover-rfc/context.md
@@ -35,10 +35,13 @@
 - [Refactor] apps/node-unit/src/scheduler.ts: 实现 fetchResourceUsage，使用 terminal.client.request 替代 loadResourceUsage 从 tags 读取
 - [Test] apps/node-unit/src/scheduler.test.ts: 更新单元测试，Mock 远程 Service 调用，验证异常处理与超时逻辑
 - [Build] pnpm build 通过，TypeScript 5.9.3 兼容性检查通过
+- 按最新 plan 改为逐个从失联地址抢占：移除批量清空，候选优先失联地址，claim SQL 同时允许失联地址与未指派。
+
 
 ### 🟡 进行中
 
-(暂无)
+- 可选：运行 node-unit 测试或 E2E 以验证新抢占策略。
+
 
 ### ⚠️ 阻塞/待定
 

--- a/apps/node-unit/scripts/e2e-node-unit-failover.sh
+++ b/apps/node-unit/scripts/e2e-node-unit-failover.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-WORK_DIR="${ROOT_DIR}/.tmp/node-unit-e2e"
+NODE_UNIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_DIR="$(cd "${NODE_UNIT_DIR}/../.." && pwd)"
+WORK_DIR="${REPO_DIR}/.tmp/node-unit-e2e"
 CONTAINER_NAME="yuan-postgres-e2e"
 POSTGRES_URI="postgres://postgres:postgres@localhost:5432/yuan"
 HOST_URL="ws://localhost:8888"
@@ -60,33 +61,33 @@ fi
 
 echo "[e2e] Starting host..."
 env -i PATH="$PATH" PORT=8888 HOST_TOKEN= \
-  node "${ROOT_DIR}/apps/host/lib/cli.js" > "${WORK_DIR}/host.log" 2>&1 &
+  node "${REPO_DIR}/apps/host/lib/cli.js" > "${WORK_DIR}/host.log" 2>&1 &
 HOST_PID=$!
 
 sleep 2
 
 echo "[e2e] Starting postgres-storage..."
 env -i PATH="$PATH" HOST_URL="${HOST_URL}" POSTGRES_URI="${POSTGRES_URI}" TERMINAL_ID="postgres-storage" \
-  node "${ROOT_DIR}/apps/postgres-storage/lib/cli.js" > "${WORK_DIR}/postgres-storage.log" 2>&1 &
+  node "${REPO_DIR}/apps/postgres-storage/lib/cli.js" > "${WORK_DIR}/postgres-storage.log" 2>&1 &
 PG_STORAGE_PID=$!
 
 sleep 2
 
 echo "[e2e] Running SQL migrations..."
 env -i PATH="$PATH" HOST_URL="${HOST_URL}" TERMINAL_ID="sql-migration" \
-  node "${ROOT_DIR}/tools/sql-migration/lib/cli.js"
+  node "${REPO_DIR}/tools/sql-migration/lib/cli.js"
 
 sleep 2
 
 echo "[e2e] Starting node-unit instances..."
 env -i PATH="$PATH" HOST_URL="${HOST_URL}" NODE_UNIT_NAME="node-unit-1" NODE_UNIT_PASSWORD="node-unit-1" POSTGRES_URI="" \
   NODE_UNIT_CLAIM_POLICY="${CLAIM_POLICY}" NODE_UNIT_CPU_WEIGHT="${CPU_WEIGHT}" NODE_UNIT_MEMORY_WEIGHT="${MEMORY_WEIGHT}" \
-  node "${ROOT_DIR}/apps/node-unit/lib/cli.js" > "${WORK_DIR}/node-unit-1.log" 2>&1 &
+  node "${NODE_UNIT_DIR}/lib/cli.js" > "${WORK_DIR}/node-unit-1.log" 2>&1 &
 NODE_UNIT_1_PID=$!
 
 env -i PATH="$PATH" HOST_URL="${HOST_URL}" NODE_UNIT_NAME="node-unit-2" NODE_UNIT_PASSWORD="node-unit-2" POSTGRES_URI="" \
   NODE_UNIT_CLAIM_POLICY="${CLAIM_POLICY}" NODE_UNIT_CPU_WEIGHT="${CPU_WEIGHT}" NODE_UNIT_MEMORY_WEIGHT="${MEMORY_WEIGHT}" \
-  node "${ROOT_DIR}/apps/node-unit/lib/cli.js" > "${WORK_DIR}/node-unit-2.log" 2>&1 &
+  node "${NODE_UNIT_DIR}/lib/cli.js" > "${WORK_DIR}/node-unit-2.log" 2>&1 &
 NODE_UNIT_2_PID=$!
 
 sleep 6

--- a/apps/node-unit/src/index.ts
+++ b/apps/node-unit/src/index.ts
@@ -28,6 +28,7 @@ import {
   firstValueFrom,
   fromEvent,
   interval,
+  timer,
   map,
   merge,
   mergeMap,
@@ -135,7 +136,7 @@ const startResourceCollector = (intervalMs: number) => {
   let lastAt = Date.now();
   const cores = Math.max(cpus().length, 1);
 
-  interval(intervalMs)
+  timer(0, intervalMs)
     .pipe(
       takeUntil(kill$), // Use kill$ instead of terminal.dispose$ as it's global now
       concatMap(() =>
@@ -167,6 +168,15 @@ const startResourceCollector = (intervalMs: number) => {
             cpuPercent: totalCpuPercent,
             memoryMb: totalMemoryMb,
           };
+          console.info(formatTime(Date.now()), 'ResourceCollectorUpdate', {
+            mainCpuPercent,
+            childCpuPercent,
+            cores,
+            totalCpuPercent,
+            mainMemoryMb,
+            childMemoryMb,
+            totalMemoryMb,
+          });
         }),
       ),
       catchError((err) => {
@@ -356,6 +366,7 @@ defer(async () => {
   startDeploymentScheduler(terminal, nodeKeyPair.public_key);
 
   terminal.server.provideService('NodeUnit/InspectResourceUsage', {}, async () => {
+    console.info(formatTime(Date.now()), 'NodeUnit/InspectResourceUsage', currentResourceUsage);
     return {
       res: {
         code: 0,

--- a/common/changes/@yuants/node-unit/2026-01-23-16-11.json
+++ b/common/changes/@yuants/node-unit/2026-01-23-16-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/node-unit",
+      "comment": "refine and bugfix",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/node-unit"
+}


### PR DESCRIPTION
- Updated the deployment failover strategy to prioritize claiming from lost addresses one at a time, instead of batch clearing.
- Enhanced the resource usage fetching mechanism to utilize requestForResponse for better error handling and logging.
- Modified the candidate selection logic to prefer lost addresses when available, falling back to unassigned deployments if necessary.
- Improved logging throughout the resource collection and scheduling processes for better traceability.
- Adjusted unit tests to reflect changes in the claiming and candidate selection logic, ensuring robust coverage for new behaviors.