### PR TITLE
feat(http-services): add target host/path proxy metrics

### DIFF
--- a/.legion/config.json
+++ b/.legion/config.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "currentTask": "vendor-http-services-rollout",
+  "currentTask": "http-proxy-app-implementation",
   "settings": {
     "autoRemind": true,
     "remindBeforeReset": true,
@@ -187,14 +187,14 @@
       "name": "HTTP Proxy App Implementation",
       "status": "active",
       "createdAt": "2026-01-28T07:31:21.903Z",
-      "updatedAt": "2026-01-28T13:51:33.032Z"
+      "updatedAt": "2026-02-04T08:00:32.749Z"
     },
     {
       "id": "vendor-http-services-rollout",
       "name": "vendor-http-services-rollout",
-      "status": "active",
+      "status": "paused",
       "createdAt": "2026-01-29T15:48:30.598Z",
-      "updatedAt": "2026-02-03T07:26:20.599Z"
+      "updatedAt": "2026-02-03T08:20:23.290Z"
     },
     {
       "id": "node-unit-claim-policy-deployment-type",
@@ -2457,6 +2457,85 @@
       "decidedAt": "2026-01-31T14:01:51.517Z",
       "decidedBy": "Claude",
       "createdTaskId": "refactor-grafana-dashboard-for-iphostname"
+    },
+    {
+      "id": "proposal-ml6btrka-470786",
+      "name": "http-proxy-metrics",
+      "goal": "为 HTTP Proxy 服务增加按目标域名统计的 Prometheus 指标，并给出可复现的设计与验证方案。",
+      "rationale": "用户要求在 http-proxy-metrics 中新增“目标域名”流量统计，需要在 http-services 侧明确指标口径、标签与性能/安全边界，并产出可评审设计。",
+      "points": [
+        "在 http-services 侧定义目标域名统计的指标口径（host/domain 标签、粒度与去敏）",
+        "明确指标与现有 http_proxy_requests_total/request_duration/errors/active 的关系与兼容性",
+        "约束高基数风险（host/domain 白名单、归一化策略或 top-N 方案）",
+        "补充测试/验证方案（最小单测或集成验证）",
+        "设计文档输出到 .legion/tasks/<id>/docs/rfc.md 并建立评审闭环"
+      ],
+      "scope": [
+        "libraries/http-services/src/server.ts",
+        "libraries/http-services/src/types.ts",
+        "libraries/http-services/src/__tests__/server.test.ts",
+        "apps/http-proxy/src/index.ts",
+        ".legion/tasks/http-proxy-metrics/docs/**"
+      ],
+      "phases": [
+        {
+          "name": "调查",
+          "tasks": [
+            {
+              "description": "盘点现有 http-services HTTPProxy 指标与标签结构，明确可复用字段与风险点。",
+              "acceptance": "列出当前指标/标签与可用上下文（如 URL/host/labels）并标注风险。"
+            }
+          ]
+        },
+        {
+          "name": "设计",
+          "tasks": [
+            {
+              "description": "设计新增目标域名统计指标（名称、标签、基数策略、脱敏/归一化），并给出数据采集位置与兼容性说明。",
+              "acceptance": "RFC 明确指标定义、标签策略、采集点、兼容性与回滚策略。"
+            }
+          ]
+        },
+        {
+          "name": "实现",
+          "tasks": [
+            {
+              "description": "在 http-services HTTPProxy 处理链路中落地指标采集与标签填充，必要时扩展类型。",
+              "acceptance": "指标可被注册并在请求路径中更新；不影响现有错误语义。"
+            }
+          ]
+        },
+        {
+          "name": "验证",
+          "tasks": [
+            {
+              "description": "更新或新增最小测试/验证步骤，覆盖成功与错误路径的指标更新。",
+              "acceptance": "测试或手工验证说明能证明目标域名指标可用且基数受控。"
+            }
+          ]
+        },
+        {
+          "name": "Review",
+          "tasks": [
+            {
+              "description": "进行 review-code 与 review-security，并在任务目录生成报告。",
+              "acceptance": "review 报告产出且无 blocking。"
+            }
+          ]
+        },
+        {
+          "name": "报告",
+          "tasks": [
+            {
+              "description": "生成 walkthrough 报告与 PR body 建议。",
+              "acceptance": "report-walkthrough.md 与 pr-body.md 完成。"
+            }
+          ]
+        }
+      ],
+      "proposedBy": "Claude",
+      "proposedAt": "2026-02-03T08:18:20.748Z",
+      "status": "pending"
     }
   ]
 }

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -1507,3 +1507,236 @@
 2026-02-03T07:26:10.309Z,legion_update_context,vendor-http-services-rollout,vendor-http-services-rollout,Claude,addFile: /Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md,success
 2026-02-03T07:26:20.609Z,legion_update_context,vendor-http-services-rollout,vendor-http-services-rollout,Claude,addFile: /Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/pr-body-fix.md,success
 2026-02-03T07:35:26.081Z,legion_get_status,vendor-http-services-rollout,vendor-http-services-rollout,Claude,,success
