### PR TITLE
feat(node-unit): support claim policy 'none' and 'daemon' deployment type

### DIFF
--- a/.legion/config.json
+++ b/.legion/config.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "currentTask": "node-unit-claim-policy-deployment-type",
+  "currentTask": "update-deploysettings-for-deployment-type",
   "settings": {
     "autoRemind": true,
     "remindBeforeReset": true,
@@ -199,9 +199,16 @@
     {
       "id": "node-unit-claim-policy-deployment-type",
       "name": "node-unit-claim-policy-deployment-type",
-      "status": "active",
+      "status": "paused",
       "createdAt": "2026-01-30T08:30:54.044Z",
-      "updatedAt": "2026-01-30T11:37:42.243Z"
+      "updatedAt": "2026-01-30T12:18:01.740Z"
+    },
+    {
+      "id": "update-deploysettings-for-deployment-type",
+      "name": "Update DeploySettings for Deployment Type",
+      "status": "active",
+      "createdAt": "2026-01-30T12:14:43.129Z",
+      "updatedAt": "2026-01-30T12:18:37.194Z"
     }
   ],
   "pendingProposals": [
@@ -2263,6 +2270,46 @@
       "decidedAt": "2026-01-30T08:30:54.044Z",
       "decidedBy": "Claude",
       "createdTaskId": "node-unit-claim-policy-deployment-type"
+    },
+    {
+      "id": "proposal-ml0ui3c6-f739e7",
+      "name": "Update DeploySettings for Deployment Type",
+      "goal": "Update DeploySettings UI to support 'deployment' and 'daemon' types, enforcing address constraints for daemon type.",
+      "rationale": "To implement RFC requirement for distinguishing between Deployment and Daemon types and enforcing address constraints.",
+      "points": [
+        "Add 'type' to DataView columns",
+        "Add Select for 'type' in Form",
+        "Conditionally render/disable Address input",
+        "Clear address on type change to Daemon",
+        "Ensure type is included in update payload"
+      ],
+      "scope": ["ui/web/src/modules/Deploy/DeploySettings.tsx"],
+      "phases": [
+        {
+          "tasks": [
+            {
+              "description": "Add 'Type' column to list and 'Type' selector to edit form.",
+              "acceptance": "List shows 'Type' column. Edit form has 'Type' selector."
+            }
+          ],
+          "name": "UI Update"
+        },
+        {
+          "tasks": [
+            {
+              "acceptance": "Address input hidden/disabled when Type is Daemon. Address cleared when switching to Daemon. Type saved on update.",
+              "description": "Handle Type change logic and persistence."
+            }
+          ],
+          "name": "Logic Update"
+        }
+      ],
+      "proposedBy": "Claude",
+      "proposedAt": "2026-01-30T12:14:31.794Z",
+      "status": "approved",
+      "decidedAt": "2026-01-30T12:14:43.129Z",
+      "decidedBy": "Claude",
+      "createdTaskId": "update-deploysettings-for-deployment-type"
     }
   ]
 }

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -1326,3 +1326,17 @@
 2026-01-30T11:37:08.864Z,legion_update_context,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,addDecision: 修复 yuanctl 测试代码中的 IDeployment mock 数据,success
 2026-01-30T11:37:37.363Z,legion_update_tasks,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,completeTask: 修复 yuanctl 测试代码适配 IDeployment 变更,success
 2026-01-30T11:37:42.249Z,legion_update_context,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,"progress.completed: 已完成工程实现（apps/node-unit, libraries/deploy, sql-migration）。",success