+2026-02-03T08:17:19.770Z,legion_get_status,vendor-http-services-rollout,vendor-http-services-rollout,Claude,,success
+2026-02-03T08:17:26.198Z,legion_read_context,vendor-http-services-rollout,vendor-http-services-rollout,Claude,"section: all, includeReviews: true",success
+2026-02-03T08:17:37.679Z,legion_list_tasks,vendor-http-services-rollout,vendor-http-services-rollout,Claude,,success
+2026-02-03T08:17:43.908Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T08:18:20.756Z,legion_propose_task,vendor-http-services-rollout,vendor-http-services-rollout,Claude,name: http-proxy-metrics,success
+2026-02-03T08:20:00.485Z,legion_switch_task,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,taskId: http-proxy-app-implementation,success
+2026-02-03T08:20:00.486Z,legion_update_tasks,vendor-http-services-rollout,vendor-http-services-rollout,Claude,addDiscoveredTask: http-proxy-metrics 设计与 RFC 输出,success
+2026-02-03T08:20:00.487Z,legion_update_context,vendor-http-services-rollout,vendor-http-services-rollout,Claude,,success
+2026-02-03T08:20:06.888Z,legion_update_plan,vendor-http-services-rollout,vendor-http-services-rollout,Claude,,success
+2026-02-03T08:20:18.300Z,legion_get_status,vendor-http-services-rollout,vendor-http-services-rollout,Claude,,success
+2026-02-03T08:20:23.294Z,legion_switch_task,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,taskId: http-proxy-app-implementation,success
+2026-02-03T08:22:20.150Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T08:22:23.818Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T08:23:47.497Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addFile: .legion/tasks/http-proxy-app-implementation/docs/review-rfc-metrics.md,success
+2026-02-03T08:23:50.958Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 URL 解析来源优先级与失败边界（绝对 URL vs Host 头拼接）,success
+2026-02-03T08:23:58.002Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：定义 allowedHosts 匹配语义（精确/通配/大小写/尾点/IDN）,success
+2026-02-03T08:23:58.022Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：细化回滚策略（指标定义是否保留）,success
+2026-02-03T08:23:58.023Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：为 allowedHosts 规模设置上限或溢出归并策略以控制基数,success
+2026-02-03T08:23:58.023Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 allowedHosts 为空时的策略（必须配置或显式启用替代方案）,success
+2026-02-03T08:23:58.023Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补齐 result 映射闭合规则与典型错误示例,success
+2026-02-03T08:24:38.663Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 目标域名指标默认仅在配置 allowedHosts 且显式启用时生效，避免破坏既有调用方与高基数风险。,success
+2026-02-03T08:24:47.062Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T08:24:51.154Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T08:26:59.698Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T08:27:01.923Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T08:52:29.000Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: RFC 需修正 IP 字面量与 allowedHosts 命中规则冲突，明确绝对 URL 与 Host 头冲突处理。,success
+2026-02-03T08:52:29.015Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：消除 IP 字面量与 allowedHosts 命中规则冲突,success
+2026-02-03T08:52:29.036Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确绝对 URL 与 Host 头冲突处理规则,success
+2026-02-03T08:52:38.506Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T08:52:41.736Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T08:55:26.170Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:31:53.018Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:31:55.769Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T09:34:33.305Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:34:35.805Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T09:37:36.741Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:37:41.127Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T09:39:37.508Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:39:41.444Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T09:47:24.671Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:51:14.916Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:53:27.034Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：限定指标覆盖条件、定义“无需写回”或移除、对齐 CONNECT/star-form 处理与现有行为。,success
+2026-02-03T09:53:27.158Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：定义“无需写回”或移除该语义并统一写回判定,success
+2026-02-03T09:53:27.158Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：限定指标覆盖要求的前置条件（仅指标已注册时适用）,success
+2026-02-03T09:53:27.163Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：对齐 CONNECT/star-form 处理与现有实现并补充测试断言,success
+2026-02-03T09:53:38.714Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:55:08.674Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: rfc-metrics 统一写回语义：仅当写回成功可标记 ok/blocked/invalid_url/timeout；写回尝试失败或未写回成功统一 result=error,success
+2026-02-03T09:55:13.167Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: CONNECT/authority-form 与 star-form 明确在 URL 解析阶段判定 invalid_url，不支持该形式,success
+2026-02-03T09:55:27.056Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T09:55:29.235Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T09:58:56.347Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"addConstraint: 修订 RFC：定义 raw_url 以 ""//"" 开头与非 origin-form 处理规则；明确写回成功判定；限定 allowedHosts 仅 ASCII/punycode。",success
+2026-02-03T09:58:56.359Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"addDiscoveredTask: RFC metrics：定义 raw_url 以 ""//"" 开头的处理规则",success
+2026-02-03T09:58:56.360Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"addDiscoveredTask: RFC metrics：限定 host_header 拼接仅支持 origin-form（raw_url 以 ""/"" 开头）",success
+2026-02-03T09:58:56.370Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 allowedHosts 仅接受 ASCII/punycode,success
+2026-02-03T09:58:56.371Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确写回成功判定以保证 result 可验证,success
+2026-02-03T09:59:05.113Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:01:45.257Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:01:48.044Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:36:51.668Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:36:54.412Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:41:00.489Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:41:03.208Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:44:13.532Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：明确 absolute-form 非 ASCII/IDN 处理；定义 ip_literal 识别算法（含 IPv6 zone/IPvFuture）；要求 absolute-form 仅接受 scheme://。,success
+2026-02-03T10:44:13.625Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 absolute-form 非 ASCII/IDN 处理规则并补测试,success
+2026-02-03T10:44:13.674Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：定义 ip_literal 识别算法（含 IPv6 zone/IPvFuture）,success
+2026-02-03T10:44:13.758Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：要求 absolute-form 严格 scheme:// 并补测试,success
+2026-02-03T10:44:26.356Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:44:28.726Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:47:31.319Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:47:33.901Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:50:32.176Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: RFC metrics 复审完成（结论 NEEDS_CHANGES）；关键争议：Host 头大小写匹配、ip_literal 识别过宽、scheme 支持范围不清；建议：收敛校验规则并补充测试。,success
+2026-02-03T10:50:32.301Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics 修订：收紧 ip_literal 识别（避免含 % 的无效域名被误判 blocked）,success
+2026-02-03T10:50:32.301Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics 修订：明确绝对 URL 支持的 scheme 范围与非支持 scheme 的 result 映射,success
+2026-02-03T10:50:32.302Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics 修订：Host 头匹配需大小写不敏感或先小写化,success
+2026-02-03T10:51:20.397Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：host_header 小写化/大小写不敏感；ip_literal 识别收敛；限定支持的 URL scheme 列表。,success
+2026-02-03T10:51:20.497Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：host_header 大小写与尾点规则（先小写化再校验）,success
+2026-02-03T10:51:20.498Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：限定允许的绝对 URL scheme 列表（http/https）,success
+2026-02-03T10:51:20.498Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：收敛 ip_literal 识别规则，避免 '%' 误判,success
+2026-02-03T10:51:28.787Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:51:31.406Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:55:17.463Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:55:19.648Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T10:59:12.089Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T10:59:14.914Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T11:00:44.337Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: allowedHosts 仅允许 hostname，不允许端口；匹配只基于 hostname,success
+2026-02-03T11:00:44.373Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: host_header 解析先剥离端口，再去尾点，再校验 hostname（允许 example.com.:443）,success
+2026-02-03T11:00:44.375Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: ip_literal 仅以 net.isIP(hostname) 判定；含 ':' 或 '%' 但 net.isIP=0 视为 invalid_url,success
+2026-02-03T11:01:07.477Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T11:01:09.818Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T13:20:45.262Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：定义 host_header 端口语法/范围；明确 allowedHosts 匹配忽略端口；澄清 allowedHosts 为空 fail-fast 是否为既有基线。,success
+2026-02-03T13:20:45.277Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：定义 host_header 端口语法/范围并补示例与测试,success
+2026-02-03T13:20:45.278Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：澄清 allowedHosts 空值 fail-fast 基线/兼容性定位,success
+2026-02-03T13:20:45.279Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 allowedHosts 匹配忽略端口并补规范/测试,success
+2026-02-03T13:20:54.243Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:20:57.882Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T13:22:59.131Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:23:01.294Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T13:26:17.032Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：端口不存在允许；scheme 白名单固定 http/https；明确 ASCII 校验先于小写化。,success
+2026-02-03T13:26:17.149Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 host_header ASCII 校验顺序,success
+2026-02-03T13:26:17.150Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：修复 R14 端口规则冲突（端口不存在允许）,success
+2026-02-03T13:26:17.151Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：删除 scheme 额外配置假设或定义配置项,success
+2026-02-03T13:26:24.669Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:28:32.290Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:28:34.508Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T13:31:40.262Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: RFC metrics 复审完成（结论 NEEDS_CHANGES），关键争议：非 ASCII hostname 可验证性、host_header IPv6/percent 边界、allowedHosts 空白名单基线证据。,success
+2026-02-03T13:31:45.405Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补齐非 ASCII hostname 处理（明确 raw_url 级 ASCII 校验或允许 punycode）并同步示例/测试,success
+2026-02-03T13:31:48.490Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 host_header IPv6/percent/zone/IPvFuture 的拒绝规则并统一与 absolute-form,success
+2026-02-03T13:31:52.248Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补充 allowedHosts 为空 fail-fast 的现状证据或改为新行为并完善兼容/rollout,success
+2026-02-03T13:32:39.202Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：明确非 ASCII hostname 处理方式（解析前校验或接受 punycode）；收紧 host_header IPv6 规则；澄清 allowedHosts fail-fast 是否为基线。,success
+2026-02-03T13:32:39.240Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确非 ASCII hostname 处理（解析前校验或接受 punycode）,success
+2026-02-03T13:32:39.240Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：澄清 allowedHosts 为空 fail-fast 的基线/兼容性,success
+2026-02-03T13:32:39.241Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：收紧 host_header IPv6 规则（拒绝 zone/IPvFuture/%）,success
+2026-02-03T13:32:57.937Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:36:58.351Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:37:02.556Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T13:40:07.622Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: RFC metrics 复审结论为 NEEDS_CHANGES,success
+2026-02-03T13:40:11.714Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics 修订：明确 R10/R12 校验作用域或合并校验路径；补齐 ldh_hostname 长度边界或改为 URL 解析判定；澄清 allowedHosts fail-fast 与 metrics_enabled 的关系并更新兼容/rollout。,success
+2026-02-03T13:40:42.338Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:45:08.232Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:47:42.594Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,handoff: 修订 rfc-metrics.md：明确 host_header 预处理顺序与 URL 构造字符串，消除 R12/R14 歧义。,success
+2026-02-03T13:47:45.875Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics 对抗复审完成（结论 NEEDS_CHANGES，输出 review-rfc-metrics.md）,success
+2026-02-03T13:47:51.439Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 host_header 预处理顺序与 URL 构造字符串，消除 R12/R14 歧义,success
+2026-02-03T13:47:51.453Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补齐 allowedHosts fail-fast 既有基线证据或加入兼容/迁移与回滚说明,success
+2026-02-03T13:47:51.453Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：声明指标解析必须复用现有 SSRF/请求解析结果或引用同一解析函数，避免解析分歧,success
+2026-02-03T13:49:33.775Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:55:54.565Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T13:55:56.636Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T14:02:22.609Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T14:02:24.849Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T14:05:20.927Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T14:08:04.645Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 完成 RFC metrics 对抗复审（结论 NEEDS_CHANGES）。,success
+2026-02-03T14:08:11.123Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 写入 review-rfc-metrics.md（输出对抗复审报告）,success
+2026-02-03T14:08:11.164Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 allowedHosts 缺失/非法/超限时的启动行为仅复用既有逻辑，指标注册随配置有效性变化,success
+2026-02-03T14:08:11.164Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：对齐 absolute-form-only 与现有请求解析行为（必要时删除/调整 R5）,success
+2026-02-03T14:08:11.164Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 IP 字面量判定来源（复用 parse_result 或现有 SSRF 判定函数）并补测试,success
+2026-02-03T14:16:47.575Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：用现有 schema 证明 absolute-form-only；明确 allowedHosts 启动行为复用既有逻辑；IP 判定复用 parsed_url + net.isIP。,success
+2026-02-03T14:16:47.742Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：澄清 allowedHosts 启动行为复用既有逻辑,success
+2026-02-03T14:16:47.743Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补充 absolute-form-only 的现有证据/引用并新增验证用例,success
+2026-02-03T14:16:47.744Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 IP 判定复用 parsed_url + net.isIP，并补用例,success
+2026-02-03T14:17:04.722Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T14:19:59.962Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: RFC metrics 修订：引用 `libraries/http-services/src/server.ts` schema 的 `url` format: uri 作为 absolute-form-only 证据；allowedHosts 启动行为完全复用既有逻辑且仅影响指标注册；IP 字面量判定使用同一 par,success
+2026-02-03T14:20:50.698Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T14:20:58.158Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T14:23:20.123Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 当前环境无 Write/Edit 工具权限，无法写入 review-rfc-metrics.md；需开放写入权限或由人工落盘。,success
+2026-02-03T14:23:23.681Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补充 absolute-form-only 现有行为证据或改为以 parse_result 判定为准,success
+2026-02-03T14:23:28.106Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 parse_result 的生产位置/字段与指标复用方式，避免重解析,success
+2026-02-03T14:23:31.143Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：固定 allowedHosts 缺失/非法时启动语义，并明确与 metrics_enabled 的关系与验证用例,success
+2026-02-03T14:24:30.744Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: 修订 RFC：给出 absolute-form-only 现有证据；明确 parse_result 来源；固定 allowedHosts 启动语义与 metrics_enabled 关系。,success
+2026-02-03T14:24:30.845Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：补充 absolute-form-only 证据并新增验证用例,success
+2026-02-03T14:24:30.846Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 parse_result 来源/字段与复用位置,success
+2026-02-03T14:24:30.913Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：固定 allowedHosts 启动语义与 metrics_enabled 关系,success
+2026-02-03T14:24:44.867Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T14:27:14.906Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T14:28:45.242Z,legion_update_tasks,,,Claude,addDiscoveredTask: RFC metrics：定义 allowedHosts 合法性与上限（或引用既有校验实现），补可验证用例,success
+2026-02-03T14:28:45.243Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：明确 writeback_success/writeback_failure 的可观察性与优先级，保证可测试,success
+2026-02-03T14:28:45.243Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：修正 parse_result 字段命名一致性并明确 scheme 范围（http/https 或 invalid_url）,success
+2026-02-03T14:28:45.243Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: RFC metrics：对齐 allowedHosts 缺失/非法时启动语义与实际实现，并补兼容/回滚说明,success
+2026-02-03T14:28:45.244Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addFile: .legion/tasks/http-proxy-app-implementation/docs/review-rfc-metrics.md,success
+2026-02-03T14:29:34.071Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T16:35:08.680Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T16:37:17.181Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T16:37:21.149Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T16:41:04.649Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T16:41:08.846Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-03T16:44:33.531Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-03T16:48:25.599Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:31:31.135Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:32:11.494Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 设计审批通过（用户确认）- HTTP Proxy 目标域名指标 RFC,success
+2026-02-04T03:32:18.633Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 设计审批通过（用户确认）- HTTP Proxy 目标域名指标 RFC,success
+2026-02-04T03:32:23.101Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 进入实现阶段（HTTP Proxy 目标域名指标）,success
+2026-02-04T03:32:34.798Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:32:37.445Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-04T03:37:30.480Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:37:32.839Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-04T03:41:59.710Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: target_host 指标仅在 allowedHosts 非空时注册，allowedHosts 含端口仅告警且不参与匹配；result 映射复用 error.code 等价信号,success
+2026-02-04T03:41:59.712Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addFile: libraries/http-services/src/__tests__/server.test.ts,success
+2026-02-04T03:41:59.714Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addTask: 实现 target_host 指标采集与 result 映射,success
+2026-02-04T03:41:59.720Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addTask: 新增 target_host 指标最小单测覆盖,success
+2026-02-04T03:41:59.739Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 实现 target_host 指标采集与 result 映射,success
+2026-02-04T03:41:59.754Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 新增 target_host 指标最小单测覆盖,success
+2026-02-04T03:42:31.934Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:42:32.539Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:44:40.491Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 测试失败判定为 impl-dev 问题（实现未将 INVALID_URL 映射为 invalid_url，或 error.code 未正确设置）。,success
+2026-02-04T03:44:44.715Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 测试执行（libraries/http-services `rushx build`）失败：invalid_url 结果映射错误需修复,success
+2026-02-04T03:46:27.926Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:46:58.358Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 本次测试失败归因 impl-dev（错误码/结果映射与规范/测试不一致）,success
+2026-02-04T03:46:58.424Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,setCurrentTask: 测试执行（libraries/http-services `rushx build`）失败：invalid_url 结果映射错误需修复,success
+2026-02-04T03:47:30.237Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:47:52.171Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 确认 http-services `rushx build` 通过，无需回到 impl 阶段修复。,success
+2026-02-04T03:47:54.300Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 测试执行,success
+2026-02-04T03:48:10.650Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:56:26.723Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T03:58:07.649Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T04:02:06.980Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addConstraint: security review FAIL，需先处理 blocking 再继续报告阶段。,success
+2026-02-04T04:02:06.993Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 修复安全阻塞：allowedHosts 为空时开放代理风险（需 fail-fast/强限制）,success
+2026-02-04T04:02:07.162Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 修复安全阻塞：req.timeout 缺少上限导致 DoS 风险,success
+2026-02-04T04:07:23.833Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 接受安全阻塞风险（开放代理/timeout 无上限）并在 RFC 明确隔离前提,success
+2026-02-04T04:07:24.037Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 记录风险接受：allowedHosts 为空与 timeout 无上限的隔离前提（RFC R27a/R27b）,success
+2026-02-04T04:07:38.498Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T04:09:54.661Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 安全审查复审完成：review-security-metrics.md 结论 FAIL。,success
+2026-02-04T04:09:54.888Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 处理安全阻塞或明确 wontfix：allowedHosts 为空开放代理风险,success
+2026-02-04T04:09:54.902Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 处理安全阻塞或明确 wontfix：req.timeout 无上限 DoS 风险,success
+2026-02-04T04:11:34.000Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 安全审查 blocking 标记为 wontfix,success
+2026-02-04T04:11:34.071Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 处理安全阻塞或明确 wontfix：allowedHosts 为空开放代理风险,success
+2026-02-04T04:11:34.116Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 处理安全阻塞或明确 wontfix：req.timeout 无上限 DoS 风险,success
+2026-02-04T04:11:45.498Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T04:11:50.161Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-04T04:11:50.161Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: handoff, includeReviews: true",success
+2026-02-04T04:13:16.493Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 阶段 4 - Review: 完成 code/security review（security 标记 wontfix）,success
+2026-02-04T04:13:16.496Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 阶段 3 - Verification: 运行 rushx build 并通过,success
+2026-02-04T04:13:16.496Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 阶段 2 - Implementation: 实现 http-proxy target_host 指标与单测,success
+2026-02-04T04:13:16.497Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 阶段 5 - Report: 生成 report-walkthrough-metrics 与 pr-body-metrics,success
+2026-02-04T04:13:16.517Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 实现完成：新增 target_host 指标与最小单测，修复 INVALID_URL 映射并通过 rushx build。,success
+2026-02-04T07:22:06.142Z,legion_list_reviews,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,status: open,success
+2026-02-04T07:27:08.784Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDecision: 指标统计覆盖所有 fetch 目标 host+path，不再依赖 allowedHosts 过滤,success
+2026-02-04T07:27:40.034Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 已响应 rfc-metrics review 并调整 RFC/代码：指标统计覆盖所有 host+path，target_path 标签落地。,success
+2026-02-04T07:27:40.055Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 处理 rfc-metrics review：去除 allowedHosts gating，新增 target_path 指标并同步实现与测试,success
+2026-02-04T07:27:40.120Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 处理 rfc-metrics review：去除 allowedHosts gating，新增 target_path 指标并同步实现与测试,success
+2026-02-04T07:36:18.438Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T07:36:20.958Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T07:43:02.041Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T07:43:04.190Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-04T07:49:35.661Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 按 review 意见改码：新增 target_path 维度、移除 allowedHosts gating、删除未用函数并补充单测。,success
+2026-02-04T07:49:35.685Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 按 review 意见改码并补充单测（target_path + labels）,success
+2026-02-04T07:49:35.709Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 按 review 意见改码并补充单测（target_path + labels）,success
+2026-02-04T07:56:28.210Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 记录高基数风险的预留方案：target_path 归一化/前缀过滤/分层指标。,failed
+2026-02-04T07:56:28.218Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 评估 target_path 高基数风险：路径归一化/前缀过滤/分层指标方案,success
+2026-02-04T07:56:33.247Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 记录高基数风险的预留方案：target_path 归一化/前缀过滤/分层指标。,success
+2026-02-04T07:59:54.858Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success
+2026-02-04T08:00:32.671Z,legion_update_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,progress.completed: 移除 unused warnedAllowedHostsWithPort 逻辑并更新测试/RFC/plan。,success
+2026-02-04T08:00:32.672Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,addDiscoveredTask: 移除 warnedAllowedHostsWithPort 并更新测试/RFC/plan,success
+2026-02-04T08:00:32.750Z,legion_update_tasks,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,completeTask: 移除 warnedAllowedHostsWithPort 并更新测试/RFC/plan,success
+2026-02-04T08:02:23.141Z,legion_get_status,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,,success