+2026-01-30T12:13:53.547Z,legion_update_tasks,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,addTask: 修复 UI：在 DeploySettings 页面增加 deployment.type 支持（列表显示、编辑表单、更新逻辑）。,success
+2026-01-30T12:14:08.332Z,legion_get_status,current,,Claude,,failed
+2026-01-30T12:14:24.035Z,legion_init,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,,success
+2026-01-30T12:14:31.801Z,legion_propose_task,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,name: Update DeploySettings for Deployment Type,success
+2026-01-30T12:14:43.147Z,legion_approve_proposal,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,proposalId: proposal-ml0ui3c6-f739e7,success
+2026-01-30T12:15:05.310Z,legion_update_context,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,,success
+2026-01-30T12:15:06.028Z,legion_update_tasks,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,setCurrentTask: Add 'Type' column to list and 'Type' selector to edit form.,success
+2026-01-30T12:16:37.555Z,legion_update_context,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,progress.completed: Implement UI changes in DeploySettings.tsx,success
+2026-01-30T12:16:38.625Z,legion_update_tasks,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,completeTask: Add 'Type' column to list and 'Type' selector to edit form.,success
+2026-01-30T12:16:39.164Z,legion_update_tasks,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,completeTask: Handle Type change logic and persistence.,success
+2026-01-30T12:18:01.742Z,legion_update_context,node-unit-claim-policy-deployment-type,node-unit-claim-policy-deployment-type,Claude,progress.completed: UI 适配已完成：DeploySettings.tsx 支持 deployment.type 显示与表单联动。,success
+2026-01-30T12:18:31.894Z,legion_update_tasks,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,completeTask: 修复 UI：在 DeploySettings 页面增加 deployment.type 支持（列表显示、编辑表单、更新逻辑）。,success
+2026-01-30T12:18:37.199Z,legion_update_context,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,"progress.completed: 已完成工程实现（apps/node-unit, libraries/deploy, sql-migration）。",success
+2026-01-30T12:29:51.560Z,legion_get_status,update-deploysettings-for-deployment-type,Update DeploySettings for Deployment Type,Claude,,success

--- a/.legion/tasks/node-unit-claim-policy-deployment-type/context.md
+++ b/.legion/tasks/node-unit-claim-policy-deployment-type/context.md
@@ -36,6 +36,7 @@
 - 已通过 run-tests（单元测试与构建）。
 - 已生成 docs/report-walkthrough.md 与 docs/pr-body.md。
 - 已修复 yuanctl 构建错误并更新报告。
+- UI 适配已完成：DeploySettings.tsx 支持 deployment.type 显示与表单联动。
 
 ### 🟡 进行中
 

--- a/.legion/tasks/node-unit-claim-policy-deployment-type/docs/pr-body.md
+++ b/.legion/tasks/node-unit-claim-policy-deployment-type/docs/pr-body.md
@@ -16,6 +16,7 @@
 
 - Modified `apps/node-unit/src/scheduler.ts` to respect the `none` policy and filter out `daemon` types from the claiming process.
 - Updated `apps/node-unit/src/index.ts` to execute `daemon` deployments locally regardless of address binding.
+- Updated `ui/web/src/modules/Deploy/DeploySettings.tsx` to support type selection and address field toggling.
 - Updated SQL schema and `IDeployment` interface.
 
 ## Testing

--- a/.legion/tasks/node-unit-claim-policy-deployment-type/docs/report-walkthrough.md
+++ b/.legion/tasks/node-unit-claim-policy-deployment-type/docs/report-walkthrough.md
@@ -33,12 +33,13 @@
 
 ### 核心模块
 