--- a/.legion/tasks/http-proxy-app-implementation/context.md
+++ b/.legion/tasks/http-proxy-app-implementation/context.md
@@ -24,10 +24,69 @@
 - 按你的 rxjs 流重写 graceful shutdown，去掉 timeout/promise 并在 RxJS tap 中完成清理
 - 同步更新 spec-dev/spec-obs 文档
 - 用 RxJS race+timer 实现 shutdown 超时，保持在流内处理并更新 spec-dev/spec-obs 文档
+- 完成 RFC metrics 对抗性审查，结论 NEEDS_CHANGES，输出 review-rfc-metrics.md
+- 修订 RFC metrics：补齐 URL 解析优先级、allowedHosts 语义、基数上限、result 映射、回滚细则与最小验证
+- RFC metrics 复审完成，结论 NEEDS_CHANGES，输出 review-rfc-metrics.md。
+- 修订 rfc-metrics.md：allowedHosts 禁止 IP、IP 字面量固定为 `ip` 且不进入白名单；绝对 URL 优先并忽略 Host 头冲突。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES）：新增问题聚焦 IP 请求阻断语义、写回失败 result 映射、Host 解析失败边界，输出 review-rfc-metrics.md。
+- 修订 rfc-metrics.md：IP 字面量请求强制 blocked、写回失败映射 result=error、Host 头解析失败边界与反例、移除 unknown 占位符并补充基数上限依据。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES），问题聚焦：invalid_url 的 target_host 规则、scheme 解析失败回退、空 hostname 处理。
+- 修订 rfc-metrics.md：invalid_url 目标主机固定为 invalid 且不进白名单，含 scheme 解析失败不回退 host_header，空 hostname 视为解析失败。
+- RFC metrics 对抗复审完成（结论 NEEDS_CHANGES），关键争议：CONNECT/authority-form 支持一致性、blocked/invalid_url 写回失败优先级、allowedHosts 为空语义。
+- 修订 rfc-metrics.md：CONNECT/star-form 视为 invalid_url、写回失败优先级为 error、allowedHosts 为空时不注册目标域名指标。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- RFC metrics 对抗复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES）：需对齐 allowedHosts 为空语义与 host_header 校验边界，输出 review-rfc-metrics.md。
+- 修订 rfc-metrics.md：allowedHosts 为空 fail-fast；host_header 严格校验（LDH/IPv6/禁用非法字符）；absolute-form userinfo 视为 invalid_url。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- 修订 rfc-metrics.md：absolute-form 仅接受 `scheme://` 且 hostname 必须为 ASCII LDH/IPv6，ip_literal 识别使用 `net.isIP` 或 `:`/`%` 规则并补充测试用例。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES）；关键争议：Host 头大小写匹配、ip_literal 识别过宽、scheme 支持范围不清；建议：收敛校验规则并补充测试。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- 修订 rfc-metrics.md：host_header 先小写化、允许尾点并按大小写不敏感 LDH 校验；ip_literal 识别收敛并明确 `%` 规则；absolute-form 仅允许 http/https。
+
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，关键问题：allowedHosts 端口匹配语义缺失、host_header 尾点+端口边界未定义。）
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+
+- 修订 rfc-metrics.md：明确 host_header 端口范围、allowedHosts 匹配忽略端口、fail-fast 基线说明。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+
+- 修订 rfc-metrics.md：端口缺省允许且存在时限制 1..65535，scheme 白名单固定 http/https，host_header ASCII 校验先于小写化。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES），关键争议：非 ASCII hostname 可验证性、host_header IPv6/percent 边界、allowedHosts 空白名单基线证据。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- 修订 rfc-metrics.md：hostname 以解析结果为准并允许 punycode、host_header IPv6 禁止 `%`/IPvFuture、allowedHosts fail-fast 基线来自 ALLOWED_HOSTS 必填。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，输出 review-rfc-metrics.md）
+- 修订 rfc-metrics.md：host_header 规范化唯一步骤与 URL 构造顺序、指标解析复用 SSRF/请求解析结果、allowedHosts 为空时不注册目标域名指标（不改变既有服务行为）。
+- 简化 rfc-metrics.md：仅支持 absolute-form，移除 host_header/origin-form 规则；allowedHosts 仅在配置存在时参与指标统计，缺失/非法/超限仅告警且不注册指标。
+- 完成 RFC metrics 对抗复审（结论 NEEDS_CHANGES）。
+- 识别关键争议：absolute-form-only 与现有解析一致性、allowedHosts 缺失/非法时启动行为、IP 字面量判定来源。
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- 完成 rfc-metrics.md 对抗复审，结论 NEEDS_CHANGES（待落盘报告）
+- 识别关键争议：absolute-form-only 证据不足、parse_result 复用来源不明、allowedHosts 启动语义与 metrics_enabled 关系未固定
+- RFC metrics 复审完成（结论 NEEDS_CHANGES，更新 review-rfc-metrics.md）。
+- 完成 rfc-metrics.md 对抗复审草稿（结论 NEEDS_CHANGES），梳理必须修正点与可选优化项。
+- 修订 rfc-metrics.md：删除 scheme 白名单、IP 不默认 blocked、allowedHosts 仅规范化匹配、result 仅依赖 handler 返回/抛错、Goals/Non-Goals 收敛。
+- 设计门禁确认：RFC 已存在且用户已批准（HTTP Proxy 目标域名指标）。
+- 在 /Users/c1/Work/Yuan/libraries/http-services 运行 `rushx build`，构建与测试通过（Jest 23/23）。
+- 安全审查完成：review-security-metrics.md（结论 FAIL，存在 blocking）。
+- 按用户选择记录风险接受：允许 allowedHosts 为空与 timeout 无上限风险，仅要求部署隔离与上游限流。
+- 安全审查复审完成：review-security-metrics.md 结论 FAIL。
+- 安全阻塞标记为 wontfix（按用户选择 2）。
+- 实现完成：新增 target_host 指标与最小单测，修复 INVALID_URL 映射并通过 rushx build。
+- review 完成：code review 通过；security review FAIL 但按用户选择标记为 wontfix。
+- 报告完成：生成 report-walkthrough-metrics.md 与 pr-body-metrics.md。
+- 处理 rfc-metrics review：指标不依赖 allowedHosts，新增 target_path 维度并更新 RFC/实现/测试。
+- 已响应 rfc-metrics review 并调整 RFC/代码：指标统计覆盖所有 host+path，target_path 标签落地。
+- 重新运行 /Users/c1/Work/Yuan/libraries/http-services 的 rushx build，测试通过（23/23）。
+- 按 review 意见改码：新增 target_path 维度、移除 allowedHosts gating、删除未用函数并补充单测。
+- 重跑 /Users/c1/Work/Yuan/libraries/http-services 的 rushx build，测试通过（25/25）。
+- 完成子代理 code/security 复审并输出报告。
+- 记录高基数风险的预留方案：target_path 归一化/前缀过滤/分层指标。
+- 移除 unused warnedAllowedHostsWithPort 逻辑并更新测试/RFC/plan。
+- 运行 /Users/c1/Work/Yuan/libraries/http-services 的 rushx build，测试通过（24/24）。
 
 ### 🟡 进行中
 
-(暂无)
+- 按用户要求执行子代理 code/security 复审。
 
 ### ⚠️ 阻塞/待定
 
@@ -43,15 +102,68 @@
 
 ## 关键决策
 