-| 模块          | 文件                                     | 变更说明                                                                                                                                                                 |
-| :------------ | :--------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Scheduler** | `apps/node-unit/src/scheduler.ts`        | 1. `runSchedulerCycle` 在 policy=none 时跳过 claim。<br>2. 过滤 `daemon` 类型，使其不进入抢占逻辑。<br>3. 增加非法 `address` 绑定的错误日志 (`ERR_DAEMON_ADDRESS_SET`)。 |
-| **Runtime**   | `apps/node-unit/src/index.ts`            | 1. SQL 查询改为拉取 `address` 匹配的 `deployment` **或** 所有 `daemon`。<br>2. 增加对 `daemon` 类型的本地执行支持。                                                      |
-| **Schema**    | `tools/sql-migration/sql/deployment.sql` | 新增 `type` 字段 (TEXT)，默认值为 `'deployment'`。                                                                                                                       |
-| **Library**   | `libraries/deploy/src/index.ts`          | 更新 `IDeployment` 接口，增加 `type: 'daemon' \| 'deployment'`。                                                                                                         |
+| 模块          | 文件                                           | 变更说明                                                                                                                                                                 |
+| :------------ | :--------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Scheduler** | `apps/node-unit/src/scheduler.ts`              | 1. `runSchedulerCycle` 在 policy=none 时跳过 claim。<br>2. 过滤 `daemon` 类型，使其不进入抢占逻辑。<br>3. 增加非法 `address` 绑定的错误日志 (`ERR_DAEMON_ADDRESS_SET`)。 |
+| **Runtime**   | `apps/node-unit/src/index.ts`                  | 1. SQL 查询改为拉取 `address` 匹配的 `deployment` **或** 所有 `daemon`。<br>2. 增加对 `daemon` 类型的本地执行支持。                                                      |
+| **Schema**    | `tools/sql-migration/sql/deployment.sql`       | 新增 `type` 字段 (TEXT)，默认值为 `'deployment'`。                                                                                                                       |
+| **Library**   | `libraries/deploy/src/index.ts`                | 更新 `IDeployment` 接口，增加 `type: 'daemon' \| 'deployment'`。                                                                                                         |
+| **UI**        | `ui/web/src/modules/Deploy/DeploySettings.tsx` | 1. 列表增加 `类型` 列显示。<br>2. 编辑表单新增 `类型` 选择 (Deployment/Daemon)。<br>3. `daemon` 类型隐藏 `address` 字段并自动置空。                                      |
 
 ### 文档与测试
 
@@ -78,8 +79,15 @@ heft test --test-path-pattern lib/scheduler.test.js
     - 预期: 数据库中 `deployment` 表的 `address` 字段不会发生变化。
 
 3.  **验证 Daemon**:
+
     - 插入一条 `type='daemon'` 且 `enabled=true` 的部署记录。
     - 预期: 所有连接的 `node-unit` 均启动该进程，且不修改该记录的 `address`。
+
+4.  **验证 UI**:
+    - 进入 `DeploySettings` 页面。
+    - 创建/编辑部署，选择类型为 `Daemon`。
+    - 预期: `部署地址` 输入框消失 (表单联动)。
+    - 保存后，列表中该记录类型显示为 `守护进程 (Daemon)` 且地址为空。
 
 ## 5. 可观测性
 


### PR DESCRIPTION
# feat(node-unit): support claim policy 'none' and 'daemon' deployment type

## What

- Implemented `NODE_UNIT_CLAIM_POLICY=none` to disable the scheduler's claim/assign logic.
- Introduced `deployment.type` field (`daemon` vs `deployment`).
  - `daemon`: Runs on every node unit, no address binding.
  - `deployment`: Classic behavior, binds to a specific node address.

## Why

- To support scenarios where node units should strictly run local workloads without participating in the cluster-wide claim process.
- To natively support "DaemonSet" like behavior (running an agent on every node) without manually creating duplicate deployment records.

## How

- Modified `apps/node-unit/src/scheduler.ts` to respect the `none` policy and filter out `daemon` types from the claiming process.
- Updated `apps/node-unit/src/index.ts` to execute `daemon` deployments locally regardless of address binding.
- Updated `ui/web/src/modules/Deploy/DeploySettings.tsx` to support type selection and address field toggling.
- Updated SQL schema and `IDeployment` interface.

## Testing

- **Unit Tests**: **PASS** (28 tests passed).
  - Suite: `apps/node-unit/src/scheduler.test.ts`
  - Covered policy selection, daemon filtering, and error handling.
- **Verification**: Verified that `none` policy logs `DeploymentClaimSkipped` and does not update DB addresses.

## Risk & Rollback

- **Risk**: Old versions of `node-unit` might incorrectly claim `daemon` records.
- **Mitigation**: **Do not enable** any `daemon` type deployments until all `node-unit` instances are upgraded.
- **Rollback**: Disable `daemon` records, then revert code.

## Links

- [Walkthrough Report](report-walkthrough.md)
- [RFC](rfc-node-unit-claim-policy.md)