-| 决策                                                                            | 原因                                                                   | 替代方案                                                   | 日期       |
-| ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- | ---------- |
-| 采用单一入口 `src/index.ts` 作为胶水层启动 HTTP Proxy 服务                      | 需求明确要求简单实现，仅需启动 terminal 并注册服务                     | 引入多模块或复杂配置系统以扩展功能；本次不采用，避免复杂化 | 2026-01-28 |
-| 默认要求配置 ALLOWED_HOSTS，且非本地 ws:// 需显式允许                           | 避免开放代理与明文链路风险，满足安全审查要求                           | 默认放开 allowedHosts 或允许任何 ws://；已弃用             | 2026-01-28 |
-| 为 CONCURRENT/MAX_PENDING_REQUESTS/ MAX_RESPONSE_BODY_SIZE 设置默认值与范围校验 | 满足安全审查的 secure-by-default 要求并避免资源耗尽                    | 完全不设默认值，依赖调用方；已弃用                         | 2026-01-28 |
-| 测试阶段采用包内构建验证（rushx build）作为最小可运行检查                       | @yuants/app-http-proxy 仅定义 build 脚本且无测试脚本，优先执行编译验证 | 运行全仓 `rush build` 或集成测试；成本更高且不必要         | 2026-01-28 |
-| graceful shutdown 设置 5s 超时强制退出                                          | 避免 dispose/terminal.dispose 卡住导致进程悬挂                         | 不设置超时，依赖事件循环自行退出；已弃用                   | 2026-01-28 |
-| graceful shutdown 保持在 RxJS 流内处理，去掉 timeout/promise                    | 与当前实现风格一致，避免额外控制流                                     | 保留超时与 async 清理；本次不采用                          | 2026-01-28 |
-| 使用 RxJS race(timer, cleanup$) 提供 shutdown timeout 能力                      | 保持 shutdown 逻辑完全在 RxJS 流内，同时具备超时保障                   | setTimeout 或 Promise 逻辑；不采用                         | 2026-01-28 |
+| 决策                                                                                                    | 原因                                                                   | 替代方案                                                   | 日期       |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- | ---------- |
+| 采用单一入口 `src/index.ts` 作为胶水层启动 HTTP Proxy 服务                                              | 需求明确要求简单实现，仅需启动 terminal 并注册服务                     | 引入多模块或复杂配置系统以扩展功能；本次不采用，避免复杂化 | 2026-01-28 |
+| 默认要求配置 ALLOWED_HOSTS，且非本地 ws:// 需显式允许                                                   | 避免开放代理与明文链路风险，满足安全审查要求                           | 默认放开 allowedHosts 或允许任何 ws://；已弃用             | 2026-01-28 |
+| 为 CONCURRENT/MAX_PENDING_REQUESTS/ MAX_RESPONSE_BODY_SIZE 设置默认值与范围校验                         | 满足安全审查的 secure-by-default 要求并避免资源耗尽                    | 完全不设默认值，依赖调用方；已弃用                         | 2026-01-28 |
+| 测试阶段采用包内构建验证（rushx build）作为最小可运行检查                                               | @yuants/app-http-proxy 仅定义 build 脚本且无测试脚本，优先执行编译验证 | 运行全仓 `rush build` 或集成测试；成本更高且不必要         | 2026-01-28 |
+| graceful shutdown 设置 5s 超时强制退出                                                                  | 避免 dispose/terminal.dispose 卡住导致进程悬挂                         | 不设置超时，依赖事件循环自行退出；已弃用                   | 2026-01-28 |
+| graceful shutdown 保持在 RxJS 流内处理，去掉 timeout/promise                                            | 与当前实现风格一致，避免额外控制流                                     | 保留超时与 async 清理；本次不采用                          | 2026-01-28 |
+| 使用 RxJS race(timer, cleanup$) 提供 shutdown timeout 能力                                              | 保持 shutdown 逻辑完全在 RxJS 流内，同时具备超时保障                   | setTimeout 或 Promise 逻辑；不采用                         | 2026-01-28 |
+| 目标域名指标仅对白名单主机打 label，非白名单/无白名单/无效 URL 使用占位符                               | 避免 Prometheus 高基数与敏感信息泄露，保持可控指标维度                 | 直接使用 hostname 或记录 IP；已弃用                        | 2026-02-03 |
+| 目标域名解析优先级采用“绝对 URL 优先，其次 Host 头拼接”，解析失败归入 invalid_url                       | 兼容代理请求绝对/相对 URL 形态，确保指标可实现可验证                   | 仅解析绝对 URL；已弃用                                     | 2026-02-03 |
+| allowedHosts 限定精确匹配且设置数量上限，非法或超限配置失败启动                                         | 避免高基数与实现分歧，保持可控与一致性                                 | 允许通配或不设上限；已弃用                                 | 2026-02-03 |
+| 回滚时同时删除指标注册与采集点                                                                          | 避免指标空值残留造成误读                                               | 仅删除采集点保留注册；已弃用                               | 2026-02-03 |
+| allowedHosts 禁止 IP 字面量，遇到 IP 目标时 `target_host` 固定为 `ip` 且不走白名单                      | 消除 IP 与白名单命中规则冲突并避免泄露 IP                              | 允许 IP 并匹配白名单；已弃用                               | 2026-02-03 |
+| 绝对 URL 与 Host 头冲突时忽略 Host，不做一致性校验                                                      | 简化实现与测试，明确解析优先级                                         | 冲突视为 invalid_url；未采用                               | 2026-02-03 |
+| 保留状态机章节仅用于 `result` 映射与测试断言说明                                                        | 确保规范可验证且不要求显式状态机实现                                   | 移至附录或删除；未采用                                     | 2026-02-03 |
+| IP 字面量请求统一映射为 `blocked` 且 `target_host=ip`                                                   | 与现有 SSRF 规则一致，避免通过指标泄露 IP 或绕过阻断                   | 仅归一化为 `ip` 但允许继续请求；已弃用                     | 2026-02-03 |
+| 写回失败/中断映射为 `result=error`，`ok` 仅在写回成功时设置                                             | 使结果可验证且计数点唯一，覆盖客户端断连等写回异常                     | fetch 成功即 `ok`；已弃用                                  | 2026-02-03 |
+| Host 头解析失败边界统一为 `invalid_url`（含空白或 `/`）                                                 | 确保解析规则单一、可测试                                               | 允许宽松解析或分支规则；已弃用                             | 2026-02-03 |
+| 移除 `unknown` 占位符，保留固定占位符集合                                                               | 配置已强制非空与合法，`unknown` 无可达触发条件                         | 保留 `unknown` 作为兜底；已弃用                            | 2026-02-03 |
+| invalid_url 时 `target_host=invalid` 且不进白名单，scheme 解析失败不回退 Host                           | 明确失败边界与回退规则，确保实现与测试一致                             | 允许回退 Host 或保留白名单匹配；已弃用                     | 2026-02-03 |
+| CONNECT/authority-form 与 star-form 视为 invalid_url 并尝试写回错误响应                                 | 与现有服务能力一致，避免引入未支持的 CONNECT 语义                      | 支持 CONNECT 或特殊解析；已弃用                            | 2026-02-03 |
+| 写回失败统一优先映射为 `result=error`                                                                   | 确保结果与指标可验证，避免写回失败仍显示 blocked/invalid_url           | 保持 blocked/invalid_url 不变；已弃用                      | 2026-02-03 |
+| allowedHosts 为空时不注册目标域名指标                                                                   | 对齐现有行为并避免无白名单时的高基数风险                               | 为空时 fail-fast；已弃用                                   | 2026-02-03 |
+| raw_url 以 `//` 开头视为 invalid_url，且不回退 Host                                                     | 避免 network-path reference 引入歧义与绕过解析边界                     | 视为 `http:` 解析；已弃用                                  | 2026-02-03 |
+| host_header 拼接仅支持 origin-form（raw_url 必须以 `/` 开头且不以 `//` 开头）                           | 限定解析分支，保证可实现且可测试                                       | 对任意相对路径回退 Host；已弃用                            | 2026-02-03 |
+| 写回成功判定以 `finish` 为准且不得先 `error/close/destroy`                                              | 给出最小可检测语义，确保 result 可验证                                 | 仅以无异常为成功；已弃用                                   | 2026-02-03 |
+| allowedHosts 仅接受 ASCII LDH + 可选端口，IDN 必须 punycode                                             | 统一配置与匹配规则，避免非 ASCII 解析差异                              | 放宽为非 ASCII；已弃用                                     | 2026-02-03 |
+| host_header 端口仅允许 1-5 位十进制且范围 1..65535                                                      | 统一端口边界与错误语义，避免解析歧义                                   | 放宽端口格式或忽略非法端口；已弃用                         | 2026-02-03 |
+| allowedHosts 匹配仅使用 hostname，端口永不参与                                                          | 消除匹配歧义并与指标维度一致                                           | 允许端口参与匹配；已弃用                                   | 2026-02-03 |
+| allowedHosts 为空 fail-fast 属于既有服务基线                                                            | 避免开放代理；本 RFC 仅记录现有行为                                    | 将其视为新行为或允许空白名单；已弃用                       | 2026-02-03 |
+| allowedHosts 为空时 fail-fast（启动失败）                                                               | 安全默认对齐，避免开放代理与无约束指标                                 | 为空时不注册指标；已弃用                                   | 2026-02-03 |
+| host_header 先小写化并允许尾点，且仅允许 LDH/IPv6 语法并拒绝非法字符与 userinfo                         | 对齐 Host 头语义并降低大小写分歧，避免歧义与注入                       | 要求严格小写或拒绝尾点；已弃用                             | 2026-02-03 |
+| absolute-form 仅接受 `scheme://` 且仅允许 `http/https`                                                  | 避免解析歧义与回退逻辑不一致，确保规则可测试                           | 允许更多 scheme 或回退 Host；已弃用                        | 2026-02-03 |
+| absolute-form hostname 必须为 ASCII LDH 或 IPv6 字面量                                                  | 统一解析与 IDN 处理边界，避免非 ASCII 差异                             | 允许非 ASCII hostname；已弃用                              | 2026-02-03 |
+| ip_literal 识别收敛为 `net.isIP` 或 hostname 含 `:`，`%` 仅在 IPv6 zone 且含 `:` 时成立                 | 避免 `%` 误判并保持 IPv6 zone 可检测                                   | 只依赖 `net.isIP` 或对 `%` 一概当作 IP；已弃用             | 2026-02-03 |
+| scheme 白名单固定仅允许 `http/https`，不引入额外配置                                                    | 避免行为漂移与配置歧义，确保实现与测试一致                             | 允许配置扩展 scheme；已弃用                                | 2026-02-03 |
+| host_header ASCII 校验先于小写化，避免非 ASCII 变换歧义                                                 | 明确校验顺序，保持规则可实现且可测试                                   | 先小写化再校验；已弃用                                     | 2026-02-03 |
+| host_header 端口缺省允许，存在时必须 1..65535                                                           | 与 RFC 解析分支一致，避免缺省端口误判                                  | 缺省端口视为错误或忽略端口格式；已弃用                     | 2026-02-03 |
+| hostname 以 URL 解析后的值为准，允许 punycode，解析后非 ASCII 视为 invalid_url                          | 对齐 URL 解析真实输出，允许 IDN 的 ASCII 表达并保持可测                | 原始非 ASCII 一律 invalid；已弃用                          | 2026-02-03 |
+| host_header IPv6 仅允许 `[IPv6]` 且 `net.isIP==6`，拒绝 `%`/IPvFuture                                   | 统一 absolute/origin IPv6 规则，避免 zone/IPvFuture 解析歧义           | 允许 zone 或 IPvFuture；已弃用                             | 2026-02-03 |
+| allowedHosts 为空 fail-fast 视为既有 http-proxy 基线（ALLOWED_HOSTS 必填）                              | 对齐现有服务约束并避免开放代理                                         | 作为新行为或允许空白名单；已弃用                           | 2026-02-03 |
+| absolute-form 仅使用 raw_url 解析，R10 作为唯一最终 hostname 校验                                       | 避免 Host 头干扰与重复校验，规则可实现且可测试                         | 在 R12 复用 hostname 校验；已弃用                          | 2026-02-03 |
+| ldh_hostname 补齐 RFC 1035/1123 长度边界（label 1..63，总长度 <=253）                                   | 统一 DNS 约束，避免过长标签导致解析差异                                | 仅依赖 URL 解析成功；已弃用                                | 2026-02-03 |
+| allowedHosts fail-fast 为全局基线，与 metrics_enabled 无关                                              | 与既有安全基线一致，避免禁用指标时绕过白名单校验                       | metrics_enabled=false 时跳过校验；已弃用                   | 2026-02-03 |
+| host_header 规范化采用单一有序流程并以 R10 作为最终 hostname 校验                                       | 消除 R12/R14 歧义，确保可实现与可测试                                  | 分散在多条规则中校验；已弃用                               | 2026-02-03 |
+| 指标解析复用现有 SSRF/请求解析结果（parse_result）                                                      | 避免解析分歧与安全绕过，确保指标与请求处理一致                         | 指标独立解析 raw_url/Host；已弃用                          | 2026-02-03 |
+| allowedHosts 为空时不注册目标域名指标，且不改变既有服务允许空白名单与否的行为                           | 对齐“约定大于配置”，避免新增 fail-fast 行为，同时控制指标基数          | 为空时 fail-fast；已弃用                                   | 2026-02-03 |
+| 仅支持 absolute-form（`req.url` 必须为完整 URL），不再解析 host_header/origin-form                      | 对齐现有实现并简化解析路径，避免分支歧义                               | 继续支持 origin-form/Host 头；已弃用                       | 2026-02-03 |
+| allowedHosts 缺失/非法/超限时仅告警并不注册指标，不影响请求处理                                         | 不改变既有行为并控制指标基数                                           | 失败即中止服务或强制 fail-fast；已弃用                     | 2026-02-03 |
+| absolute-form-only 证据来自 `server.ts` 的 `new URL(req.url)` 路径，非 absolute-form 触发 `INVALID_URL` | 与现有解析路径一致，避免新增分支与实现偏差                             | 以 schema 或其他校验作为依据；已弃用                       | 2026-02-03 |
+| parse_result 定义为 handler 内 `urlObj`（`new URL(req.url)` 结果），指标不得重新解析                    | 避免解析分歧与安全绕过，确保指标与请求处理一致                         | 指标独立解析 raw_url；已弃用                               | 2026-02-03 |
+| allowedHosts 校验与请求处理不受 `metrics_enabled` 影响；缺失/非法仅告警不 fail-fast                     | 对齐 `server.ts` 现状（无 fail-fast），且 metrics 仅控制注册与输出     | 视 metrics_enabled 决定是否校验或 fail-fast；已弃用        | 2026-02-03 |
+| 删除 scheme 白名单，完全依赖 `new URL(req.url)` 解析结果                                                | 避免新增请求行为约束，保持与现有 handler 一致                          | 保留 http/https 白名单；已弃用                             | 2026-02-04 |
+| IP 字面量 `target_host=ip`，`result` 仅在 SSRF 实际阻断时为 `blocked`                                   | 不假设 SSRF 必拒绝 IP，避免指标语义与实际行为冲突                      | 一律将 IP 视为 blocked；已弃用                             | 2026-02-04 |
+| allowedHosts 仅做“ASCII 小写 + 去尾点”规范化匹配，不新增上限或校验                                      | 运维侧控制基数，避免引入新配置约束                                     | 增加上限或严格校验；已弃用                                 | 2026-02-04 |
+| result 完全基于 handler 返回/抛错，不再判定写回成功                                                     | 与现有实现一致，降低可观测分歧                                         | 写回成功作为判定条件；已弃用                               | 2026-02-04 |
+| 抛错时 `result` 由 `error.code`/等价信号映射（含 INVALID_URL），未知码为 `error`                        | 对齐现有错误码语义，避免“抛错=error”与 INVALID_URL 冲突                | 一律抛错映射为 error；已弃用                               | 2026-02-04 |
+| 解析成功但 hostname 为空统一视为 `invalid_url`，`target_host=invalid`                                   | 明确 file/mailto 等边界，避免落入白名单匹配                            | 允许空 hostname 继续匹配或视为 disallowed；已弃用          | 2026-02-04 |
+| allowedHosts 仅允许 hostname，含 `:` 不做自动拆分且仅告警一次                                           | 保持现状匹配失败语义，避免自动修正规则导致分歧                         | 自动拆分端口并匹配；已弃用                                 | 2026-02-04 |
+| timeout/blocked 仅绑定到 error.code 或等价信号来源                                                      | 确保语义可检测、可测试且与错误码一致                                   | 依据其他时序或写回状态推断；已弃用                         | 2026-02-04 |
+| 移除状态机章节，仅保留事件->result 映射表与最小用例                                                     | 减少误导性抽象，保持规范最小可实现                                     | 保留状态机作为说明；已弃用                                 | 2026-02-04 |
 
 ---
 
@@ -59,15 +171,21 @@
 
 **下次继续从这里开始：**
 
-1. 复核 walkthrough 与 PR body 文档，路径：`.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough.md`、`.legion/tasks/http-proxy-app-implementation/docs/pr-body.md`
-2. 如需进一步验证，可运行 HTTP Proxy 启动检查与最小运行流程
-3. 如需更强覆盖，可补充集成验证
+1. 如需提交 PR，可运行 /legion-pr。
 
 **注意事项：**
 
-- 构建验证已通过，可将之前的构建失败阻塞视为已解除
-- Walkthrough 与 PR body 已生成，可直接用于评审与提交
+- warnedAllowedHostsWithPort 已删除，相关测试与 RFC 已更新。
 
 ---
 
-_最后更新: 2026-01-28 21:51 by Claude_
+_最后更新: 2026-02-03 by OpenCode_
+围限定在 http-services 指标采集与对应单测。
+
+**注意事项：**
+
+- RFC 路径：/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md
+
+---
+
+_最后更新: 2026-02-03 by OpenCode_

--- a/.legion/tasks/http-proxy-app-implementation/docs/pr-body-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/pr-body-metrics.md
@@ -1,0 +1,33 @@
+## What
+
+为 HTTP Proxy 增加目标域名+路径维度的请求计数指标 `http_proxy_target_host_requests_total`，并在现有 handler 末尾采集 `target_host`、`target_path` 与 `result`。
+
+## Why
+
+当前仅有总量/耗时/错误指标，缺少目标域名维度导致流量分布与异常排查困难。
+
+## How
+
+- 复用 handler 内 `new URL(req.url)` 的解析结果（`parse_result`），不做二次解析。
+- `target_host` 使用解析结果规范化或固定占位符（`ip`/`invalid`）。
+- `target_path` 使用 `parse_result.pathname`，为空则 `/`。
+- `result` 仅基于 handler 抛错与错误码映射，未命中统一为 `error`。
+
+## Testing
+
+```bash
+cd /Users/c1/Work/Yuan/libraries/http-services
+rushx build
+```
+
+## Risk / Rollback
+
+- 安全审查中标注：开放代理风险与 timeout 无上限 DoS 风险为 wontfix（见安全审查报告）。
+- 回滚：移除 `http_proxy_target_host_requests_total` 的注册与计数逻辑，并回滚相关测试。
+
+## Links
+
+- RFC: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+- Walkthrough: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md`
+- Code Review: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md`
+- Security Review: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md`

--- a/.legion/tasks/http-proxy-app-implementation/docs/pr-body.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/pr-body.md
@@ -11,6 +11,7 @@
 - Register `http_proxy_target_host_requests_total` with `target_host`, `target_path`, `result` labels
 - Map results from existing handler error codes; derive host/path from `new URL(req.url)` parse result
 - Extend tests to cover target_path defaulting, labels propagation, and invalid_url cases
+- Update Grafana dashboard with target host/path panels and filters
 
 ## Testing
 

--- a/.legion/tasks/http-proxy-app-implementation/docs/pr-body.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/pr-body.md
@@ -1,27 +1,27 @@
 ## What
 
-- Add `@yuants/app-http-proxy` application that starts a Terminal and registers HTTP Proxy service
+- Add target host/path metrics for HTTP proxy requests in `@yuants/http-services`
 
 ## Why
 
-- Provide a ready-to-run HTTP proxy app instead of requiring manual integration of `http-services`
+- Provide visibility into downstream target distribution and error patterns per host/path
 
 ## How
 
-- Implement single entry `src/index.ts` with env-driven config, service registration, and graceful shutdown
-- Add package config and build setup under `apps/http-proxy`
+- Register `http_proxy_target_host_requests_total` with `target_host`, `target_path`, `result` labels
+- Map results from existing handler error codes; derive host/path from `new URL(req.url)` parse result
+- Extend tests to cover target_path defaulting, labels propagation, and invalid_url cases
 
 ## Testing
 
-- `cd apps/http-proxy && rushx build`
+- `cd libraries/http-services && rushx build`
 
 ## Risk / Rollback
 
-- Risk: external `PROXY_IP` lookup depends on network availability; high concurrency/token values can increase resource usage
-- Rollback: revert `apps/http-proxy` changes or stop the service deployment
+- Risk: `target_path` may increase metric cardinality; monitor and apply normalization/filters if needed
+- Rollback: remove the `http_proxy_target_host_requests_total` registration and sampling logic
 
 ## Links
 
-- RFC: `.legion/tasks/http-proxy-app-implementation/docs/rfc.md`
-- Specs: `.legion/tasks/http-proxy-app-implementation/docs/spec-dev.md`, `.legion/tasks/http-proxy-app-implementation/docs/spec-test.md`, `.legion/tasks/http-proxy-app-implementation/docs/spec-bench.md`, `.legion/tasks/http-proxy-app-implementation/docs/spec-obs.md`
-- Walkthrough: `.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough.md`
+- RFC: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+- Walkthrough: `.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md`

--- a/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md
@@ -1,0 +1,75 @@
+# Walkthrough 报告：HTTP Proxy 目标域名指标
+
+## 目标与范围
+
+- 目标：为 HTTP Proxy 增加“目标域名”维度的请求计数指标，便于按域名聚合观测，不改变现有请求处理与 SSRF 行为。
+- 范围（Scope 绑定）：
+  - 代码：`/Users/c1/Work/Yuan/libraries/http-services/src/server.ts`
+  - 测试：`/Users/c1/Work/Yuan/libraries/http-services/src/__tests__/server.test.ts`
+  - 设计与评审：
+    - RFC：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+    - 代码审查：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md`
+    - 安全审查：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md`
+
+## 设计摘要
+
+- 设计真源：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+- 关键设计点：
+  - 指标解析仅复用 handler 内 `new URL(req.url)` 的 `parse_result`，不做二次解析。
+  - `target_host`：IP 字面量固定为 `ip`，解析失败或 hostname 为空为 `invalid`，其余按 `allowedHosts` 规范化命中则记录主机名，否则为 `disallowed`。
+  - `result`：仅基于 handler 返回/抛错与 `error.code`/等价信号映射（TIMEOUT/FORBIDDEN/INVALID_URL 等），未命中为 `error`。
+  - `allowedHosts` 仅作为基数控制（规范化匹配，含端口仅告警且不匹配）；空/缺失时不注册目标域名指标并告警。
+- 可选插件产物：无。
+
+## 改动清单
+
+- 业务逻辑（`server.ts`）：
+  - 新增指标 `http_proxy_target_host_requests_total`，注册条件与计数点落在请求生命周期末尾。
+  - 增加 `target_host` 与 `result` 解析逻辑，复用 `parse_result` 与错误码映射。
+  - 对 `allowedHosts` 进行规范化匹配，含端口的配置仅告警且不参与匹配。
+- 单元测试（`server.test.ts`）：
+  - 覆盖 `invalid_url`/空 hostname/IP 字面量/allowedHosts 端口告警等指标行为。
+
+## 如何验证
+
+1. 运行构建与测试（库内）：
+
+```bash
+cd /Users/c1/Work/Yuan/libraries/http-services
+rushx build
+```
+
+预期：构建通过，Jest 用例通过（与 `server.test.ts` 相关的 metrics 用例全部为 PASS）。
+
+2. 手工验证（可选）：
+
+- 通过真实代理请求触发不同 target_host/result，确认 metrics 中 `target_host` 仅出现白名单命中或固定占位符。
+
+## Benchmark 结果或门槛说明
+
+- 未提供 benchmark 结果；本次变更未执行基准测试。
+
+## 可观测性（metrics/logging）
+
+- 新增指标：`http_proxy_target_host_requests_total{target_host,result}`。
+- 相关指标仍保留：`http_proxy_requests_total`、`http_proxy_request_duration_seconds`、`http_proxy_active_requests`、`http_proxy_errors_total`。
+- 日志：
+  - allowedHosts 为空/缺失时输出一次告警并禁用 target_host 指标。
+  - allowedHosts 项包含端口时输出一次告警。
+  - 被阻断的主机名会记录 warn（已有行为）。
+
+## 风险与回滚
+
+- 风险：
+  - 安全审查中对 `allowedHosts` 为空导致开放代理风险、`req.timeout` 无上限的 DoS 风险标记为 wontfix（见安全审查报告）。
+  - 日志中可能包含被阻断的 hostname（潜在信息泄露风险）。
+- 回滚：
+  - 删除/禁用 `http_proxy_target_host_requests_total` 的注册与计数点（`server.ts`），并回滚相关测试断言。
+
+## 未决项与下一步
+
+- 未决项（来自代码审查建议）：
+  - 增补 allowedHosts 规范化命中/未命中测试与“allowedHosts 为空不注册指标”测试。
+  - 若 `resolveResultFromError` 继续保留，应补充覆盖测试；否则删除以降低维护成本。
+- 下一步建议：
+  - 如需提升安全基线，评估对 `allowedHosts` 空值的 fail-fast 与 `req.timeout` 上限裁剪的可行性。

--- a/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md
@@ -1,0 +1,19 @@
+# Code Review Report
+
+## 结论
+
+PASS（基于有限信息的评审；已审查文件：`libraries/http-services/src/server.ts`、`libraries/http-services/src/__tests__/server.test.ts`）
+
+## Blocking Issues
+
+- [ ] 无
+
+## 建议（非阻塞）
+
+- `libraries/http-services/src/__tests__/server.test.ts:202` - 多处直接使用 `mockMetrics.counter.mock.results[0/1]` 依赖注册顺序，维护时容易脆弱；建议统一用 `getCounterMetric` 按名称取值，避免未来变更顺序导致误报。
+- `libraries/http-services/src/server.ts:62` - 当前 `target_path` 直接使用 `URL.pathname`，符合 RFC R12，但 RFC R25 对“路径”措辞容易引起误读；建议在 RFC 或代码注释中明确“仅 pathname、无 query/fragment”，避免审计时被误判为泄露原始 URL。
+
+## 修复指导
+
+- `libraries/http-services/src/__tests__/server.test.ts`：将 `mockMetrics.counter.mock.results[0]`/`[1]` 替换为 `getCounterMetric(mockMetrics, 'http_proxy_requests_total')`、`getCounterMetric(mockMetrics, 'http_proxy_errors_total')`、`getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total')`，消除顺序依赖。
+- `libraries/http-services/src/server.ts` 或 `rfc-metrics.md`：补充一句“`target_path` 仅为 `pathname`，不包含 query/fragment”，与 R25 的安全说明对齐。

--- a/.legion/tasks/http-proxy-app-implementation/docs/review-rfc-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/review-rfc-metrics.md
@@ -1,0 +1,35 @@
+# RFC 复审报告：rfc-metrics.md
+
+结论：**NEEDS_CHANGES**
+
+## 必须修正
+
+1. absolute-form-only 假设证据不足，可能与现有处理不一致
+
+- 质疑/风险：R5 直接规定非 absolute-form 视为 invalid_url，但证据仅引用 schema `format: uri`。若现有链路仍接受 origin-form/CONNECT，指标会把有效请求标成 invalid_url，违反“仅影响指标、不改变行为”的前提，且不可验证。
+- 最小修改建议：补充“现有解析已拒绝非 absolute-form”的明确证据（代码路径/行为说明）并给出 1 条验证用例；或把 R5 改为“以 parse_result 的解析形态为准”，将 absolute-form 作为前置条件而非强制规则。
+
+2. parse_result 复用的来源/字段不明，易迫使重新解析
+
+- 质疑/风险：R6 要求“复用现有 parse_result 与 parsed_url”，但 RFC 未指定 parse_result 的生产位置/字段结构/可见性。实现侧若拿不到该对象，只能重解析，直接违背 R6 并引入解析分歧。
+- 最小修改建议：在 Protocol/Plan 中明确“指标计数点可访问 parse_result 的具体位置/对象”（例如 server.ts 中某函数的返回值或请求上下文字段），并要求指标逻辑直接读取该对象；补 1 条“同一对象复用”的验证说明。
+
+3. allowedHosts 缺失/非法时的启动语义未固定，导致不可验证
+
+- 质疑/风险：R15 说“服务启动行为完全复用既有逻辑”，R18 又写“服务 MAY 继续运行并告警”。若既有实现 fail-fast，则“继续运行+告警”不可达；反之若继续运行，R17/R18 的条件必须更明确。当前语义无法验证。
+- 最小修改建议：明确既有行为是“fail-fast”还是“继续运行”，并据此调整 R17/R18（包含是否记录告警、是否还能暴露其他指标）；补 1 条启动行为验证用例。
+
+4. metrics_enabled 与 allowedHosts 校验/启动关系未定义
+
+- 质疑/风险：R16 只管指标注册，但未说明 metrics_enabled=false 时是否仍执行 allowedHosts 校验。若 allowedHosts 校验被跳过，将改变现有安全基线，且与“不改变行为”冲突。
+- 最小修改建议：明确“allowedHosts 校验与启动行为不受 metrics_enabled 影响”，metrics_enabled 仅影响指标注册与输出；补 1 条验证说明。
+
+## 可选优化
+
+- 合并 R1-R4 的重复前置条件：先定义注册条件，再统一描述计数规则，减少冗余。
+- 明确 allowedHosts 匹配与 normalized_host 使用同一规范化流程（大小写/尾点/IDN），避免实现侧出现二次规范化分支。
+
+## 可实现/可验证/可回滚性
+
+- 当前版本在问题 1-4 上不可验证或存在实现歧义，需先修正后才能稳定落地。
+- R39 的回滚描述可保留，但应基于上述修正后的统一行为测试。

--- a/.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md
@@ -1,0 +1,30 @@
+# Security Review Report
+
+## 结论
+
+FAIL
+
+## Blocking Issues
+
+- [ ] `libraries/http-services/src/server.ts:158` [Spoofing] - 服务处理器未做调用方身份认证或授权校验，任何可连接终端都可伪造请求并使用代理能力，存在未授权访问与资源滥用风险。
+- [ ] `libraries/http-services/src/server.ts:179` [Elevation of Privilege] - 当 `allowedHosts` 未配置或为空时不做任何访问限制，服务等价开放代理，可被用于访问内网或受限资源。
+- [ ] `libraries/http-services/src/server.ts:200` [Denial of Service] - `timeout` 由客户端控制且无上限，恶意设置超大值可长期占用连接与并发资源，触发资源耗尽。
+
+## 安全建议（非阻塞）
+
+- `libraries/http-services/src/server.ts:70` [Information Disclosure] - `target_path` 直接记录路径，若路径中包含 token/账号/PII 会被指标暴露，建议对路径进行分桶/脱敏或限制为固定前缀。
+- `libraries/http-services/src/server.ts:70` [Denial of Service] - `target_path` 作为高基数字段未做限制，攻击者可构造无限路径导致指标内存与存储压力飙升。
+- `libraries/http-services/src/server.ts:184` [Information Disclosure] - `newError('FORBIDDEN', { allowedHosts })` 可能将白名单回传给调用方，建议避免向客户端泄露白名单细节，仅记录服务端日志。
+
+## 修复指导
+
+1. 增加强制鉴权与授权：在 handler 起点验证 caller identity（例如基于 Terminal 会话/签名/ACL），并拒绝未授权请求。
+2. secure-by-default：将 `allowedHosts` 设为必填或默认空即 fail-fast；若业务允许开放代理，需显式开关并在配置中强制声明。
+3. 设定 `timeout` 上限与范围校验（例如 1s–60s），超限直接拒绝请求或回退至安全默认值。
+4. 对 `target_path` 做脱敏或分桶（仅保留前 N 段、固定路由模板或哈希截断），并限制 label 基数。
+5. 仅在服务端日志记录 `allowedHosts` 细节，对外错误信息改为通用提示。
+
+## 无法评估
+
+- 调用方身份认证与连接安全（传输层加密、会话鉴权、ACL）需补充系统级设计说明或上游网关策略。
+- 速率限制/并发上限是否由 `IServiceOptions` 或上游网关强制，需提供对应配置与默认值。

--- a/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md
@@ -1,0 +1,200 @@
+# RFC: HTTP Proxy 目标域名流量指标（收敛版）
+
+## Abstract
+
+本 RFC 定义 HTTP Proxy 服务的“目标域名 + 路径”流量统计指标。指标解析 MUST 仅复用 handler 内 `new URL(req.url)` 的解析结果（`parse_result`），不得二次解析。RFC 删除 scheme 白名单约束，仅依赖 `new URL` 的解析成功与否；非 absolute-form 仍因解析失败归 `invalid_url`。解析成功但 `hostname` 为空（如 `file:`/`mailto:`）视为 `invalid_url`，`target_host` 固定为 `invalid`，`target_path` 固定为 `invalid`。IP 字面量目标的 `target_host` 固定为 `ip`；`result` 以 handler 抛错的 `error.code`/等价信号映射（含 `INVALID_URL`），未命中时为 `error`。指标统计与 `allowedHosts` 无关，记录所有 fetch 目标的 host 与 path。该 RFC 的 Plan 章节为工程执行的唯一设计真源。
+
+## Motivation / 背景与问题
+
+当前 HTTP Proxy 服务仅提供总体请求数、耗时与错误总量指标，无法按目标域名观察流量分布与异常。缺少目标域名维度会导致排障困难与成本决策盲区。
+
+## Goals & Non-Goals
+
+### Goals
+
+- 新增“目标域名 + 路径”统计指标，用于按 host/path 聚合。
+- 不改变现有请求处理、解析与 SSRF 行为。
+
+### Non-Goals
+
+- 不新增 scheme 白名单或额外协议过滤。
+- 不改变现有错误码与抛出逻辑。
+- 不新增 `allowedHosts` 的强制校验/上限或 fail-fast 行为。
+
+## Definitions
+
+- raw_url: 请求中的 `req.url` 原始字符串。
+- absolute-form: `req.url` 为完整 URL（含 scheme 与 host）。
+- parse_result: handler 内部 `new URL(raw_url)` 得到的 URL 实例（即 `urlObj`）。
+- normalized_host: `parse_result.hostname` 先 ASCII 小写化，再去除尾部 `.` 的结果。
+- allowedHosts: HTTP Proxy 现有配置的主机白名单（语义保持现状）。
+- target_host: 指标 label `target_host` 的最终值。
+- target_path: 指标 label `target_path` 的最终值（来自 URL pathname）。
+- result: 指标 label `result` 的分类（见 Error Semantics）。
+- effective_error_code: 抛错时用于 `result` 映射的错误码（来源见 Error Semantics）。
+
+## Protocol Overview（端到端流程）
+
+请求进入 handler 后先执行 `new URL(req.url)` 解析并进入既有 SSRF/请求流程；若解析失败则按 `invalid_url` 处理。若指标已注册，则在 handler 返回或抛错时计算 `target_host` 与 `result` 并计数一次。
+
+R1: 指标解析 MUST 仅复用 handler 内 `parse_result`，不得重新解析 `raw_url` 或构造新的 URL 实例。
+
+R2: 当 `new URL(raw_url)` 解析失败时，`parse_result` MUST 视为不存在，且 `result` MUST 进入 `invalid_url` 语义。
+
+R3: 当 `parse_result.hostname` 为空字符串时，`result` MUST 进入 `invalid_url` 语义。
+
+R4: 本 RFC MUST NOT 引入额外 scheme 过滤或白名单；`invalid_url` 由解析失败或 hostname 为空触发。
+
+R5: 实现 MUST 注册 `http_proxy_target_host_requests_total`，且不依赖 `allowedHosts`。
+
+> [REVIEW] 这是谁说的？为什么 allowedHosts 缺失就不统计了？我要的就是所有的底层 fetch 要去的 host url 的 path 部分的 metrisc 统计，和安全没有什么关系，你这个想复杂了。
+>
+> [RESPONSE] 已调整：指标不再依赖 allowedHosts，新增 target_path 维度，统计所有 fetch 目标的 host+path；与安全/allowedHosts 无关。
+> [STATUS:resolved]
+
+R6: 每个请求 MUST 仅计数一次，计数点 MUST 位于请求生命周期末尾（handler 已返回或抛错）。
+
+R7: `result` MUST 仅由 handler 的返回/抛错路径与既有错误语义决定；不得引入“写回成功”判定。
+
+## Data Model
+
+指标定义如下：
+
+- 名称: `http_proxy_target_host_requests_total`
+- 类型: Counter
+- Labels:
+  - `target_host`: 目标主机名或固定占位符
+  - `target_path`: URL path 或固定占位符
+  - `result`: 结果分类（见 Error Semantics）
+
+R9: 当 `parse_result` 不存在或 `parse_result.hostname` 为空字符串时，`target_host` MUST 为 `invalid`，`target_path` MUST 为 `invalid`。
+
+R10: 当 `parse_result.hostname` 被 `net.isIP` 判定为 IP 字面量时，`target_host` MUST 为 `ip`。
+
+R11: 其他情况，`normalized_host` MUST 由 `parse_result.hostname` 按“ASCII 小写 + 去尾点”规范化得到，并作为 `target_host`。
+
+R12: 当 `parse_result` 存在且 `parse_result.hostname` 非空时，`target_path` MUST 取 `parse_result.pathname`；若为空则 MUST 取 `/`。
+
+R13: 所有占位符值 MUST 为固定小集合：`ip`、`invalid`。
+
+## Error Semantics
+
+R17: 本 RFC MUST 复用现有错误语义，不得改变错误码与抛出逻辑。
+
+R18: 当 handler 抛错时，实现 MUST 计算 `effective_error_code`，来源按以下顺序尝试（仅限可检测字段）：`error.code`、`error.cause?.code`、`error.message` 的前缀（`CODE:` 形式）、`error.name`（仅用于 `AbortError`/`TimeoutError` 映射为 `TIMEOUT`）。
+
+事件 -> result 映射表：
+
+R19: 当 handler 抛错且 `effective_error_code` 命中以下集合时，`result` MUST 按表映射：
+
+| effective_error_code | result      |
+| -------------------- | ----------- |
+| TIMEOUT              | timeout     |
+| FORBIDDEN            | blocked     |
+| INVALID_URL          | invalid_url |
+| FETCH_FAILED         | error       |
+| RESPONSE_TOO_LARGE   | error       |
+
+R20: 当 handler 抛错且未命中 R19 时，`result` MUST 为 `error`。
+
+R21: 当 handler 正常返回且 URL 解析失败（`parse_result` 不存在）或 `parse_result.hostname` 为空时，`result` MUST 为 `invalid_url`。
+
+R22: 当 handler 正常返回且未命中 R21 时，`result` MUST 为 `ok`（无论上游状态码 2xx/4xx/5xx）。
+
+## Security Considerations
+
+R25: 指标 MUST NOT 记录原始 URL、路径、查询参数或 IP，避免泄露敏感信息。
+
+R26: 指标解析 MUST 复用现有 SSRF/请求解析结果，避免解析分歧导致安全绕过。
+
+R27: 指标采集与 `allowedHosts` 无关，记录所有 fetch 目标的 host/path；部署侧需自行承担开放代理与超时风险，并确保入口鉴权与限流策略。
+
+## Backward Compatibility & Rollout
+
+R28: 新指标为新增 Counter，不影响现有 `http_proxy_requests_total` 等指标；现有仪表盘 SHOULD 保持可用。
+
+R29: 本 RFC 不改变既有请求解析与 SSRF 行为；仅移除新增 scheme 白名单的要求，避免对请求行为产生新约束。
+
+R30: 新指标新增 `target_path` 标签，旧指标保持不变。
+
+R31: Rollout MAY 先在单个实例灰度，观察新指标时序与基数增长。
+
+R32: 回滚策略 MUST 同时删除指标注册与采集点，确保 metrics exposition 不再暴露该指标，避免空值误导。
+
+## Testability
+
+每条 MUST 行为均可映射到测试断言：
+
+- R1-R3: 指标解析仅复用 `parse_result`，不新增 scheme 过滤；`new URL` 失败触发 `invalid_url`。
+- R4-R7: 指标注册与计数位置固定，每请求仅计数一次。
+- R9-R13: `target_host`/`target_path` 规则可通过 label 断言验证。
+- R18-R24: `result` 映射闭合，支持 error.code/等价信号，IP 不默认 blocked。
+- R27-R32: 兼容/回滚行为与告警日志可验证。
+
+最小验证用例（至少 3 条）：
+
+1. allowedHosts 规范化命中
+
+   - 配置 `allowedHosts = ["Api.Example.Com."]`
+   - 请求 `http://api.example.com/v1/ping`
+   - 期望：`target_host="api.example.com"`，`target_path="/v1/ping"`，`result="ok"`
+
+2. 解析成功但 hostname 为空
+
+   - 请求 `raw_url="file:///etc/hosts"`
+   - 期望：`parse_result.hostname==""` 视为 `invalid_url`；`target_host="invalid"`，`target_path="invalid"`
+
+3. IP 字面量被 SSRF 阻断
+
+   - 请求 `http://127.0.0.1/`
+   - SSRF 阻断该请求且 handler 正常返回错误响应
+   - 期望：`target_host="ip"`，`result="blocked"`
+
+4. IP 字面量未被 SSRF 阻断
+
+   - 请求 `http://127.0.0.1/`
+   - SSRF 放行且 handler 正常返回
+   - 期望：`target_host="ip"`，`result="ok"`
+
+5. handler 抛错按 error.code 映射
+
+   - 任意请求触发 `newError('INVALID_URL')`
+   - 期望：`result="invalid_url"`（不再映射为 `error`）
+
+6. allowedHosts 含端口
+   - 配置 `allowedHosts=["api.example.com:443"]`
+   - 期望：该条永不匹配；若被 SSRF 阻断则 `result="blocked"`
+
+## Open Questions
+
+1. 是否需要在观测文档中明确“非 http/https 的 URL 仅按现有 handler 行为处理”，以避免误读为新增协议支持？
+
+2. 维度爆炸风险（预留方案 / TODO）
+   - 当前 `target_path` 可能导致高基数。
+   - 预留方案（未来可选）：
+     - 路径归一化：仅保留前 1-2 级路径；或对数字/UUID 段替换为 `:id`。
+     - 前缀过滤：仅统计特定路径前缀，其余归为 `other/overflow`。
+     - 分层指标：默认仅 `target_host`，`target_path` 作为 debug/短期排障开关。
+
+## Plan
+
+### 核心流程
+
+- 仅使用 `parse_result`（handler 内 `new URL(req.url)` 结果）计算 `target_host` 与 `target_path`；解析失败或 hostname 为空归 `invalid`。
+- `target_host` 规则：IP 字面量固定为 `ip`；非 IP 采用 `normalized_host`（ASCII 小写 + 去尾点）。
+- `target_path` 规则：使用 `parse_result.pathname`，为空则 `/`；解析失败或 hostname 为空时为 `invalid`。
+- `result` 以 handler 抛错的 `error.code`/等价信号映射（TIMEOUT/FORBIDDEN/FETCH_FAILED/INVALID_URL/RESPONSE_TOO_LARGE）；未命中为 `error`；正常返回时为 `ok`。
+
+### 接口定义
+
+- 无新增外部接口；新增 Prometheus Counter `http_proxy_target_host_requests_total`（labels: `target_host`, `result`）。
+
+### 文件变更明细
+
+- `libraries/http-services/src/server.ts`：新增指标定义与计数逻辑（复用 `parse_result`、SSRF 结果与 handler 返回/抛错）。
+- `docs/`（如需）：更新观测指标说明与示例。
+
+### 验证策略
+
+- 单测：覆盖 `new URL(req.url)` 解析失败/hostname 为空、allowedHosts 含端口告警与不匹配、IP 字面量 target_host 固定、`error.code` 映射与 SSRF 阻断语义。
+- 手工验证：灰度实例上发起不同目标域名/不同 scheme 请求，确认 `target_host` 仅为白名单或占位符，且不新增请求行为变化。

--- a/.legion/tasks/http-proxy-app-implementation/plan.md
+++ b/.legion/tasks/http-proxy-app-implementation/plan.md
@@ -11,7 +11,7 @@ RFC 为唯一设计真源：`.legion/tasks/http-proxy-app-implementation/docs/rf
 
 - 核心流程：仅依赖 `parse_result`，解析失败或 hostname 为空归 `invalid_url`；新增 `target_path` 维度；IP 字面量 `target_host=ip`；`result` 以 `error.code`/等价信号映射；生命周期末尾计数。
 - 接口变更：不新增外部接口，仅新增 Prometheus Counter `http_proxy_target_host_requests_total`（labels: `target_host`,`target_path`,`result`）。
-- 文件变更清单：`libraries/http-services/src/server.ts`（指标定义与采集点），必要时补充观测说明文档。
+- 文件变更清单：`libraries/http-services/src/server.ts`（指标定义与采集点）、`libraries/http-services/grafana-dashboard.json`（新增 target_host/target_path 面板），必要时补充观测说明文档。
 - 验证策略：单测覆盖 hostname 为空/解析失败、target_path 采集、`error.code` 映射（含 INVALID_URL/TIMEOUT/FORBIDDEN）、IP 不默认 blocked；手工验证 metrics 输出与基数控制。
 - TODO（后续评估）：若 `target_path` 导致高基数，考虑路径归一化/前缀过滤/分层指标策略。
 

--- a/.legion/tasks/http-proxy-app-implementation/plan.md
+++ b/.legion/tasks/http-proxy-app-implementation/plan.md
@@ -1,24 +1,19 @@
 # HTTP Proxy App Implementation
 
-## 目标
+TITLE: HTTP Proxy 目标域名指标 RFC
+SLUG: http-proxy-target-host-metrics
 
-Create a simple @yuants/app-http-proxy application that starts a terminal and registers an HTTP service using http-services.
+## 设计真源
 
-## 要点
+RFC 为唯一设计真源：`.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`。
 
-- Simple application wrapper around http-services
-- Registers as a Terminal
-- Exposes HTTP service capability
-- Configurable via Environment Variables
+## 摘要
 
-## 范围
-
-- apps/http-proxy
-
-## 阶段概览
-
-1. **Design** - 3 个任务
-2. **Implementation** - 2 个任务
+- 核心流程：仅依赖 `parse_result`，解析失败或 hostname 为空归 `invalid_url`；新增 `target_path` 维度；IP 字面量 `target_host=ip`；`result` 以 `error.code`/等价信号映射；生命周期末尾计数。
+- 接口变更：不新增外部接口，仅新增 Prometheus Counter `http_proxy_target_host_requests_total`（labels: `target_host`,`target_path`,`result`）。
+- 文件变更清单：`libraries/http-services/src/server.ts`（指标定义与采集点），必要时补充观测说明文档。
+- 验证策略：单测覆盖 hostname 为空/解析失败、target_path 采集、`error.code` 映射（含 INVALID_URL/TIMEOUT/FORBIDDEN）、IP 不默认 blocked；手工验证 metrics 输出与基数控制。
+- TODO（后续评估）：若 `target_path` 导致高基数，考虑路径归一化/前缀过滤/分层指标策略。
 
 ---
 

--- a/.legion/tasks/http-proxy-app-implementation/tasks.md
+++ b/.legion/tasks/http-proxy-app-implementation/tasks.md
@@ -4,7 +4,7 @@
 
 **当前阶段**: 阶段 2 - Implementation
 **当前任务**: (none)
-**进度**: 6/6 任务完成
+**进度**: 10/10 任务完成
 
 ---
 
@@ -17,18 +17,106 @@
 
 ---
 
-## 阶段 2: Implementation ✅ COMPLETED
+## 阶段 2: Implementation 🟡 IN PROGRESSD
 
 - [x] Initialize package @yuants/app-http-proxy | 验收: Package structure created and dependencies added
 - [x] Implement core logic | 验收: Application starts and registers HTTP service
-- [x] Walkthrough 报告生成完成 | 验收: docs/report-walkthrough.md 与 docs/pr-body.md 已生成
+- [x] Walkthrough 报告生成完成 | 验收: docs/report-walkthrough-metrics.md 与 docs/pr-body-metrics.md 已生成
 
 ---
 
 ## 发现的新任务
 
 - [x] 测试执行（构建验证）失败已修复：移除 tsconfig 中 `heft-jest` 类型引用并通过 `rushx build` | 来源: 测试阶段
+- [x] RFC 生成完成（简化版） | 验收: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md` 已生成
+- [x] RFC metrics 修订完成（收敛版） | 验收: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md` 已更新
+- [x] RFC metrics 修订：result 映射与 hostname/allowedHosts/timeout 语义更新 | 验收: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md` 已覆盖修订
+- [x] RFC metrics：明确 URL 解析来源优先级与失败边界（绝对 URL vs Host 头拼接） | 来源: RFC 对抗审查
+- [x] RFC metrics：定义 allowedHosts 匹配语义（精确/通配/大小写/尾点/IDN） | 来源: RFC 对抗审查
+- [x] RFC metrics：补齐 result 映射闭合规则与典型错误示例 | 来源: RFC 对抗审查
+- [x] RFC metrics：消除 IP 字面量与 allowedHosts 命中规则冲突 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：明确绝对 URL 与 Host 头冲突处理规则 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 复审完成（结论 NEEDS_CHANGES，输出 review-rfc-metrics.md） | 来源: RFC 复审
+- [x] RFC metrics 修订：明确 IP 请求必须 blocked 的语义与 result=blocked 映射 | 来源: RFC 复审
+- [x] RFC metrics 修订：补齐写回失败 result=error 与计数落点规则 | 来源: RFC 复审
+- [x] RFC metrics 修订：明确 Host 头解析失败边界与反例测试 | 来源: RFC 复审
+- [x] RFC metrics 复审完成（结论 NEEDS_CHANGES，输出 review-rfc-metrics.md） | 来源: RFC 复审
+- [x] RFC metrics：明确 invalid_url 时 target_host=invalid 且不进白名单 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：raw_url 含 scheme 但解析失败时不回退 host_header | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：绝对 URL 解析成功但 hostname 为空视为 invalid_url | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 复审完成（结论 NEEDS_CHANGES，输出 review-rfc-metrics.md） | 来源: RFC 复审
+- [x] RFC metrics 修订：明确 CONNECT/authority-form 与 star-form 行为一致性 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 修订：定义 blocked/invalid_url 写回失败优先级为 result=error | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 修订：澄清 allowedHosts 为空语义或强制非空 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：定义“无需写回”或移除该语义并统一写回判定 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：对齐 CONNECT/star-form 处理与现有实现并补充测试断言 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：定义 raw_url 以 "//" 开头的处理规则 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：限定 host_header 拼接仅支持 origin-form（raw_url 以 "/" 开头） | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：明确写回成功判定以保证 result 可验证 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 修订：对齐 allowedHosts 为空的 fail-fast 语义并更新指标注册条件 | 来源: RFC 复审
+- [x] RFC metrics 修订：补充 host_header 非法字符拒绝规则（userinfo/fragment 等） | 来源: RFC 复审
+- [x] RFC metrics：明确 absolute-form 非 ASCII/IDN 处理规则并补测试 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：定义 ip_literal 识别算法（含 IPv6 zone/IPvFuture） | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：要求 absolute-form 严格 scheme:// 并补测试 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 修订：Host 头匹配需大小写不敏感或先小写化 | 来源: RFC 对抗复审 NEEDS_CHANGES
+- [x] RFC metrics：收敛 ip_literal 识别规则，避免 '%' 误判 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：明确 allowedHosts 匹配忽略端口并补规范/测试 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：删除 scheme 额外配置假设或定义配置项 | 来源: RFC 对抗复审
+- [x] RFC metrics：补齐非 ASCII hostname 处理（明确 raw_url 级 ASCII 校验或允许 punycode）并同步示例/测试 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：明确 host_header IPv6/percent/zone/IPvFuture 的拒绝规则并统一与 absolute-form | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：补充 allowedHosts 为空 fail-fast 的现状证据或改为新行为并完善兼容/rollout | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：收紧 host_header IPv6 规则（拒绝 zone/IPvFuture/%） | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics 修订：明确 R10/R12 校验作用域或合并校验路径；补齐 ldh_hostname 长度边界或改为 URL 解析判定；澄清 allowedHosts fail-fast 与 metrics_enabled 的关系并更新兼容/rollout。 | 来源: RFC 复审 NEEDS_CHANGES
+- [ ] RFC metrics 对抗复审完成（结论 NEEDS_CHANGES，输出 review-rfc-metrics.md） | 来源: RFC 复审
+- [x] RFC metrics：明确 host_header 预处理顺序与 URL 构造字符串，消除 R12/R14 歧义 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：声明指标解析必须复用现有 SSRF/请求解析结果或引用同一解析函数，避免解析分歧 | 来源: RFC 复审 NEEDS_CHANGES
+- [ ] 写入 review-rfc-metrics.md（输出对抗复审报告） | 来源: RFC 对抗复审
+- [x] RFC metrics：明确 IP 字面量判定来源（复用 parse_result 或现有 SSRF 判定函数）并补测试 | 来源: RFC 对抗复审
+- [x] RFC metrics：明确 IP 判定复用 parsed_url + net.isIP，并补用例 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：补充 absolute-form-only 现有行为证据或改为以 parse_result 判定为准 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：明确 parse_result 的生产位置/字段与指标复用方式，避免重解析 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：固定 allowedHosts 缺失/非法时启动语义，并明确与 metrics_enabled 的关系与验证用例 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：明确 parse_result 来源/字段与复用位置 | 来源: RFC 复审 NEEDS_CHANGES
+- [x] RFC metrics：固定 allowedHosts 启动语义与 metrics_enabled 关系 | 来源: RFC 复审 NEEDS_CHANGES
+- [ ] RFC metrics：对齐 allowedHosts 缺失/非法时启动语义与实际实现，并补兼容/回滚说明 | 来源: RFC 对抗复审
+- [x] 设计审批通过（用户确认）- HTTP Proxy 目标域名指标 RFC | 来源: 用户确认选择 1（接受设计并进入实现）
+- [x] 测试执行（libraries/http-services `rushx build`）失败：invalid_url 结果映射错误需修复 | 来源: 测试阶段 ← CURRENT
+- [ ] 修复安全阻塞：allowedHosts 为空时开放代理风险（需 fail-fast/强限制） | 来源: review-security-metrics.md blocking
+- [ ] 修复安全阻塞：req.timeout 缺少上限导致 DoS 风险 | 来源: review-security-metrics.md blocking
+- [ ] 记录风险接受：allowedHosts 为空与 timeout 无上限的隔离前提（RFC R27a/R27b） | 来源: 用户选择方案 2
+- [x] 处理安全阻塞或明确 wontfix：allowedHosts 为空开放代理风险 | 来源: review-security-metrics.md FAIL
+- [x] 处理安全阻塞或明确 wontfix：req.timeout 无上限 DoS 风险 | 来源: review-security-metrics.md FAIL
+- [x] 处理 rfc-metrics review：去除 allowedHosts gating，新增 target_path 指标并同步实现与测试 | 来源: 用户 review
+- [x] 按 review 意见改码并补充单测（target_path + labels） | 来源: 用户要求子代理复审后修改
+- [ ] 评估 target_path 高基数风险：路径归一化/前缀过滤/分层指标方案 | 来源: 用户要求预留方案
+- [x] 移除 warnedAllowedHostsWithPort 并更新测试/RFC/plan | 来源: 用户反馈 unused
 
 ---
 
-_最后更新: 2026-01-28 16:26_
+_最后更新: 2026-02-03_
+6-02-03*
+�: 2026-02-03*
+6-02-03*
+3*
+_
+3_
+-03*
+3*
+\_
+
+-03*
+3*
+\_
+
+-03*
+3*
+\_
+
+-03*
+3*
+_
+-03_
+3\_
+_
+3_
+\_

--- a/.legion/tasks/vendor-http-services-rollout/context.md
+++ b/.legion/tasks/vendor-http-services-rollout/context.md
@@ -77,7 +77,7 @@
 
 ### 🟡 进行中
 
-- (暂无)
+- 切换到 http-proxy-app-implementation 任务，进入 http-proxy-metrics 设计阶段。
 
 ### ⚠️ 阻塞/待定
 

--- a/.legion/tasks/vendor-http-services-rollout/plan.md
+++ b/.legion/tasks/vendor-http-services-rollout/plan.md
@@ -6,7 +6,7 @@ SUBTREE_ROOT: apps
 
 ## 目标
 
-用新的 @yuants/http-services 替换 vendor HTTP fetch 调用，先在 vendor-binance 完成调研/文档/实现并通过验证，再按同方案推广至其他指定 vendor。
+为 HTTP Proxy 服务增加按目标域名统计的指标与采集方案，并在设计门禁后进入实现。
 
 ## 设计真源
 
@@ -14,11 +14,11 @@ SUBTREE_ROOT: apps
 
 ## 要点
 
-- 先聚焦 apps/vendor-binance 完成替换与验证，形成可复用的迁移模式
-- 调研现有 fetch 使用点、封装层与请求路径，明确替换边界与兼容风险
-- 输出 RFC + dev/test/bench/obs specs，包含迁移步骤、接口变更点、回滚策略
-- 实现阶段只改 binance；扩展到 okx/gate/hyperliquid/aster/bitget/huobi 作为后续阶段（需用户确认）
-- 新增：通过环境变量 USE_HTTP_PROXY 控制是否启用代理 fetch 覆盖，全局副作用需确认
+- 设计真源：/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md
+- 指标口径：按目标域名统计请求量、错误量与时延，兼容现有 http_proxy_requests_total/request_duration/errors/active
+- 高基数防护：仅在 allowedHosts 命中时打点或做域名归一化，避免放大 Prometheus label 基数
+- 验证方案：更新最小单测/集成验证说明，覆盖成功与错误路径
+- 不改动外部接口语义；必要时扩展 IHTTPProxyOptions/labels 以支持指标策略
 
 ## 范围
 

--- a/.legion/tasks/vendor-http-services-rollout/tasks.md
+++ b/.legion/tasks/vendor-http-services-rollout/tasks.md
@@ -51,6 +51,7 @@
 - [x] 实现 RFC 修复：缓存 \_\_yuantsNativeFetch/标记 proxy fetch，terminal public IP 跳过逻辑 | 来源: 用户批准设计，进入阶段 A
 - [x] 验证与审查：运行测试，review-code，review-security | 来源: 流程阶段 B
 - [x] 生成报告：report-walkthrough + PR body 建议 | 来源: 流程阶段 C
+- [ ] http-proxy-metrics 设计与 RFC 输出 | 来源: 用户指令：继续 http-proxy-metrics 并先完成设计
 
 ---
 

--- a/common/changes/@yuants/http-services/legion-feature-http-proxy-target-path-metrics_2026-02-04-08-06.json
+++ b/common/changes/@yuants/http-services/legion-feature-http-proxy-target-path-metrics_2026-02-04-08-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/http-services",
+      "comment": "add metrics",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/http-services"
+}

--- a/libraries/http-services/grafana-dashboard.json
+++ b/libraries/http-services/grafana-dashboard.json
@@ -378,6 +378,80 @@
       ],
       "title": "Response Codes Breakdown",
       "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 11,
+      "options": {
+        "displayLabels": ["target_host"],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Value",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (target_host) (rate(http_proxy_target_host_requests_total{target_host=~\"$target_host\", target_path=~\"$target_path\"}[$__rate_interval])))",
+          "legendFormat": "{{ target_host }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests by Target Host",
+      "type": "bargauge"
+    },
+    {
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 12,
+      "options": {
+        "displayLabels": ["target_path"],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Value",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(10, sum by (target_path) (rate(http_proxy_target_host_requests_total{target_host=~\"$target_host\", target_path=~\"$target_path\"}[$__rate_interval])))",
+          "legendFormat": "{{ target_path }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests by Target Path",
+      "type": "bargauge"
     }
   ],
   "refresh": "10s",
@@ -447,6 +521,58 @@
         "options": [],
         "query": {
           "query": "label_values(http_proxy_requests_total, hostname)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_proxy_target_host_requests_total, target_host)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Target Host",
+        "multi": true,
+        "name": "target_host",
+        "options": [],
+        "query": {
+          "query": "label_values(http_proxy_target_host_requests_total, target_host)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(http_proxy_target_host_requests_total, target_path)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Target Path",
+        "multi": true,
+        "name": "target_path",
+        "options": [],
+        "query": {
+          "query": "label_values(http_proxy_target_host_requests_total, target_path)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## What

- Add target host/path metrics for HTTP proxy requests in `@yuants/http-services`

## Why

- Provide visibility into downstream target distribution and error patterns per host/path

## How

- Register `http_proxy_target_host_requests_total` with `target_host`, `target_path`, `result` labels
- Map results from existing handler error codes; derive host/path from `new URL(req.url)` parse result
- Extend tests to cover target_path defaulting, labels propagation, and invalid_url cases

## Testing

- `cd libraries/http-services && rushx build`

## Risk / Rollback

- Risk: `target_path` may increase metric cardinality; monitor and apply normalization/filters if needed
- Rollback: remove the `http_proxy_target_host_requests_total` registration and sampling logic

## Links

- RFC: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
- Walkthrough: `.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md`