### PR TITLE
fix(http-services): await proxy ip readiness

### DIFF
--- a/.legion/config.json
+++ b/.legion/config.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "currentTask": "vendor-tokenbucket-proxy-ip",
+  "currentTask": "http-services-terminalinfos-ready",
   "settings": {
     "autoRemind": true,
     "remindBeforeReset": true,
@@ -220,9 +220,16 @@
     {
       "id": "vendor-tokenbucket-proxy-ip",
       "name": "vendor-tokenbucket-proxy-ip",
-      "status": "active",
+      "status": "paused",
       "createdAt": "2026-02-03T16:40:42.595Z",
-      "updatedAt": "2026-02-05T06:27:27.061Z"
+      "updatedAt": "2026-02-05T11:41:19.733Z"
+    },
+    {
+      "id": "http-services-terminalinfos-ready",
+      "name": "http-services-terminalinfos-ready",
+      "status": "active",
+      "createdAt": "2026-02-05T11:41:19.733Z",
+      "updatedAt": "2026-02-05T13:24:43.631Z"
     }
   ],
   "pendingProposals": [
@@ -2634,6 +2641,76 @@
       "decidedAt": "2026-02-03T16:40:42.595Z",
       "decidedBy": "Claude",
       "createdTaskId": "vendor-tokenbucket-proxy-ip"
+    },
+    {
+      "id": "proposal-ml9dxxr3-c0aac3",
+      "name": "http-services-terminalinfos-ready",
+      "goal": "为 HTTP proxy IP 选择引入 terminalInfos$ 就绪 gate，避免进程启动阶段 selectHTTPProxyIpRoundRobin 失败，并统一生命周期管理策略。",
+      "rationale": "当前进程刚启动时 terminal.terminalInfos$ 尚未首发，selectHTTPProxyIpRoundRobin 直接从空池选择会抛错，导致依赖链路（如 http-services selectHTTPProxyRoundRobin）启动失败；需要提供可等待的就绪路径并更新调用点。",
+      "points": [
+        "梳理 terminal 加入 host 后的事件链路（GetTerminalInfos + HostEvent/TERMINAL_CHANGE）并作为就绪判断依据",
+        "在 @yuants/http-services 增加异步选择 helper（方案 A）并保留同步 API",
+        "更新各 vendor 调用点改为等待就绪后选择 proxy ip",
+        "补充超时/错误语义与观测（最小日志）"
+      ],
+      "scope": [
+        "libraries/http-services/src/proxy-ip.ts",
+        "libraries/http-services/src/index.ts",
+        "apps/vendor-binance/src/api/client.ts",
+        "apps/vendor-aster/src/api/public-api.ts",
+        "apps/vendor-aster/src/api/private-api.ts",
+        "apps/vendor-bitget/src/api/client.ts",
+        "apps/vendor-gate/src/api/http-client.ts",
+        "apps/vendor-huobi/src/api/public-api.ts",
+        "apps/vendor-huobi/src/api/private-api.ts",
+        "apps/vendor-hyperliquid/src/api/client.ts",
+        "apps/vendor-okx/src/api/public-api.ts",
+        "apps/vendor-okx/src/api/private-api.ts"
+      ],
+      "phases": [
+        {
+          "name": "调研",
+          "tasks": [
+            {
+              "description": "梳理 terminal 初始化与 terminalInfos$ 更新路径（GetTerminalInfos + HostEvent），明确就绪条件与可能的空池情形。",
+              "acceptance": "context.md 记录：事件链路、首次可用时机与空池边界条件。"
+            }
+          ]
+        },
+        {
+          "name": "设计",
+          "tasks": [
+            {
+              "description": "定义异步选择 API（输入/输出/超时/错误语义）与调用点改造方案（方案 A）。",
+              "acceptance": "RFC 明确 API 形态、等待策略、错误码/日志与调用点调整清单。"
+            }
+          ]
+        },
+        {
+          "name": "实现",
+          "tasks": [
+            {
+              "description": "在 http-services 增加 async helper，并更新各 vendor 调用点使用新 API。",
+              "acceptance": "启动阶段不再因 terminalInfos$ 未就绪而抛 E_PROXY_TARGET_NOT_FOUND；功能行为保持一致。"
+            }
+          ]
+        },
+        {
+          "name": "验证",
+          "tasks": [
+            {
+              "description": "最小验证：相关包 typecheck/build 或指定 vendor 构建。",
+              "acceptance": "构建通过或给出可复现失败原因。"
+            }
+          ]
+        }
+      ],
+      "proposedBy": "Claude",
+      "proposedAt": "2026-02-05T11:40:53.152Z",
+      "status": "approved",
+      "decidedAt": "2026-02-05T11:41:19.733Z",
+      "decidedBy": "Claude",
+      "createdTaskId": "http-services-terminalinfos-ready"
     }
   ]
 }

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -2035,3 +2035,99 @@
 2026-02-05T05:36:43.094Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,setCurrentTask: CI 下禁用集成/E2E 测试（http-services integration）,success
 2026-02-05T05:37:02.388Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 在 http-services 集成测试中增加 CI/CI_RUN 跳过逻辑，避免 CI 运行 E2E/Integration。,success
 2026-02-05T06:27:27.073Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: Gate 测试在 HOST_URL 未设置时跳过，并延迟导入依赖，避免 fromNodeEnv 在测试加载阶段直接报错。,success
+2026-02-05T11:25:45.841Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-05T11:25:48.143Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-05T11:40:53.161Z,legion_propose_task,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,name: http-services-terminalinfos-ready,success
+2026-02-05T11:41:19.744Z,legion_approve_proposal,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,proposalId: proposal-ml9dxxr3-c0aac3,success
+2026-02-05T11:41:36.860Z,legion_switch_task,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,taskId: http-services-terminalinfos-ready,success
+2026-02-05T11:41:40.283Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T11:41:57.195Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 就绪判断以 terminalInfos$ 首发为准，空池发生在 GetTerminalInfos 尚未返回时。,success
+2026-02-05T11:42:06.750Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 方案 A 在 http-services 提供异步选择 helper；调用点改为 await 等待就绪后再选 ip。,success
+2026-02-05T11:42:10.208Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: apps/host/src/host-manager.ts,success
+2026-02-05T11:42:14.322Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: libraries/protocol/src/terminal.ts,success
+2026-02-05T11:42:18.075Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,completeTask: phase 1,success
+2026-02-05T11:42:25.837Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:42:32.212Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T11:44:25.104Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:46:00.366Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:48:42.716Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/review-rfc.md,success
+2026-02-05T11:50:23.956Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"addDecision: timeoutMs <= 0 视为立即超时；超时错误使用 newError('E_PROXY_TARGET_NOT_FOUND', { reason, terminal_id, timeoutMs }) 并按 terminal_id 限频日志（interval=3_600_000ms）。",success
+2026-02-05T11:50:30.423Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 空池语义定义为 terminalInfos$ 不可用或 proxyCandidates 为空；proxyCandidates 非空但 ip pool 为空则进入等待并可能超时。,success
+2026-02-05T11:50:50.528Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:50:53.018Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T11:52:05.614Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 完成 RFC 对抗审查并输出 review-rfc.md,success
+2026-02-05T11:52:48.119Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 完成 RFC 对抗审查并形成必须修正/可选优化清单（见 review-rfc.md）。,success
+2026-02-05T11:52:48.139Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDiscoveredTask: 修订 RFC：收敛空池/timeout 语义与 terminalInfos$ 判定、统一错误结构与限频来源、补齐调用点清单。,success
+2026-02-05T11:53:42.845Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,handoff: 按审查建议修订 RFC：选择空池/timeout 语义策略（A:声明不变量或B:空池统一等待），明确 terminalInfos$ 判定条件或移除分支。,success
+2026-02-05T11:54:38.680Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 空池语义收敛：仅在 terminalInfos$ 不可用时返回 empty_pool，其余空池一律等待至 timeout。,success
+2026-02-05T11:54:46.716Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:58:05.776Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: timeout 语义明确为“等待窗口内未出现任何可用 ip（含未就绪与无代理）”，empty_pool 仅用于 terminalInfos$ 不可用的防御分支。,success
+2026-02-05T11:58:10.991Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:59:43.016Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T11:59:47.615Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 完成最新 RFC 对抗审查，阻塞项聚焦 timeout 成本说明、terminalInfos$ 判定统一、错误 payload 同构、限频常量来源、调用点清单生成方法。,success
+2026-02-05T11:59:52.733Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDiscoveredTask: 修订 RFC：补充无代理配置下 timeout 成本与策略；统一 terminalInfos$ 判定条件；统一错误 payload 字段；明确限频常量定义/导出来源；补齐调用点清单生成方法与排除项。,success
+2026-02-05T12:00:43.516Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 允许调用点通过 timeoutMs 控制等待成本，含 timeoutMs=0 快速失败策略。,success
+2026-02-05T12:00:52.139Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:03:08.795Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDiscoveredTask: 修订RFC：量化无代理配置下timeout成本并给出调用点策略；统一terminalInfos$判定规范或删分支；明确错误payload契约与terminal_id缺失规则；注明限频常量定义/引用方式；完善调用点清单生成与排除规则。,success
+2026-02-05T12:03:08.796Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 完成本次对抗审查，聚焦空池/timeout成本、terminalInfos$判定一致性、错误payload同构、限频常量来源、调用点清单方法。,success
+2026-02-05T12:03:51.280Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:03:55.880Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDiscoveredTask: 修订 RFC：补充无代理配置下 timeout 成本与调用点策略；给出 terminalInfos$ 可用性唯一判定定义；封闭错误 payload 同构契约；明确限频常量定义/复用方式；扩展调用点清单生成方法与排除规则。,success
+2026-02-05T12:04:36.684Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: terminalInfos$ 可用性判定统一为 `terminal.terminalInfos$ != null` 且 `typeof terminal.terminalInfos$?.subscribe === 'function'`。,success
+2026-02-05T12:04:41.322Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"addDecision: 所有失败路径统一错误契约 `newError('E_PROXY_TARGET_NOT_FOUND', { reason, terminal_id, timeoutMs })`，terminal_id 缺失统一写入 'unknown'。",success
+2026-02-05T12:04:44.762Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 运行策略：USE_HTTP_PROXY=true 默认等待 10s；无代理配置时允许调用点传 timeoutMs=0/更短以快速失败。,success
+2026-02-05T12:04:48.450Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 补充 RFC：新增错误契约与运行策略段落，统一 terminalInfos$ 可用性定义，完善清单生成方法。,success
+2026-02-05T12:04:55.560Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:04:58.506Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T12:05:54.053Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 对抗审查结论：历史必修项已在 RFC 中覆盖，但新增阻塞项为 timeoutMs 合理性校验缺乏可执行边界，需修订后方可闭环。,success
+2026-02-05T12:06:21.225Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDiscoveredTask: 修订 RFC：为 timeoutMs 合理性校验补充明确边界与处理策略（NaN/Infinity/上限），或删除该 MUST 条款以确保可实现/可验证。,success
+2026-02-05T12:07:52.969Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: timeoutMs 在内部规范化为有限非负值（NaN/Infinity/负数 -> 0），并在错误 payload 中使用规范化值。,success
+2026-02-05T12:07:59.831Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:19:04.713Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 完成最新 RFC 对抗审查（基于 .legion/tasks/http-services-terminalinfos-ready/docs/rfc.md），结论无必须修正项，允许推进。,success
+2026-02-05T12:19:07.650Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addTask: RFC 对抗审查完成（本次审查结论通过，无必修项）。,success
+2026-02-05T12:19:14.159Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 完成最新 RFC 对抗审查（.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md），未发现必须修正项；仅给出可选优化建议。,success
+2026-02-05T12:19:37.164Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:20:27.963Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 记录审查结论：无必须修正项，允许通过；争议点仅为可选优化方向。,success
+2026-02-05T12:20:28.054Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addTask: 更新 RFC 审查状态：无必修项，结论通过。,success
+2026-02-05T12:20:31.706Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 准备写入 review-rfc.md 覆盖旧内容。,success
+2026-02-05T12:20:31.762Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addTask: 写入 review-rfc.md 新审查报告。,success
+2026-02-05T12:20:48.450Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 尝试使用写入工具更新 review-rfc.md。,success
+2026-02-05T12:20:53.841Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 若写入工具可用，将覆盖 review-rfc.md。,success
+2026-02-05T12:20:53.842Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addTask: 等待写入工具可用以更新 review-rfc.md。,success
+2026-02-05T12:20:57.826Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 准备直接使用 write 工具覆盖 review-rfc.md。,success
+2026-02-05T12:21:07.191Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addTask: 覆盖 review-rfc.md 内容以反映通过结论。,success
+2026-02-05T12:21:07.192Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 准备覆盖 review-rfc.md 内容以反映最新审查结论。,success
+2026-02-05T12:21:11.706Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 准备调用 write 工具（若可用）覆盖 review-rfc.md。,success
+2026-02-05T12:21:21.478Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 开始写入 review-rfc.md 新内容。,success
+2026-02-05T12:21:21.560Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addTask: 写入 review-rfc.md（等待写入工具支持）。,success
+2026-02-05T12:22:11.205Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: RFC 对抗审查通过，未发现必须修正项。,success
+2026-02-05T12:23:09.358Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 设计阶段完成：RFC 与对抗审查已通过，等待用户确认进入实现。,success
+2026-02-05T12:32:33.092Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,setCurrentTask: 按用户要求调整 RFC：timeout 固定 30 秒且调用点不传参。,success
+2026-02-05T12:32:38.853Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addConstraint: 用户要求：调用点不传入 timeout 参数，等待窗口固定 30 秒。,success
+2026-02-05T12:32:47.572Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:35:28.325Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:39:11.225Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 修订 RFC：补充迁移验收闭环（rg 校验与调用点无参数约束）。,success
+2026-02-05T12:39:17.750Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:40:10.922Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 完成本轮 RFC 对抗审查：确认迁移验收闭环可执行且无必须修正项；仅保留可选优化建议。,success
+2026-02-05T12:40:13.943Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,completeTask: 修订 RFC：补充迁移验收闭环（rg 校验仅剩 benchmarks 且无 timeout 参数）。,success
+2026-02-05T12:41:20.843Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 对抗审查通过（固定 30 秒版本），无必须修正项。,success
+2026-02-05T12:44:13.108Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:44:31.851Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addDecision: 用户已确认进入实现阶段（并要求 timeout 固定 30 秒）。,success
+2026-02-05T12:44:34.954Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,completeTask: phase 2,success
+2026-02-05T12:44:47.541Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:44:49.539Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T12:47:10.823Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T12:47:14.180Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T13:04:45.575Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,setCurrentTask: phase 3,success
+2026-02-05T13:05:04.616Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T13:05:06.655Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T13:05:07.436Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T13:06:58.769Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T13:07:07.459Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 最小验证：在 libraries/http-services 运行 `rushx build`（heft build+jest）。构建与测试通过；API Extractor 提示签名变更并更新 etc/http-services.api.md；有 TS/Node 版本兼容性警告但不影响本次通过。,success
+2026-02-05T13:07:10.655Z,legion_update_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,completeTask: phase 4,success
+2026-02-05T13:09:32.576Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-05T13:09:35.713Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-05T13:11:05.520Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/review-code.md,success
+2026-02-05T13:11:14.265Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/review-security.md,success
+2026-02-05T13:11:19.363Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md,success
+2026-02-05T13:11:25.140Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/pr-body.md,success
+2026-02-05T13:24:43.640Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 已推送分支 `legion/http-services-terminalinfos-ready` 并创建 PR：https://github.com/No-Trade-No-Life/Yuan/pull/2565。,success

--- a/.legion/tasks/http-services-terminalinfos-ready/context.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/context.md
@@ -1,0 +1,91 @@
+# http-services-terminalinfos-ready - 上下文
+
+## 会话进展 (2026-02-05)
+
+### ✅ 已完成
+
+- 梳理 terminalInfos$ 生命周期：Terminal 在 \_setupTerminalInfoStuff() 先 GetTerminalInfos，确认 @host 后写入 terminalInfos 与 \_terminalInfos$；随后订阅 HostEvent(TERMINAL_CHANGE) 增量更新；首次 next 发生在 GetTerminalInfos 成功之后。
+- 确认空池路径：selectHTTPProxyIpRoundRobin 同步读取 listHTTPProxyIps，依赖 terminal.terminalInfos；在 terminalInfos$ 首发前列表为空，直接抛 E_PROXY_TARGET_NOT_FOUND。
+- 修订 RFC：补齐 terminalInfos$ 可用判定、空池/timeout 语义、错误结构、日志限频细节与调用点清单。
+- 完成 RFC 对抗审查并形成必须修正/可选优化清单（见 review-rfc.md）。
+- 完成本次对抗审查（聚焦空池/timeout、terminalInfos$ 判定、错误结构一致性、限频来源、调用点清单），更新 review-rfc.md。
+- 按二次审查意见调整 RFC：移除 proxyCandidates 立即失败分支，空池统一等待到 timeout，并补齐限频常量来源与 benchmarks 调用点说明。
+- 按三次审查意见修订 RFC：明确 timeout 覆盖语义、terminalInfos$ 判定条件、错误结构一致性与清单生成方法。
+- 完成最新 RFC 对抗审查，阻塞项聚焦 timeout 成本说明、terminalInfos$ 判定统一、错误 payload 同构、限频常量来源、调用点清单生成方法。
+- 补充 RFC：明确 timeout 语义成本说明（允许 timeoutMs=0/更短以快速失败），统一终端判定与错误 payload 约束。
+- 完成本次对抗审查，聚焦空池/timeout 成本、terminalInfos$判定一致性、错误 payload 同构、限频常量来源、调用点清单方法。
+- 补充 RFC：新增错误契约与运行策略段落，统一 terminalInfos$ 可用性定义，完善清单生成方法。
+- 完成最新 RFC 对抗审查并输出 review-rfc.md（覆盖旧内容），逐条质疑必要性/假设/边界/复杂度/替代方案。
+- 按最新审查补齐 timeoutMs 规范化规则与测试断言，修复 Observability 编号。
+- 完成最新 RFC 对抗审查（.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md），未发现必须修正项；仅给出可选优化建议。
+- 记录审查结论：无必须修正项，允许通过；争议点仅为可选优化方向。
+- 准备写入 review-rfc.md 覆盖旧内容。
+- 尝试使用写入工具更新 review-rfc.md。
+- 若写入工具可用，将覆盖 review-rfc.md。
+- 准备直接使用 write 工具覆盖 review-rfc.md。
+- 准备覆盖 review-rfc.md 内容以反映最新审查结论。
+- 准备调用 write 工具（若可用）覆盖 review-rfc.md。
+- 开始写入 review-rfc.md 新内容。
+- RFC 对抗审查通过，未发现必须修正项。
+- 设计阶段完成：RFC 与对抗审查已通过，等待用户确认进入实现。
+- 按用户要求调整 RFC：等待超时固定 30 秒且接口无 options，调用点不传参。
+- 完成本次对抗审查（聚焦固定 30 秒、错误语义、日志与迁移闭环），新增必须修正：补迁移验收闭环（rg/清单验证）；可选优化：调用点 guard 说明、empty_pool 日志策略。
+- 修订 RFC：补充迁移验收闭环（rg 校验与调用点无参数约束）。
+- 完成本轮 RFC 对抗审查：确认迁移验收闭环可执行且无必须修正项；仅保留可选优化建议。
+- 对抗审查通过（固定 30 秒版本），无必须修正项。
+- 最小验证：在 libraries/http-services 运行 `rushx build`（heft build+jest）。构建与测试通过；API Extractor 提示签名变更并更新 etc/http-services.api.md；有 TS/Node 版本兼容性警告但不影响本次通过。
+- 实现：新增 http-services 异步 proxy ip 选择（固定 30s），并将 vendor 调用点改为 await 版本。
+- 生成 code/security review 报告与 walkthrough/PR body。
+- 已推送分支 `legion/http-services-terminalinfos-ready` 并创建 PR：https://github.com/No-Trade-No-Life/Yuan/pull/2565。
+
+### ⚠️ 阻塞/待定
+
+(暂无)
+
+---
+
+## 关键文件
+
+- `.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md`
+
+---
+
+## 关键决策
+
+| 决策                                                                                                                                                                   | 原因                                                                                                                               | 替代方案                                                      | 日期       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------- |
+| 就绪判断以 terminalInfos$ 首发为准，空池发生在 GetTerminalInfos 尚未返回时。                                                                                           | terminalInfos$ 是 ReplaySubject，只有 GetTerminalInfos 成功后才首发；此前 terminal.terminalInfos 为空，导致同步 round-robin 失败。 | 仅依赖 terminal.terminalInfos 当前值（会出现空池）            | 2026-02-05 |
+| 方案 A 在 http-services 提供异步选择 helper；调用点改为 await 等待就绪后再选 ip。                                                                                      | 同步 API 无法等待 terminalInfos$ 首发，导致启动阶段失败；异步 helper 可统一等待逻辑并复用 servicesReady 语义。                     | 在各 app 入口统一等待 terminalInfos$ 首发（容易遗漏、耦合强） | 2026-02-05 |
+| timeoutMs 默认 10_000，超时统一抛 E_PROXY_TARGET_NOT_FOUND（reason=timeout）并记录最小日志。                                                                           | 启动阶段偶发延迟可被容忍；统一错误便于调用方处理。                                                                                 | 细分新错误码或返回空值                                        | 2026-02-05 |
+| 空池与超时统一错误码，但通过 reason 区分 empty_pool/timeout。                                                                                                          | 兼容现有处理逻辑，同时保留定位信息。                                                                                               | 维持无 reason 字段                                            | 2026-02-05 |
+| 超时日志限频复用现有 log interval 机制。                                                                                                                               | 避免高频噪音并保持可观测性。                                                                                                       | 每次超时都记录                                                | 2026-02-05 |
+| timeoutMs <= 0 视为立即超时；超时错误使用 newError('E_PROXY_TARGET_NOT_FOUND', { reason, terminal_id, timeoutMs }) 并按 terminal_id 限频日志（interval=3_600_000ms）。 | 统一错误结构便于调用侧区分 reason，并控制高频日志噪音。                                                                            | 不记录 reason 或每次超时都记录日志                            | 2026-02-05 |
+| 空池语义定义为 terminalInfos$ 不可用或 proxyCandidates 为空；proxyCandidates 非空但 ip pool 为空则进入等待并可能超时。                                                 | 区分“无代理终端配置”与“代理已存在但 ip 尚未就绪”的场景，避免误判。                                                                 | 首发后 ip 仍为空立即 empty_pool                               | 2026-02-05 |
+| 完成 RFC 对抗审查并输出 review-rfc.md                                                                                                                                  | 依据奥卡姆剃刀逐条质疑空池/timeout 语义、terminalInfos$ 可用性、错误结构与日志限频、调用点清单完整性；形成必须修正与可选优化清单。 | 无                                                            | 2026-02-05 |
+| 空池语义收敛：仅在 terminalInfos$ 不可用时返回 empty_pool，其余空池一律等待至 timeout。                                                                                | 避免假设 proxyCandidates 稳定性，统一等待语义与可验证性。                                                                          | 首发后 proxyCandidates 为空立即 empty_pool                    | 2026-02-05 |
+| timeout 语义明确为“等待窗口内未出现任何可用 ip（含未就绪与无代理）”，empty_pool 仅用于 terminalInfos$ 不可用的防御分支。                                               | 避免对“无代理”与“未就绪”做不可验证假设，减少语义歧义。                                                                             | 空池单独立即失败或引入更细 reason                             | 2026-02-05 |
+| 允许调用点通过 timeoutMs 控制等待成本，含 timeoutMs=0 快速失败策略。                                                                                                   | 在无代理配置场景下避免每次等待到默认超时，降低启动成本。                                                                           | 维持固定默认超时                                              | 2026-02-05 |
+| terminalInfos$ 可用性判定统一为 `terminal.terminalInfos$ != null` 且 `typeof terminal.terminalInfos$?.subscribe === 'function'`。                                      | 提供唯一实现与可测试判断，避免 pipe/subscribe 口径不一致。                                                                         | 删除该分支并将空池归入 timeout                                | 2026-02-05 |
+| 所有失败路径统一错误契约 `newError('E_PROXY_TARGET_NOT_FOUND', { reason, terminal_id, timeoutMs })`，terminal_id 缺失统一写入 'unknown'。                              | 保证错误 payload 同构、测试断言稳定。                                                                                              | 各分支使用不同字段或消息字符串                                | 2026-02-05 |
+| 运行策略：USE_HTTP_PROXY=true 默认等待 10s；无代理配置时允许调用点传 timeoutMs=0/更短以快速失败。                                                                      | 控制无代理环境下的等待成本。                                                                                                       | 固定等待默认超时                                              | 2026-02-05 |
+| 等待超时固定 30_000ms 且不可配置，异步接口无 options 参数，错误 payload 中 timeoutMs 固定为 30_000。                                                                   | 避免调用点配置漂移与不一致等待成本，保证协议简单可审。                                                                             | 保留 timeoutMs 参数或改为环境配置                             | 2026-02-05 |
+| 对抗审查结论：历史必修项已在 RFC 中覆盖，但新增阻塞项为 timeoutMs 合理性校验缺乏可执行边界，需修订后方可闭环。                                                         | RFC 出现 MUST 校验 timeoutMs 合理性但未给出数值范围/处理策略，导致不可实现与不可验证。                                             | 删除该 MUST 条款或将其降级为可选指导。                        | 2026-02-05 |
+| timeoutMs 在内部规范化为有限非负值（NaN/Infinity/负数 -> 0），并在错误 payload 中使用规范化值。                                                                        | 提供可执行边界，避免实现分歧。                                                                                                     | 删除 timeoutMs 合理性校验条款                                 | 2026-02-05 |
+| 完成最新 RFC 对抗审查（基于 .legion/tasks/http-services-terminalinfos-ready/docs/rfc.md），结论无必须修正项，允许推进。                                                | timeoutMs 规范化规则已补齐，错误契约、terminalInfos$ 判定与限频细节可实现且可验证。                                                | 继续保留阻塞并要求新增上限策略                                | 2026-02-05 |
+| 用户已确认进入实现阶段（并要求 timeout 固定 30 秒）。                                                                                                                  | 用户明确指令“动手实现”，视为设计批准。                                                                                             | 等待显式文字确认                                              | 2026-02-05 |
+
+---
+
+## 快速交接
+
+**下次继续从这里开始：**
+
+1. 如需纳入非 Scope 文件（.legion 任务文档、SESSION_NOTES 等），请明确确认是否纳入 PR。
+
+**注意事项：**
+
+- 当前 PR 仅包含 Scope 内代码与 http-services API Extractor 输出。
+
+---
+
+_最后更新: 2026-02-05 21:24 by Claude_

--- a/.legion/tasks/http-services-terminalinfos-ready/docs/pr-body.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/docs/pr-body.md
@@ -1,0 +1,30 @@
+## What
+
+为 http-services 增加 async proxy ip 选择与 terminalInfos$ 就绪等待，超时固定 30s，并将 vendor 调用点改为 await。
+
+## Why
+
+启动阶段 terminalInfos$ 未就绪时，同步 round-robin 会出现空池并抛错；async 等待可消除该类启动失败。
+
+## How
+
+- 新增 async helper 等待 terminalInfos$ 首发后选择 proxy ip。
+- 超时固定 30_000ms，错误契约保持一致。
+- vendor 调用点改为 await 版本。
+
+## Testing
+
+- `(cd libraries/http-services && rushx build)`
+
+## Risk / Rollback
+
+- Risk: 启动阶段可能等待最长 30s；无代理配置场景需关注启动延迟。
+- Rollback: 回退 async helper 与 vendor await 调用，恢复同步选择。
+- Review: code/security PASS。
+
+## Links
+
+- RFC: `.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md`
+- Walkthrough: `.legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md`
+- Review Code: `.legion/tasks/http-services-terminalinfos-ready/docs/review-code.md`
+- Review Security: `.legion/tasks/http-services-terminalinfos-ready/docs/review-security.md`

--- a/.legion/tasks/http-services-terminalinfos-ready/docs/review-code.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/docs/review-code.md
@@ -1,0 +1,14 @@
+# Code Review Report
+
+## 结论
+
+PASS
+
+## Blocking Issues
+
+- None.
+
+## 建议（非阻塞）
+
+- `libraries/http-services/src/proxy-ip.ts`：`waitForHTTPProxyIps` 每次调用都会订阅 `terminalInfos$` 并启动独立计时器；并发调用频繁时会增加订阅与计时器开销，可考虑在同一 `terminal_id` 上复用 in-flight Promise。
+- `libraries/http-services/src/proxy-ip.ts`：`listHTTPProxyIps` 使用 `terminal.terminalInfos$?.pipe` 判断可用性，而 RFC 约定用 `subscribe` 判定；可统一口径减少语义分叉。

--- a/.legion/tasks/http-services-terminalinfos-ready/docs/review-rfc.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/docs/review-rfc.md
@@ -1,0 +1,45 @@
+# RFC 对抗审查报告 - http-services terminalInfos$ 就绪等待
+
+RFC Path: `.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md`
+Output Path: `.legion/tasks/http-services-terminalinfos-ready/docs/review-rfc.md`
+
+## 结论
+
+- 迁移验收闭环已具备可执行检查（rg 校验 + 允许保留同步基准调用 + async 调用点约束），满足可验证性。
+- 必须修正：无。
+- 可实现/可验证/可回滚：满足。实现路径与回滚路径清晰可落地。
+
+## 必须修正
+
+- 无。
+
+## 可选优化（逐条质疑与最小化建议）
+
+1. 固定 30 秒等待是否必要
+
+- 质疑：假设所有 USE_HTTP_PROXY=true 的场景都能容忍 30s 等待，但无代理环境可能长期空等。
+- 最小化建议：在迁移验收中补一句“调用点必须保证 USE_HTTP_PROXY=true 或已确认存在 proxy”，作为运行前置条件，避免无意义等待。
+
+2. terminalInfos$ 不可用即 empty_pool 的边界假设
+
+- 质疑：假设该分支只用于非标准 Terminal/测试双场景，但未定义如何识别。
+- 最小化建议：测试计划增加一条“terminalInfos$ 不可用场景”用例，明确该分支只服务 stub/测试，避免误用。
+
+3. 仅 timeout 记录日志的可观测性假设
+
+- 质疑：假设 empty_pool 分支不需要可观测，但当 terminalInfos$ 结构被破坏时可能静默失败。
+- 最小化建议：仅在 empty_pool 分支增加一次性 debug/trace 级日志（不含 ip 字段），保持最小噪音。
+
+4. 迁移验收的扫描完整性假设
+
+- 质疑：仅靠 `rg "selectHTTPProxyIpRoundRobin"` 可能漏掉别名 re-export 或包装函数。
+- 最小化建议：补充 `rg "selectHTTPProxyIpRoundRobinAsync"` 确认无多参数调用与 `rg "from '@yuants/http-services'"` 复核导入口径，作为可选增强验证。
+
+5. async 化对调用链的隐性风险
+
+- 质疑：假设所有调用点都被正确 await，若漏 await 将回退为未等待的旧行为。
+- 最小化建议：迁移验收增加一次 TypeScript 编译或 lint 检查，确认无未 await 的 Promise 泄漏。
+
+## 回滚性检查
+
+- 回滚策略清晰：恢复同步调用点并移除/停用 async 导出。无额外不可逆依赖。

--- a/.legion/tasks/http-services-terminalinfos-ready/docs/review-security.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/docs/review-security.md
@@ -1,0 +1,16 @@
+# Security Review Report
+
+## 结论
+
+PASS
+
+## Blocking Issues
+
+- None.
+
+## 安全建议（非阻塞）
+
+- `libraries/http-services/src/proxy-ip.ts`：并发调用 `waitForHTTPProxyIps` 会各自订阅与计时，启动阶段高并发可能放大内存与计时器压力；可考虑复用等待 Promise 或合并订阅。
+- `apps/vendor-binance/src/api/client.ts`：`requestContext` 可由调用方注入，若需强制可信来源，可在入口限制或校验 `requestContext.ip` 的来源标记。
+- `apps/vendor-aster/src/api/private-api.ts`：抛错包含响应文本与参数，上游若直接日志输出可能暴露订单细节；建议在上层日志脱敏。
+- 需确认 HTTPProxy 服务端对 `labels.ip` 的鉴权/路由约束保持一致（不在本次改动范围）。

--- a/.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md
@@ -1,0 +1,210 @@
+# RFC: http-services terminalInfos$ 就绪等待与异步 proxy IP 选择
+
+## Abstract
+
+本文定义 @yuants/http-services 中 HTTP proxy IP 选择的“就绪等待”协议与异步 API，解决 terminalInfos$ 首发前 ip 池为空导致的启动失败。设计保留同步 API，通过新增异步 helper 和调用点改造实现无侵入迁移，并将等待超时固定为 30 秒且不可配置，提供可观测、可回滚、可测试的行为规范。
+
+## Motivation / 背景
+
+terminalInfos$ 的首次发射发生在 GetTerminalInfos 成功后；在启动阶段，terminal.terminalInfos 为空时同步选择逻辑会抛出 E_PROXY_TARGET_NOT_FOUND，导致请求上下文初始化失败。需要提供一种在 terminalInfos$ 首发并且 ip 池非空之后再返回的机制，同时不破坏已有同步 API。为避免调用点配置漂移，等待超时固定为 30 秒且无可覆盖参数。
+
+## Goals & Non-Goals / 目标与非目标
+
+**Goals**
+
+- 在 terminalInfos$ 首发前通过等待机制避免误判“无代理 ip”。
+- 保留同步 API，新增异步 API 并改造需要 proxy 的调用点。
+- 明确固定 30_000ms 超时、空池与日志语义，并提供可测试断言。
+
+**Non-Goals**
+
+- 不改变 terminalInfos$ 的生命周期管理与 HostEvent 订阅逻辑。
+- 不引入新的依赖或跨包基础设施。
+- 不统一改造所有 HTTP 客户端，仅修改需要 proxy ip 的 vendor 调用点。
+
+## Definitions / 术语
+
+- terminalInfos$: Terminal 内部 ReplaySubject，首次 next 在 GetTerminalInfos 成功后。
+- ip pool: listHTTPProxyIps(terminal) 过滤可信 ip 后的可用列表。
+- terminalInfos$ 可用性：`terminal.terminalInfos$ != null` 且 `typeof terminal.terminalInfos$?.subscribe === 'function'`。
+- selectHTTPProxyIpRoundRobin(terminal): 同步选择 ip，空池抛 E_PROXY_TARGET_NOT_FOUND。
+- waitForHTTPProxyIps(terminal): 新增异步等待 helper。
+
+## 现状问题
+
+- 启动阶段 terminalInfos$ 未首发时，listHTTPProxyIps 为空，selectHTTPProxyIpRoundRobin 直接抛 E_PROXY_TARGET_NOT_FOUND。
+- 该错误并非“真实无代理”，而是“尚未就绪”。
+
+## 方案 A 设计
+
+新增异步 helper 等待 terminalInfos$ 首发并重算 ip 列表；同时提供异步 round-robin 选择 API。同步 API 保持不变。
+
+### 接口定义
+
+```ts
+export function waitForHTTPProxyIps(terminal: Terminal): Promise<string[]>;
+
+export function selectHTTPProxyIpRoundRobinAsync(terminal: Terminal): Promise<string>;
+```
+
+固定超时常量：`TIMEOUT_MS = 30_000`（不可配置）。
+
+### Protocol Overview / 端到端流程
+
+1. 调用 waitForHTTPProxyIps 先执行 listHTTPProxyIps。
+2. 若列表非空，立即返回。
+3. 若 terminalInfos$ 不可用，立即抛 E_PROXY_TARGET_NOT_FOUND（reason=empty_pool）。
+4. 订阅 terminalInfos$；每次变更时重算 ip pool：
+   - ip pool 非空：返回结果。
+   - ip pool 仍为空：继续等待，直到超时。
+5. 超时仍未返回，抛 E_PROXY_TARGET_NOT_FOUND（reason=timeout）。
+6. selectHTTPProxyIpRoundRobinAsync 在 waitForHTTPProxyIps 成功后执行 round-robin 选择。
+
+### State Machine / 状态机
+
+状态：
+
+- Idle：尚未检查。
+- AwaitingInfos：已确认空池且已订阅 terminalInfos$。
+- Ready：ip 列表非空并返回。
+- TimedOut：超时失败。
+
+转移：
+
+- Idle -> Ready：首次 listHTTPProxyIps 非空。
+- Idle -> AwaitingInfos：首次 listHTTPProxyIps 为空且 terminalInfos$ 可用。
+- AwaitingInfos -> Ready：terminalInfos$ 变更后 ip 列表非空。
+- Idle/AwaitingInfos -> TimedOut：等待超过 30_000ms。
+
+## Data Model / 数据模型
+
+### 输入参数
+
+- 无可配置参数。
+
+### 输出/错误
+
+- 成功返回 string[] 或 string。
+- 失败统一抛 E_PROXY_TARGET_NOT_FOUND，使用 newError 结构化信息：
+- `newError('E_PROXY_TARGET_NOT_FOUND', { reason, terminal_id, timeoutMs })`
+- terminal_id 来源：`terminal.terminal_id`，若不可用则写入 `'unknown'`。
+- timeoutMs 固定为 30_000（不可配置）。
+- 所有失败路径（timeout/empty_pool）必须使用相同 payload 结构。
+
+## Error Contract / 错误契约
+
+- 唯一错误形态：`newError('E_PROXY_TARGET_NOT_FOUND', { reason, terminal_id, timeoutMs })`
+- timeoutMs 字段固定为 30_000。
+- reason 取值：`timeout` / `empty_pool`
+- terminal_id 缺失策略：一律写入 `'unknown'`
+- reason 可取：
+  - timeout: 等待窗口内未出现任何可用 ip（包含未就绪与无代理）。
+  - empty_pool: terminalInfos$ 不可用（无法订阅）。
+
+### 兼容策略
+
+- 同步 API 仍保留原行为与签名。
+- 异步 API 在 index.ts 导出，按需改造调用点。
+
+## Error Semantics / 错误语义
+
+timeout 语义覆盖“等待窗口内未出现可用 ip”的所有原因（含未就绪与无代理）。等待窗口固定为 30 秒，不允许调用点覆盖。
+
+R1. waitForHTTPProxyIps MUST 在首次 listHTTPProxyIps 非空时立即 resolve，不得订阅 terminalInfos$。
+R2. terminalInfos$ 不可用且初始空池时 MUST 立即以 newError('E_PROXY_TARGET_NOT_FOUND', { reason: 'empty_pool', terminal_id, timeoutMs: 30_000 }) reject；该分支用于非标准 Terminal/测试双场景的防御。
+R3. 订阅 terminalInfos$ 后，每次变更 MUST 重新计算 ip pool；若仍为空 MUST 继续等待直到超时。
+R4. 超时 MUST 以 newError('E_PROXY_TARGET_NOT_FOUND', { reason: 'timeout', terminal_id, timeoutMs: 30_000 }) reject，timeout 代表等待窗口内未出现可用 ip（包含未就绪与无代理）。
+R5. selectHTTPProxyIpRoundRobinAsync MUST 基于 waitForHTTPProxyIps 的结果执行 round-robin；若 waitForHTTPProxyIps 失败则原样抛出。
+R6. 超时日志 MUST 仅包含 terminal_id 与 timeoutMs，并对 terminal_id 维度限频。
+R7. 所有失败路径 MUST 使用相同错误 payload 结构，terminal_id 缺失一律写入 'unknown'，timeoutMs 固定为 30_000。
+
+## Observability / 观测
+
+- 仅在超时失败时记录日志（R6）。
+- 日志不包含 ip 列表或敏感字段。
+- 限频规则：以 terminal_id 为粒度，复用 `libraries/http-services/src/proxy-ip.ts` 既有常量 `MISSING_IP_LOG_INTERVAL = 3_600_000`，避免新增配置并与缺失 ip 日志保持一致。
+  - 说明：该常量已存在于 proxy-ip.ts 内部，无需新增导出；timeout 日志与缺失 ip 日志在同模块内复用。
+
+## Operational Guidance / 运行策略
+
+- 仅在 `USE_HTTP_PROXY=true` 的调用路径启用等待逻辑，预期存在 proxy 终端。
+- 等待窗口固定为 30 秒，调用点不得传参与覆盖；无 proxy 环境应避免触发该路径。
+- 基准/示例：benchmarks 保持同步调用，不引入等待成本。
+
+## Backward Compatibility & Rollout / 兼容性与灰度
+
+- 同步 API 不变；原调用点保持可编译。
+- 仅 vendor HTTP 请求上下文改为 async；不改动非 proxy 相关请求路径。
+- 可按 vendor 分批替换，支持灰度上线。
+
+## 迁移步骤
+
+1. 在 `libraries/http-services/src/proxy-ip.ts` 增加 waitForHTTPProxyIps 与 selectHTTPProxyIpRoundRobinAsync。
+2. 在 `libraries/http-services/src/index.ts` 导出新增 API。
+3. 全仓库基于 `rg "selectHTTPProxyIpRoundRobin"` 搜索调用点并逐一改造（或说明不改造原因）；当前清单：
+   - `apps/vendor-binance/src/api/client.ts`（2 处调用点）
+   - `apps/vendor-aster/src/api/public-api.ts`
+   - `apps/vendor-aster/src/api/private-api.ts`
+   - `apps/vendor-bitget/src/api/client.ts`
+   - `apps/vendor-gate/src/api/http-client.ts`
+   - `apps/vendor-huobi/src/api/public-api.ts`
+   - `apps/vendor-huobi/src/api/private-api.ts`
+   - `apps/vendor-hyperliquid/src/api/client.ts`
+   - `apps/vendor-okx/src/api/public-api.ts`
+   - `apps/vendor-okx/src/api/private-api.ts`
+   - `libraries/http-services/benchmarks/index.ts`（基准测试保留同步调用，无需等待）
+   - 清单生成方法：`rg "selectHTTPProxyIpRoundRobin"` 全仓库扫描，并辅以 `rg "from '@yuants/http-services'"` 复核别名导入；排除项需在清单中标注理由。
+4. 调用点不得再传 timeout 参数；移除所有 timeoutMs 相关覆写逻辑。
+5. 迁移验收（必须满足）：
+   - `rg "selectHTTPProxyIpRoundRobin"` 结果仅允许 `libraries/http-services/benchmarks/index.ts`。
+   - `selectHTTPProxyIpRoundRobinAsync` 仅以单一参数调用（不得出现第二参数）。
+   - vendor 调用点不再出现 timeoutMs/options 相关覆写逻辑。
+
+## Testability / 可测试性
+
+每条 MUST 行为可映射到测试断言：
+
+- R1: 初始 listHTTPProxyIps 非空时不订阅 terminalInfos$，直接返回结果。
+- R2: terminalInfos$ 不可用且空池时立即抛 E_PROXY_TARGET_NOT_FOUND，reason=empty_pool 且 timeoutMs=30_000。
+- R3: 订阅 terminalInfos$ 后 ip pool 仍为空则持续等待，直到超时。
+- R4: 超时后抛 E_PROXY_TARGET_NOT_FOUND，reason=timeout 且 timeoutMs=30_000。
+- R5: 异步 round-robin 仅在 waitForHTTPProxyIps 成功后执行。
+- R6: 超时日志只包含 terminal_id 与 timeoutMs 且按 terminal_id 限频。
+- R7: 所有失败路径错误 payload 同构，terminal_id 缺失写入 'unknown'。
+
+## 安全性与资源考虑 / Security Considerations
+
+- MUST 在成功或失败时释放 terminalInfos$ 订阅，避免资源泄漏。
+- 固定 30 秒等待窗口防止无界等待与滥用资源消耗。
+- 日志仅记录最小上下文，避免泄露代理信息。
+
+## 兼容性与迁移 / Backward Compatibility & Rollout
+
+- 保持同步 API 行为，避免影响未改造调用点。
+- 异步 API 新增不破坏现有导出结构。
+- 调用点签名变更为无 options 参数，确保不存在隐式超时覆盖。
+
+## 测试计划
+
+- 单元测试：覆盖 R1-R4 的等待与超时语义。
+- 单元测试：覆盖 terminalInfos$ 不可用的 empty_pool 分支（R2）。
+- 观测测试：验证超时日志限频与字段最小化（R6）。
+- 冒烟测试：选一至两个 vendor 启动并发起请求，确认不再因启动阶段抛 E_PROXY_TARGET_NOT_FOUND。
+
+## 风险与回滚
+
+- 风险：等待逻辑订阅未正确释放导致资源泄漏或重复订阅。
+- 风险：调用点 async 化导致上下游未 await。
+- 风险：固定 30 秒超时在无 proxy 环境下造成等待成本。
+- 回滚：恢复 vendor 调用点为同步 API，并移除/停用异步导出；确认启动阶段仍可能触发旧空池问题并接受该风险。
+
+## Open Questions / 未决项
+
+- (暂无)
+
+## Plan
+
+1. 核心流程：在 waitForHTTPProxyIps 内先 list，再基于 terminalInfos$ 订阅等待非空或 30_000ms 超时；selectHTTPProxyIpRoundRobinAsync 依赖该结果。
+2. 接口定义：新增 waitForHTTPProxyIps 与 selectHTTPProxyIpRoundRobinAsync，接口不带 options 参数，超时固定 30_000ms。
+3. 文件变更明细：仅改 `libraries/http-services/src/proxy-ip.ts`、`libraries/http-services/src/index.ts` 与列出的 vendor HTTP 调用点（移除 timeout 传参）。
+4. 验证策略：单元测试覆盖 R1-R4；超时日志限频验证；选定 vendor 冒烟验证启动阶段不再抛 E_PROXY_TARGET_NOT_FOUND。

--- a/.legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md
@@ -1,0 +1,73 @@
+# Walkthrough: http-services terminalInfos 就绪等待与 async proxy ip 选择
+
+## 目标与范围
+
+目标：为 HTTP proxy ip 选择引入 terminalInfos$ 就绪等待，避免启动阶段空池失败；新增 async 选择 helper，统一固定 30s 超时，并将 vendor 调用点改为 await。
+
+范围（Scope）：
+
+- libraries/http-services/src/proxy-ip.ts
+- libraries/http-services/src/index.ts
+- apps/vendor-binance/src/api/client.ts
+- apps/vendor-aster/src/api/public-api.ts
+- apps/vendor-aster/src/api/private-api.ts
+- apps/vendor-bitget/src/api/client.ts
+- apps/vendor-gate/src/api/http-client.ts
+- apps/vendor-huobi/src/api/public-api.ts
+- apps/vendor-huobi/src/api/private-api.ts
+- apps/vendor-hyperliquid/src/api/client.ts
+- apps/vendor-okx/src/api/public-api.ts
+- apps/vendor-okx/src/api/private-api.ts
+
+## 设计摘要
+
+- RFC：`.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md`
+- 新增 async helper：等待 terminalInfos$ 首发后重算 proxy ip 列表，非空返回，否则在 30s 内等待并统一超时语义。
+- 超时固定为 30_000ms 且不可配置，错误契约保持 `E_PROXY_TARGET_NOT_FOUND`，payload 统一包含 reason/terminal_id/timeoutMs。
+- vendor 调用点改为 await 版本，消除启动阶段 terminalInfos$ 未就绪导致的同步失败。
+
+## 改动清单（按模块/文件类型）
+
+- http-services：新增 async proxy ip 选择与等待逻辑，保留同步 API。
+- http-services 导出：补充 async API 导出。
+- vendor 调用点：将 proxy ip 选择从同步改为 await 调用。
+
+涉及文件：
+
+- libraries/http-services/src/proxy-ip.ts
+- libraries/http-services/src/index.ts
+- apps/vendor-binance/src/api/client.ts
+- apps/vendor-aster/src/api/public-api.ts
+- apps/vendor-aster/src/api/private-api.ts
+- apps/vendor-bitget/src/api/client.ts
+- apps/vendor-gate/src/api/http-client.ts
+- apps/vendor-huobi/src/api/public-api.ts
+- apps/vendor-huobi/src/api/private-api.ts
+- apps/vendor-hyperliquid/src/api/client.ts
+- apps/vendor-okx/src/api/public-api.ts
+- apps/vendor-okx/src/api/private-api.ts
+
+## 如何验证
+
+- 命令：`(cd libraries/http-services && rushx build)`
+- 预期：heft build + jest 通过（24/24）；API Extractor 可能提示签名变更但不影响通过。
+
+## benchmark 结果或门槛说明
+
+- 本次未运行 benchmark，未提供相关结果。
+
+## 可观测性（metrics/logging）
+
+- 超时与空池统一错误契约：`E_PROXY_TARGET_NOT_FOUND`，payload 包含 reason/terminal_id/timeoutMs（固定 30_000）。
+- 超时日志采用限频策略（按 terminal_id）。
+
+## 风险与回滚
+
+- 风险：调用点改为 await 后，启动阶段可能等待最长 30s；无代理配置场景需注意启动延迟。
+- 回滚：回退 http-services async helper 与 vendor 调用点 await 变更，恢复同步选择逻辑。
+- Review：code/security PASS。
+
+## 未决项与下一步
+
+- 如需扩大覆盖面，可在各 vendor 包运行 `rushx build` 或 `rushx test`。
+- 若需性能或等待成本评估，可补充 benchmark 与启动耗时统计。

--- a/.legion/tasks/http-services-terminalinfos-ready/plan.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/plan.md
@@ -1,0 +1,52 @@
+# http-services-terminalinfos-ready
+
+TITLE: HTTP Services terminalInfos Ready RFC
+SLUG: http-services-terminalinfos-ready
+
+## 目标
+
+为 HTTP proxy IP 选择引入 terminalInfos$ 就绪 gate，避免进程启动阶段 selectHTTPProxyIpRoundRobin 失败，并统一生命周期管理策略。
+
+## 要点
+
+- 梳理 terminal 加入 host 后的事件链路（GetTerminalInfos + HostEvent/TERMINAL_CHANGE）并作为就绪判断依据
+- 在 @yuants/http-services 增加异步选择 helper（方案 A）并保留同步 API
+- 更新各 vendor 调用点改为等待就绪后选择 proxy ip（接口无 options）
+- 固定等待超时为 30 秒且不可配置，补充错误语义与观测（最小日志）
+
+## 设计真源
+
+- RFC: `.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md`
+
+## 摘要
+
+- 核心流程：等待 terminalInfos$ 首发并重算 ip 列表，非空后返回或 30 秒超时失败。
+- 接口变更：新增 waitForHTTPProxyIps / selectHTTPProxyIpRoundRobinAsync，无 options 参数，保留同步 API。
+- 文件变更清单：proxy-ip.ts、index.ts、vendor HTTP 调用点（移除 timeout 传参）。
+- 验证策略：单测覆盖 R1-R4；超时日志限频；vendor 冒烟验证。
+
+## 范围
+
+- libraries/http-services/src/proxy-ip.ts
+- libraries/http-services/src/index.ts
+- apps/vendor-binance/src/api/client.ts
+- apps/vendor-aster/src/api/public-api.ts
+- apps/vendor-aster/src/api/private-api.ts
+- apps/vendor-bitget/src/api/client.ts
+- apps/vendor-gate/src/api/http-client.ts
+- apps/vendor-huobi/src/api/public-api.ts
+- apps/vendor-huobi/src/api/private-api.ts
+- apps/vendor-hyperliquid/src/api/client.ts
+- apps/vendor-okx/src/api/public-api.ts
+- apps/vendor-okx/src/api/private-api.ts
+
+## 阶段概览
+
+1. **调研** - 1 个任务
+2. **设计** - 1 个任务
+3. **实现** - 1 个任务
+4. **验证** - 1 个任务
+
+---
+
+_创建于: 2026-02-05 | 最后更新: 2026-02-05_

--- a/.legion/tasks/http-services-terminalinfos-ready/tasks.md
+++ b/.legion/tasks/http-services-terminalinfos-ready/tasks.md
@@ -1,0 +1,44 @@
+# http-services-terminalinfos-ready - 任务清单
+
+## 快速恢复
+
+**当前阶段**: (unknown)
+**当前任务**: (none)
+**进度**: 6/6 任务完成
+
+---
+
+## 阶段 1: 调研 ✅ COMPLETE
+
+- [x] 梳理 terminal 初始化与 terminalInfos$ 更新路径（GetTerminalInfos + HostEvent），明确就绪条件与可能的空池情形。 | 验收: context.md 记录：事件链路、首次可用时机与空池边界条件。
+
+---
+
+## 阶段 2: 设计 ✅ COMPLETE
+
+- [x] 定义异步选择 API（输入/输出/超时/错误语义）与调用点改造方案（方案 A）。 | 验收: RFC 明确 API 形态、等待策略、错误码/日志与调用点调整清单。
+- [x] RFC 生成完成。 | 验收: `.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md` 覆盖最新需求并可评审。
+- [x] RFC 对抗审查完成（聚焦固定 30 秒、错误语义、日志、迁移闭环）。 | 验收: `.legion/tasks/http-services-terminalinfos-ready/docs/review-rfc.md` 更新。
+
+---
+
+## 阶段 3: 实现 ✅ COMPLETE
+
+- [x] 在 http-services 增加 async helper，并更新各 vendor 调用点使用新 API。 | 验收: 启动阶段不再因 terminalInfos$ 未就绪而抛 E_PROXY_TARGET_NOT_FOUND；功能行为保持一致。
+
+---
+
+## 阶段 4: 验证 ✅ COMPLETE
+
+- [x] 最小验证：相关包 typecheck/build 或指定 vendor 构建。 | 验收: 构建通过或给出可复现失败原因。
+- [x] Walkthrough 报告生成完成。 | 验收: `.legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md` 与 `.legion/tasks/http-services-terminalinfos-ready/docs/pr-body.md` 生成。
+
+---
+
+## 发现的新任务
+
+(暂无)
+
+---
+
+_最后更新: 2026-02-05 21:07_

--- a/apps/vendor-aster/SESSION_NOTES.md
+++ b/apps/vendor-aster/SESSION_NOTES.md
@@ -117,6 +117,16 @@
 ### 2026-02-05 — OpenCode
 
 - **本轮摘要**：
+  - proxy IP 选择改为异步等待（固定 30s），public/private API 调用链改为 await 请求上下文。
+- **修改的文件**：
+  - `apps/vendor-aster/src/api/public-api.ts`
+  - `apps/vendor-aster/src/api/private-api.ts`
+- **运行的测试 / 检查**：
+  - 未运行（本次仅修改 proxy ip 选择链路）
+
+### 2026-02-05 — OpenCode
+
+- **本轮摘要**：
   - 修复 Aster tokenBucket 维度改为 ip 后的容量配置缺失问题，按 base bucket 复用相同限频参数，避免 `acquireSync(weight)` 直接失败。
 - **修改的文件**：
   - `apps/vendor-aster/src/api/client.ts`

--- a/apps/vendor-aster/src/api/private-api.ts
+++ b/apps/vendor-aster/src/api/private-api.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import {
   encodeHex,
   encodePath,
@@ -51,9 +51,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -192,7 +192,7 @@ const SpotBaseURL = 'https://sapi.asterdex.com';
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E8%B4%A6%E6%88%B7%E4%BF%A1%E6%81%AFv4-user_data
  */
-export const getFApiV4Account = (
+export const getFApiV4Account = async (
   credential: ICredential,
   params: Record<string, never>,
 ): Promise<{
@@ -250,7 +250,7 @@ export const getFApiV4Account = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -262,7 +262,7 @@ export const getFApiV4Account = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E7%94%A8%E6%88%B7%E6%8C%81%E4%BB%93%E9%A3%8E%E9%99%A9v2-user_data
  */
-export const getFApiV2PositionRisk = (
+export const getFApiV2PositionRisk = async (
   credential: ICredential,
   params: {
     symbol?: string;
@@ -288,7 +288,7 @@ export const getFApiV2PositionRisk = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -298,7 +298,7 @@ export const getFApiV2PositionRisk = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#L2840-L2855
  */
-export const getFApiV2Balance = (
+export const getFApiV2Balance = async (
   credential: ICredential,
   params: Record<string, never>,
 ): Promise<
@@ -318,7 +318,7 @@ export const getFApiV2Balance = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -328,7 +328,7 @@ export const getFApiV2Balance = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#post-fapiv1order-%E7%9A%84%E7%A4%BA%E4%BE%8B
  */
-export const postFApiV1Order = (
+export const postFApiV1Order = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -352,7 +352,7 @@ export const postFApiV1Order = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const secondBucketKey = buildTokenBucketKey('order/future/second', requestContext.ip);
   const minuteBucketKey = buildTokenBucketKey('order/future/minute', requestContext.ip);
   scopeError(
@@ -375,7 +375,7 @@ export const postFApiV1Order = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#L2728-L2766
  */
-export const getFApiV1OpenOrders = (
+export const getFApiV1OpenOrders = async (
   credential: ICredential,
   params: {
     symbol?: string;
@@ -385,7 +385,7 @@ export const getFApiV1OpenOrders = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = params?.symbol ? 1 : 40;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   scopeError(
     'ASTER_API_RATE_LIMIT',
     {
@@ -413,7 +413,7 @@ export const getFApiV1OpenOrders = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md#L1196-L1234
  */
-export const getApiV1OpenOrders = (
+export const getApiV1OpenOrders = async (
   credential: ICredential,
   params: {
     symbol?: string;
@@ -423,7 +423,7 @@ export const getApiV1OpenOrders = (
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = params?.symbol ? 1 : 40;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   scopeError(
     'ASTER_API_RATE_LIMIT',
     {
@@ -449,7 +449,7 @@ export const getApiV1OpenOrders = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#L2498-L2516
  */
-export const deleteFApiV1Order = (
+export const deleteFApiV1Order = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -461,7 +461,7 @@ export const deleteFApiV1Order = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const secondBucketKey = buildTokenBucketKey('order/future/second', requestContext.ip);
   const minuteBucketKey = buildTokenBucketKey('order/future/minute', requestContext.ip);
   scopeError(
@@ -484,7 +484,7 @@ export const deleteFApiV1Order = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md#%E8%B4%A6%E6%88%B7%E4%BF%A1%E6%81%AF-user_data
  */
-export const getApiV1Account = (
+export const getApiV1Account = async (
   credential: ICredential,
   params: Record<string, never>,
 ): Promise<{
@@ -504,7 +504,7 @@ export const getApiV1Account = (
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', SpotBaseURL, endpoint, params, requestContext);
 };
@@ -516,7 +516,7 @@ export const getApiV1Account = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md#%E6%9C%80%E6%96%B0%E4%BB%B7%E6%A0%BC
  */
-export const getApiV1TickerPrice = (
+export const getApiV1TickerPrice = async (
   credential: ICredential,
   params: Record<string, never>,
 ): Promise<
@@ -530,7 +530,7 @@ export const getApiV1TickerPrice = (
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = 2;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', SpotBaseURL, endpoint, params, requestContext);
 };
@@ -540,7 +540,7 @@ export const getApiV1TickerPrice = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md#post-apiv1order-%E7%9A%84%E7%A4%BA%E4%BE%8B
  */
-export const postApiV1Order = (
+export const postApiV1Order = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -558,7 +558,7 @@ export const postApiV1Order = (
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const secondBucketKey = buildTokenBucketKey('order/spot/second', requestContext.ip);
   const minuteBucketKey = buildTokenBucketKey('order/spot/minute', requestContext.ip);
   scopeError(
@@ -581,7 +581,7 @@ export const postApiV1Order = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md#L1040-L1074
  */
-export const deleteApiV1Order = (
+export const deleteApiV1Order = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -593,7 +593,7 @@ export const deleteApiV1Order = (
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const secondBucketKey = buildTokenBucketKey('order/spot/second', requestContext.ip);
   const minuteBucketKey = buildTokenBucketKey('order/spot/minute', requestContext.ip);
   scopeError(
@@ -616,7 +616,7 @@ export const deleteApiV1Order = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E8%8E%B7%E5%8F%96%E8%B4%A6%E6%88%B7%E6%8D%9F%E7%9B%8A%E8%B5%84%E9%87%91%E6%B5%81%E6%B0%B4user_data
  */
-export const getAccountIncome = (
+export const getAccountIncome = async (
   credential: ICredential,
   params: {
     symbol?: string;
@@ -643,7 +643,7 @@ export const getAccountIncome = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 30;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -655,7 +655,7 @@ export const getAccountIncome = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E8%B4%A6%E6%88%B7%E6%88%90%E4%BA%A4%E5%8E%86%E5%8F%B2-user_data
  */
-export const getAccountTradeList = (
+export const getAccountTradeList = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -688,7 +688,7 @@ export const getAccountTradeList = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit('GET', url, endpoint, weight, requestContext);
   return request(credential, 'GET', FutureBaseURL, endpoint, params, requestContext);
 };

--- a/apps/vendor-aster/src/api/public-api.ts
+++ b/apps/vendor-aster/src/api/public-api.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { GlobalPrometheusRegistry, Terminal } from '@yuants/protocol';
 import { encodePath, formatTime, scopeError, tokenBucket } from '@yuants/utils';
 
@@ -39,9 +39,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -106,7 +106,7 @@ const request = async <T>(
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E6%9F%A5%E8%AF%A2%E8%B5%84%E9%87%91%E8%B4%B9%E7%8E%87%E5%8E%86%E5%8F%B2
  */
-export const getFApiV1FundingRate = (params: {
+export const getFApiV1FundingRate = async (params: {
   symbol?: string;
   startTime?: number;
   endTime?: number;
@@ -122,7 +122,7 @@ export const getFApiV1FundingRate = (params: {
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit(url, endpoint, weight, requestContext);
   return request('GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -159,12 +159,12 @@ export interface IAsterExchangeInfo {
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E4%BA%A4%E6%98%93%E5%AF%B9%E4%BF%A1%E6%81%AF
  */
-export const getFApiV1ExchangeInfo = (params: Record<string, never>): Promise<IAsterExchangeInfo> => {
+export const getFApiV1ExchangeInfo = async (params: Record<string, never>): Promise<IAsterExchangeInfo> => {
   const endpoint = '/fapi/v1/exchangeInfo';
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit(url, endpoint, weight, requestContext);
   return request('GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -176,12 +176,12 @@ export const getFApiV1ExchangeInfo = (params: Record<string, never>): Promise<IA
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md#L1080-L1145
  */
-export const getApiV1ExchangeInfo = (params: Record<string, never>): Promise<IAsterExchangeInfo> => {
+export const getApiV1ExchangeInfo = async (params: Record<string, never>): Promise<IAsterExchangeInfo> => {
   const endpoint = '/api/v1/exchangeInfo';
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit(url, endpoint, weight, requestContext);
   return request('GET', SpotBaseURL, endpoint, params, requestContext);
 };
@@ -195,7 +195,7 @@ export const getApiV1ExchangeInfo = (params: Record<string, never>): Promise<IAs
  * Weight: 1
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Open-Interest
  */
-export const getFApiV1OpenInterest = (params: {
+export const getFApiV1OpenInterest = async (params: {
   symbol: string;
 }): Promise<{
   symbol: string;
@@ -206,7 +206,7 @@ export const getFApiV1OpenInterest = (params: {
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit(url, endpoint, weight, requestContext);
   return request('GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -218,7 +218,7 @@ export const getFApiV1OpenInterest = (params: {
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#%E6%9C%80%E6%96%B0%E4%BB%B7%E6%A0%BC
  */
-export const getFApiV1TickerPrice = (
+export const getFApiV1TickerPrice = async (
   params: Record<string, never>,
 ): Promise<
   {
@@ -231,7 +231,7 @@ export const getFApiV1TickerPrice = (
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 2;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit(url, endpoint, weight, requestContext);
   return request('GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -243,7 +243,7 @@ export const getFApiV1TickerPrice = (
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md
  */
-export const getFApiV1PremiumIndex = (params: {
+export const getFApiV1PremiumIndex = async (params: {
   symbol?: string;
 }): Promise<
   | {
@@ -271,7 +271,7 @@ export const getFApiV1PremiumIndex = (params: {
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   acquireRateLimit(url, endpoint, weight, requestContext);
   return request('GET', FutureBaseURL, endpoint, params, requestContext);
 };
@@ -300,7 +300,7 @@ export interface IAsterKline extends Array<string | number> {
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api_CN.md#k%E7%BA%BF%E6%95%B0%E6%8D%AE
  */
-export const getFApiV1Klines = (params: {
+export const getFApiV1Klines = async (params: {
   symbol: string;
   interval: string;
   startTime?: number;
@@ -311,7 +311,7 @@ export const getFApiV1Klines = (params: {
   const url = new URL(FutureBaseURL);
   url.pathname = endpoint;
   const weight = getKlinesRequestWeight(params?.limit);
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   scopeError(
     'ASTER_API_RATE_LIMIT',
     {
@@ -341,7 +341,7 @@ export const getFApiV1Klines = (params: {
  *
  * https://github.com/asterdex/api-docs/blob/master/aster-finance-spot-api_CN.md
  */
-export const getApiV1Klines = (params: {
+export const getApiV1Klines = async (params: {
   symbol: string;
   interval: string;
   startTime?: number;
@@ -352,7 +352,7 @@ export const getApiV1Klines = (params: {
   const url = new URL(SpotBaseURL);
   url.pathname = endpoint;
   const weight = getKlinesRequestWeight(params?.limit);
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   scopeError(
     'ASTER_API_RATE_LIMIT',
     {

--- a/apps/vendor-binance/SESSION_NOTES.md
+++ b/apps/vendor-binance/SESSION_NOTES.md
@@ -104,6 +104,17 @@
 ### 2026-02-05 — OpenCode
 
 - **本轮摘要**：
+  - proxy IP 选择改为异步等待（固定 30s），public/private API 调用链改为 await 请求上下文。
+- **修改的文件**：
+  - `apps/vendor-binance/src/api/client.ts`
+  - `apps/vendor-binance/src/api/public-api.ts`
+  - `apps/vendor-binance/src/api/private-api.ts`
+- **运行的测试 / 检查**：
+  - 未运行（本次仅修改 proxy ip 选择链路）
+
+### 2026-02-05 — OpenCode
+
+- **本轮摘要**：
   - 修复 Binance per-ip tokenBucket 未复用 base 限频参数的问题，避免 `acquireSync(weight)` 直接失败。
   - public/private API 的 per-ip bucket 统一使用 base bucket 的限频配置。
 - **修改的文件**：

--- a/apps/vendor-binance/src/api/client.ts
+++ b/apps/vendor-binance/src/api/client.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { GlobalPrometheusRegistry, Terminal } from '@yuants/protocol';
 import {
   encodeHex,
@@ -100,9 +100,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-export const createRequestContext = (): IRequestContext => {
+export const createRequestContext = async (): Promise<IRequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -185,9 +185,7 @@ const callApi = async <T>(
 
   MetricBinanceApiCounter.labels({ path: url.pathname, terminal_id: terminal.terminal_id }).inc();
 
-  const proxyIp = shouldUseHttpProxy
-    ? requestContext?.ip ?? selectHTTPProxyIpRoundRobin(terminal)
-    : undefined;
+  const proxyIp = shouldUseHttpProxy ? requestContext?.ip : undefined;
   const res = await fetchImpl(
     url.href,
     shouldUseHttpProxy

--- a/apps/vendor-binance/src/api/private-api.ts
+++ b/apps/vendor-binance/src/api/private-api.ts
@@ -258,11 +258,13 @@ export interface IAccountIncomeRecord {
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/account/Account-Information
  */
-export const getUnifiedAccountInfo = (credential: ICredential): Promise<IUnifiedAccountInfo | IApiError> => {
+export const getUnifiedAccountInfo = async (
+  credential: ICredential,
+): Promise<IUnifiedAccountInfo | IApiError> => {
   const endpoint = 'https://papi.binance.com/papi/v1/account';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -287,11 +289,13 @@ export const getUnifiedAccountInfo = (credential: ICredential): Promise<IUnified
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/account/Get-UM-Account-Detail
  */
-export const getUnifiedUmAccount = (credential: ICredential): Promise<IUnifiedUmAccount | IApiError> => {
+export const getUnifiedUmAccount = async (
+  credential: ICredential,
+): Promise<IUnifiedUmAccount | IApiError> => {
   const endpoint = 'https://papi.binance.com/papi/v1/um/account';
   const url = new URL(endpoint);
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -316,7 +320,7 @@ export const getUnifiedUmAccount = (credential: ICredential): Promise<IUnifiedUm
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/trade/Query-All-Current-UM-Open-Orders
  */
-export const getUnifiedUmOpenOrders = (
+export const getUnifiedUmOpenOrders = async (
   credential: ICredential,
   params?: {
     symbol?: string;
@@ -325,7 +329,7 @@ export const getUnifiedUmOpenOrders = (
   const endpoint = 'https://papi.binance.com/papi/v1/um/openOrders';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 1 : 40;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -352,7 +356,7 @@ export const getUnifiedUmOpenOrders = (
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/account/Account-Balance
  */
-export const getUnifiedAccountBalance = (
+export const getUnifiedAccountBalance = async (
   credential: ICredential,
   params?: {
     assets?: string;
@@ -361,7 +365,7 @@ export const getUnifiedAccountBalance = (
   const endpoint = 'https://papi.binance.com/papi/v1/balance';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -384,7 +388,7 @@ export const getUnifiedAccountBalance = (
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api#%E8%B4%A6%E6%88%B7%E4%BF%A1%E6%81%AF-user_data
  */
-export const getSpotAccountInfo = (
+export const getSpotAccountInfo = async (
   credential: ICredential,
   params?: {
     omitZeroBalances?: boolean;
@@ -393,7 +397,7 @@ export const getSpotAccountInfo = (
   const endpoint = 'https://api.binance.com/api/v3/account';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -410,7 +414,7 @@ export const getSpotAccountInfo = (
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/account-endpoints#%E6%9F%A5%E7%9C%8B%E8%B4%A6%E6%88%B7%E5%BD%93%E5%89%8D%E6%8C%82%E5%8D%95-user_data
  */
-export const getSpotOpenOrders = (
+export const getSpotOpenOrders = async (
   credential: ICredential,
   params?: {
     symbol?: string;
@@ -419,7 +423,7 @@ export const getSpotOpenOrders = (
   const endpoint = 'https://api.binance.com/api/v3/openOrders';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 6 : 80;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -444,7 +448,7 @@ export const getSpotOpenOrders = (
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/trading-endpoints#%E4%B8%8B%E5%8D%95-trade
  */
-export const postSpotOrder = (
+export const postSpotOrder = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -470,7 +474,7 @@ export const postSpotOrder = (
   const endpoint = 'https://api.binance.com/api/v3/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -493,7 +497,7 @@ export const postSpotOrder = (
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/trading-endpoints#%E6%92%A4%E9%94%80%E8%AE%A2%E5%8D%95-trade
  */
-export const deleteSpotOrder = (
+export const deleteSpotOrder = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -506,7 +510,7 @@ export const deleteSpotOrder = (
   const endpoint = 'https://api.binance.com/api/v3/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -527,7 +531,7 @@ export const deleteSpotOrder = (
  *
  * https://developers.binance.com/docs/zh-CN/wallet/asset/user-universal-transfer
  */
-export const postAssetTransfer = (
+export const postAssetTransfer = async (
   credential: ICredential,
   params: {
     type: string;
@@ -540,7 +544,7 @@ export const postAssetTransfer = (
   const endpoint = 'https://api.binance.com/sapi/v1/asset/transfer';
   const url = new URL(endpoint);
   const weight = 900;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -567,11 +571,11 @@ export const postAssetTransfer = (
  *
  * ISSUE(2024-07-18): 目前这是唯一能够将资金从原 U 本位合约账户转入统一账户的接口。
  */
-export const postUnifiedAccountAutoCollection = (credential: ICredential): Promise<{ msg: string }> => {
+export const postUnifiedAccountAutoCollection = async (credential: ICredential): Promise<{ msg: string }> => {
   const endpoint = 'https://papi.binance.com/papi/v1/auto-collection';
   const url = new URL(endpoint);
   const weight = 750;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -590,7 +594,7 @@ export const postUnifiedAccountAutoCollection = (credential: ICredential): Promi
  *
  * https://developers.binance.com/docs/zh-CN/wallet/capital/deposite-address
  */
-export const getDepositAddress = (
+export const getDepositAddress = async (
   credential: ICredential,
   params: {
     coin: string;
@@ -601,7 +605,7 @@ export const getDepositAddress = (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/deposit/address';
   const url = new URL(endpoint);
   const weight = 10;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -618,7 +622,7 @@ export const getDepositAddress = (
  *
  * https://developers.binance.com/docs/zh-CN/sub_account/account-management/Query-Sub-account-List
  */
-export const getSubAccountList = (
+export const getSubAccountList = async (
   credential: ICredential,
   params?: {
     email?: string;
@@ -630,7 +634,7 @@ export const getSubAccountList = (
   const endpoint = 'https://api.binance.com/sapi/v1/sub-account/list';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -653,7 +657,7 @@ export const getSubAccountList = (
  *
  * https://developers.binance.com/docs/zh-CN/wallet/capital/withdraw
  */
-export const postWithdraw = (
+export const postWithdraw = async (
   credential: ICredential,
   params: {
     coin: string;
@@ -670,7 +674,7 @@ export const postWithdraw = (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/withdraw/apply';
   const url = new URL(endpoint);
   const weight = 600;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -692,7 +696,7 @@ export const postWithdraw = (
  *
  * https://developers.binance.com/docs/zh-CN/wallet/capital/withdraw-history
  */
-export const getWithdrawHistory = (
+export const getWithdrawHistory = async (
   credential: ICredential,
   params?: {
     coin?: string;
@@ -707,7 +711,7 @@ export const getWithdrawHistory = (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/withdraw/history';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -724,7 +728,7 @@ export const getWithdrawHistory = (
  *
  * https://developers.binance.com/docs/zh-CN/wallet/capital/deposite-history
  */
-export const getDepositHistory = (
+export const getDepositHistory = async (
   credential: ICredential,
   params?: {
     includeSource?: boolean;
@@ -740,7 +744,7 @@ export const getDepositHistory = (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/deposit/hisrec';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -757,7 +761,7 @@ export const getDepositHistory = (
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/trade/New-UM-Order
  */
-export const postUmOrder = (
+export const postUmOrder = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -777,7 +781,7 @@ export const postUmOrder = (
   const endpoint = 'https://papi.binance.com/papi/v1/um/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey('order/unified/minute', requestContext.ip);
   scopeError(
     'BINANCE_UNIFIED_ORDER_API_RATE_LIMIT',
@@ -793,7 +797,7 @@ export const postUmOrder = (
   );
 };
 
-export const deleteUmOrder = (
+export const deleteUmOrder = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -804,7 +808,7 @@ export const deleteUmOrder = (
   const endpoint = 'https://papi.binance.com/papi/v1/um/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey('order/unified/minute', requestContext.ip);
   scopeError(
     'BINANCE_UNIFIED_ORDER_API_RATE_LIMIT',
@@ -827,7 +831,7 @@ export const deleteUmOrder = (
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/account/Get-UM-Income-History
  */
-export const getUMIncome = (
+export const getUMIncome = async (
   credential: ICredential,
   params?: {
     symbol?: string;
@@ -842,7 +846,7 @@ export const getUMIncome = (
   const endpoint = 'https://papi.binance.com/papi/v1/um/income';
   const url = new URL(endpoint);
   const weight = 30;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -858,7 +862,7 @@ export const getUMIncome = (
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/account/rest-api/Get-Income-History
  */
-export const getAccountIncome = (
+export const getAccountIncome = async (
   credential: ICredential,
   params?: {
     symbol?: string;
@@ -874,7 +878,7 @@ export const getAccountIncome = (
   const endpoint = 'https://fapi.binance.com/fapi/v1/income';
   const url = new URL(endpoint);
   const weight = 30;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -891,7 +895,7 @@ export const getAccountIncome = (
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/trading-endpoints#%E6%92%A4%E9%94%80%E5%B9%B6%E9%87%8D%E6%96%B0%E4%B8%8B%E5%8D%95-trade
  */
-export const postSpotOrderCancelReplace = (
+export const postSpotOrderCancelReplace = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -921,7 +925,7 @@ export const postSpotOrderCancelReplace = (
   const endpoint = 'https://api.binance.com/api/v3/order/cancelReplace';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -944,7 +948,7 @@ export const postSpotOrderCancelReplace = (
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/portfolio-margin/trade/Modify-UM-Order
  */
-export const putUmOrder = (
+export const putUmOrder = async (
   credential: ICredential,
   params: {
     orderId?: number;
@@ -961,7 +965,7 @@ export const putUmOrder = (
   const endpoint = 'https://papi.binance.com/papi/v1/um/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -993,12 +997,12 @@ export interface IMarginPair {
  *
  * https://developers.binance.com/docs/zh-CN/margin_trading/market-data/Get-All-Cross-Margin-Pairs
  */
-export const getMarginAllPairs = (params?: { symbol?: string }): Promise<IMarginPair[]> => {
+export const getMarginAllPairs = async (params?: { symbol?: string }): Promise<IMarginPair[]> => {
   const credential = getDefaultCredential();
   const endpoint = 'https://api.binance.com/sapi/v1/margin/allPairs';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -1013,7 +1017,7 @@ export const getMarginAllPairs = (params?: { symbol?: string }): Promise<IMargin
  *
  * https://developers.binance.com/docs/zh-CN/margin_trading/borrow-and-repay/Get-a-future-hourly-interest-rate
  */
-export const getMarginNextHourlyInterestRate = (params: {
+export const getMarginNextHourlyInterestRate = async (params: {
   assets: string;
   isIsolated: boolean;
 }): Promise<
@@ -1026,7 +1030,7 @@ export const getMarginNextHourlyInterestRate = (params: {
   const endpoint = 'https://api.binance.com/sapi/v1/margin/next-hourly-interest-rate';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -1046,7 +1050,7 @@ export const getMarginNextHourlyInterestRate = (params: {
  *
  * https://developers.binance.com/docs/zh-CN/margin_trading/borrow-and-repay/Query-Margin-Interest-Rate-History
  */
-export const getMarginInterestRateHistory = (params: {
+export const getMarginInterestRateHistory = async (params: {
   asset: string;
   vipLevel?: number;
   startTime?: number;
@@ -1064,7 +1068,7 @@ export const getMarginInterestRateHistory = (params: {
   const endpoint = 'https://api.binance.com/sapi/v1/margin/interestRateHistory';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -1088,7 +1092,7 @@ export const getMarginInterestRateHistory = (params: {
  * @param params
  * @returns
  */
-export const getUserAsset = (
+export const getUserAsset = async (
   credential: ICredential,
   params: {
     timestamp: number;
@@ -1100,7 +1104,7 @@ export const getUserAsset = (
   const endpoint = 'https://api.binance.com/sapi/v3/asset/getUserAsset';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -1128,7 +1132,7 @@ export const getUserAsset = (
  * @param params
  * @returns
  */
-export const getFundingAsset = (
+export const getFundingAsset = async (
   credential: ICredential,
   params: {
     timestamp: number;
@@ -1140,7 +1144,7 @@ export const getFundingAsset = (
   const endpoint = 'https://api.binance.com/sapi/v1/asset/get-funding-asset';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -1168,7 +1172,7 @@ export const getFundingAsset = (
  * @param params
  * @returns
  */
-export const getUmAccountTradeList = (
+export const getUmAccountTradeList = async (
   credential: ICredential,
   params: {
     symbol: string;
@@ -1183,7 +1187,7 @@ export const getUmAccountTradeList = (
   const endpoint = 'https://papi.binance.com/papi/v1/um/userTrades';
   const url = new URL(endpoint);
   const weight = 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',

--- a/apps/vendor-binance/src/api/public-api.ts
+++ b/apps/vendor-binance/src/api/public-api.ts
@@ -110,11 +110,11 @@ export interface IMarginPair {
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Exchange-Information
  */
-export const getFutureExchangeInfo = (): Promise<IFutureExchangeInfo> => {
+export const getFutureExchangeInfo = async (): Promise<IFutureExchangeInfo> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/exchangeInfo';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -131,7 +131,7 @@ export const getFutureExchangeInfo = (): Promise<IFutureExchangeInfo> => {
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Get-Funding-Rate-History
  */
-export const getFutureFundingRate = (params: {
+export const getFutureFundingRate = async (params: {
   symbol?: string;
   startTime?: number;
   endTime?: number;
@@ -140,7 +140,7 @@ export const getFutureFundingRate = (params: {
   const endpoint = 'https://fapi.binance.com/fapi/v1/fundingRate';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host + 'fundingRate', requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -162,11 +162,11 @@ export const getFutureFundingRate = (params: {
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Get-Funding-Rate-Info
  */
-export const getFutureFundingInfo = (): Promise<IFutureFundingInfoEntry[]> => {
+export const getFutureFundingInfo = async (): Promise<IFutureFundingInfoEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/fundingInfo';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host + 'fundingRate', requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -190,11 +190,13 @@ export const getFutureFundingInfo = (): Promise<IFutureFundingInfoEntry[]> => {
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Mark-Price
  */
-export const getFuturePremiumIndex = (params: { symbol?: string }): Promise<IFuturePremiumIndexEntry[]> => {
+export const getFuturePremiumIndex = async (params: {
+  symbol?: string;
+}): Promise<IFuturePremiumIndexEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/premiumIndex';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 1 : 10;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -221,11 +223,13 @@ export const getFuturePremiumIndex = (params: { symbol?: string }): Promise<IFut
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Symbol-Order-Book-Ticker
  */
-export const getFutureBookTicker = (params?: { symbol?: string }): Promise<IFutureBookTickerEntry[]> => {
+export const getFutureBookTicker = async (params?: {
+  symbol?: string;
+}): Promise<IFutureBookTickerEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/ticker/bookTicker';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 2 : 5;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -252,11 +256,11 @@ export const getFutureBookTicker = (params?: { symbol?: string }): Promise<IFutu
  *
  * https://developers.binance.com/docs/zh-CN/derivatives/usds-margined-futures/market-data/rest-api/Open-Interest
  */
-export const getFutureOpenInterest = (params: { symbol: string }): Promise<IFutureOpenInterest> => {
+export const getFutureOpenInterest = async (params: { symbol: string }): Promise<IFutureOpenInterest> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/openInterest';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -280,11 +284,11 @@ export interface ISpotBookTickerEntry {
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/market-data-endpoints#%E6%9C%80%E4%BC%98%E6%8C%82%E5%8D%95%E6%8E%A5%E5%8F%A3
  */
-export const getSpotBookTicker = (params?: { symbol?: string }): Promise<ISpotBookTickerEntry[]> => {
+export const getSpotBookTicker = async (params?: { symbol?: string }): Promise<ISpotBookTickerEntry[]> => {
   const endpoint = 'https://api.binance.com/api/v3/ticker/bookTicker';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 2 : 4;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -347,11 +351,11 @@ export interface ISpotExchangeInfo {
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/general-endpoints#%E4%BA%A4%E6%98%93%E8%A7%84%E8%8C%83%E4%BF%A1%E6%81%AF
  */
-export const getSpotExchangeInfo = (): Promise<ISpotExchangeInfo> => {
+export const getSpotExchangeInfo = async (): Promise<ISpotExchangeInfo> => {
   const endpoint = 'https://api.binance.com/api/v3/exchangeInfo';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',
@@ -368,7 +372,7 @@ export const getSpotExchangeInfo = (): Promise<ISpotExchangeInfo> => {
  *
  * https://developers.binance.com/docs/zh-CN/binance-spot-api-docs/rest-api/market-data-endpoints#%E6%9C%80%E6%96%B0%E4%BB%B7%E6%A0%BC%E6%8E%A5%E5%8F%A3
  */
-export const getSpotTickerPrice = (params?: {
+export const getSpotTickerPrice = async (params?: {
   symbol?: string;
   symbols?: string;
   symbolStatus?: string;
@@ -381,7 +385,7 @@ export const getSpotTickerPrice = (params?: {
   const endpoint = 'https://api.binance.com/api/v3/ticker/price';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 2 : 4;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
   scopeError(
     'BINANCE_API_RATE_LIMIT',

--- a/apps/vendor-bitget/SESSION_NOTES.md
+++ b/apps/vendor-bitget/SESSION_NOTES.md
@@ -103,6 +103,15 @@
 ### 2026-02-05 — OpenCode
 
 - **本轮摘要**：
+  - proxy IP 选择改为异步等待（固定 30s），requestPublic/requestPrivate 使用 await 请求上下文。
+- **修改的文件**：
+  - `apps/vendor-bitget/src/api/client.ts`
+- **运行的测试 / 检查**：
+  - 未运行（本次仅修改 proxy ip 选择链路）
+
+### 2026-02-05 — OpenCode
+
+- **本轮摘要**：
   - Bitget REST client 在 `USE_HTTP_PROXY=true` 时引入 proxy ip 维度，流控 key 由 `encodePath([BaseKey, ip])` 生成；请求通过 `labels.ip` 路由。
   - 直连场景使用 `terminal.terminalInfo.tags.public_ip`，缺失时限频日志并 fallback 到 `public-ip-unknown`。
 - **修改的文件**：

--- a/apps/vendor-gate/SESSION_NOTES.md
+++ b/apps/vendor-gate/SESSION_NOTES.md
@@ -110,6 +110,15 @@
 ### 2026-02-05 — OpenCode
 
 - **本轮摘要**：
+  - proxy IP 选择改为异步等待（固定 30s），requestPublic/requestPrivate 使用 await 请求上下文。
+- **修改的文件**：
+  - `apps/vendor-gate/src/api/http-client.ts`
+- **运行的测试 / 检查**：
+  - 未运行（本次仅修改 proxy ip 选择链路）
+
+### 2026-02-05 — OpenCode
+
+- **本轮摘要**：
   - Gate HTTP client 在 `USE_HTTP_PROXY=true` 时引入 proxy ip 维度，request 通过 `labels.ip` 路由。
   - 直连场景使用 `terminal.terminalInfo.tags.public_ip`，缺失时限频日志并 fallback 到 `public-ip-unknown`。
 - **修改的文件**：

--- a/apps/vendor-huobi/src/api/private-api.ts
+++ b/apps/vendor-huobi/src/api/private-api.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { Terminal } from '@yuants/protocol';
 import { encodeBase64, encodePath, formatTime, HmacSHA256, scopeError, tokenBucket } from '@yuants/utils';
 
@@ -45,9 +45,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -72,7 +72,7 @@ const privateRequestWithRateLimit = async (
   params?: any,
 ) => {
   const meta = { method, api_root, path, business, interfaceType };
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
 
   const interfaceTypeUpper = interfaceType.toUpperCase();
   const businessUpper = business.toUpperCase();

--- a/apps/vendor-huobi/src/api/public-api.ts
+++ b/apps/vendor-huobi/src/api/public-api.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { Terminal } from '@yuants/protocol';
 import { encodePath, formatTime, scopeError, tokenBucket } from '@yuants/utils';
 
@@ -33,9 +33,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -133,7 +133,7 @@ async function publicRequest(
 }
 
 const spotMarketRequest = async (method: string, path: string, params?: any) => {
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const meta = {
     method,
     api_root: SPOT_API_ROOT,
@@ -147,7 +147,7 @@ const spotMarketRequest = async (method: string, path: string, params?: any) => 
 };
 
 const spotNonMarketRequest = async (method: string, path: string, params?: any) => {
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const meta = {
     method,
     api_root: SPOT_API_ROOT,
@@ -160,7 +160,7 @@ const spotNonMarketRequest = async (method: string, path: string, params?: any) 
 };
 
 const linearSwapMarketRequest = async (method: string, path: string, params?: any) => {
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const meta = {
     method,
     api_root: SWAP_API_ROOT,
@@ -174,7 +174,7 @@ const linearSwapMarketRequest = async (method: string, path: string, params?: an
 };
 
 const linearSwapNonMarketRequest = async (method: string, path: string, params?: any) => {
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   const meta = {
     method,
     api_root: SWAP_API_ROOT,

--- a/apps/vendor-hyperliquid/SESSION_NOTES.md
+++ b/apps/vendor-hyperliquid/SESSION_NOTES.md
@@ -202,6 +202,15 @@
 ### 2026-02-05 — OpenCode
 
 - **本轮摘要**：
+  - proxy IP 选择改为异步等待（固定 30s），REST 请求上下文改为 await。
+- **修改的文件**：
+  - `apps/vendor-hyperliquid/src/api/client.ts`
+- **运行的测试 / 检查**：
+  - 未运行（本次仅修改 proxy ip 选择链路）
+
+### 2026-02-05 — OpenCode
+
+- **本轮摘要**：
   - Hyperliquid REST client 在 `USE_HTTP_PROXY=true` 时使用 proxy ip 作为 labels.ip 路由，并将 REST IP 限流维度改为 `encodePath([BaseKey, ip])`。
   - 直连场景使用 `terminal.terminalInfo.tags.public_ip`，缺失时限频日志并 fallback 到 `public-ip-unknown`。
 - **修改的文件**：

--- a/apps/vendor-hyperliquid/src/api/client.ts
+++ b/apps/vendor-hyperliquid/src/api/client.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { Terminal } from '@yuants/protocol';
 import { UUID, formatTime, newError } from '@yuants/utils';
 import { Subject, filter, firstValueFrom, mergeMap, of, shareReplay, throwError, timeout, timer } from 'rxjs';
@@ -22,9 +22,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -68,7 +68,7 @@ const callApi = async (method: HttpMethod, path: string, params?: any) => {
 
   const requestContext = getRestRequestContext(method, path, params);
   const requestKey = getRequestKey(requestContext);
-  const proxyContext = createRequestContext();
+  const proxyContext = await createRequestContext();
 
   beforeRestRequest(
     { method, url: url.href, path, kind: requestContext.kind, infoType: requestContext.infoType, requestKey },

--- a/apps/vendor-okx/src/api/private-api.ts
+++ b/apps/vendor-okx/src/api/private-api.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { Terminal } from '@yuants/protocol';
 import { encodeBase64, formatTime, HmacSHA256 } from '@yuants/utils';
 
@@ -26,9 +26,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -58,7 +58,7 @@ export async function request(
 ) {
   const url = new URL('https://www.okx.com');
   url.pathname = path;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   if (method === 'GET' && params) {
     for (const key in params) {
       url.searchParams.set(key, String(params[key]));

--- a/apps/vendor-okx/src/api/public-api.ts
+++ b/apps/vendor-okx/src/api/public-api.ts
@@ -1,4 +1,4 @@
-import { fetch, selectHTTPProxyIpRoundRobin } from '@yuants/http-services';
+import { fetch, selectHTTPProxyIpRoundRobinAsync } from '@yuants/http-services';
 import { Terminal } from '@yuants/protocol';
 import { formatTime } from '@yuants/utils';
 
@@ -26,9 +26,9 @@ const resolveLocalPublicIp = (): string => {
   return 'public-ip-unknown';
 };
 
-const createRequestContext = (): RequestContext => {
+const createRequestContext = async (): Promise<RequestContext> => {
   if (shouldUseHttpProxy) {
-    const ip = selectHTTPProxyIpRoundRobin(terminal);
+    const ip = await selectHTTPProxyIpRoundRobinAsync(terminal);
     return { ip };
   }
   return { ip: resolveLocalPublicIp() };
@@ -40,7 +40,7 @@ const createRequestContext = (): RequestContext => {
 async function publicRequest(method: string, path: string, params?: Record<string, string>) {
   const url = new URL('https://www.okx.com');
   url.pathname = path;
-  const requestContext = createRequestContext();
+  const requestContext = await createRequestContext();
   if (method === 'GET') {
     for (const key in params) {
       url.searchParams.set(key, params[key]);

--- a/common/changes/@yuants/http-services/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/http-services/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/http-services",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/http-services"
+}

--- a/common/changes/@yuants/vendor-aster/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-aster/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-aster",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-aster"
+}

--- a/common/changes/@yuants/vendor-binance/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-binance/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-binance",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-binance"
+}

--- a/common/changes/@yuants/vendor-bitget/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-bitget/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-bitget",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-bitget"
+}

--- a/common/changes/@yuants/vendor-gate/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-gate/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-gate",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-gate"
+}

--- a/common/changes/@yuants/vendor-huobi/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-huobi/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-huobi",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-huobi"
+}

--- a/common/changes/@yuants/vendor-hyperliquid/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-hyperliquid/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-hyperliquid",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-hyperliquid"
+}

--- a/common/changes/@yuants/vendor-okx/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
+++ b/common/changes/@yuants/vendor-okx/legion-http-services-terminalinfos-ready_2026-02-05-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-okx",
+      "comment": "add async select ip",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-okx"
+}

--- a/libraries/http-services/etc/http-services.api.md
+++ b/libraries/http-services/etc/http-services.api.md
@@ -64,4 +64,10 @@ export const provideHTTPProxyService: (terminal: Terminal, labels: Record<string
 // @public (undocumented)
 export const selectHTTPProxyIpRoundRobin: (terminal: Terminal) => string;
 
+// @public (undocumented)
+export const selectHTTPProxyIpRoundRobinAsync: (terminal: Terminal) => Promise<string>;
+
+// @public (undocumented)
+export const waitForHTTPProxyIps: (terminal: Terminal) => Promise<string[]>;
+
 ```


### PR DESCRIPTION
为 http-services 增加 async proxy ip 选择与 terminalInfos$ 就绪等待，超时固定 30s，并将 vendor 调用点改为 await。

## Why

启动阶段 terminalInfos$ 未就绪时，同步 round-robin 会出现空池并抛错；async 等待可消除该类启动失败。

## How

- 新增 async helper 等待 terminalInfos$ 首发后选择 proxy ip。
- 超时固定 30_000ms，错误契约保持一致。
- vendor 调用点改为 await 版本。

## Testing

- `(cd libraries/http-services && rushx build)`

## Risk / Rollback

- Risk: 启动阶段可能等待最长 30s；无代理配置场景需关注启动延迟。
- Rollback: 回退 async helper 与 vendor await 调用，恢复同步选择。
- Review: code/security PASS。

## Links

- RFC: `.legion/tasks/http-services-terminalinfos-ready/docs/rfc.md`
- Walkthrough: `.legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md`
- Review Code: `.legion/tasks/http-services-terminalinfos-ready/docs/review-code.md`
- Review Security: `.legion/tasks/http-services-terminalinfos-ready/docs/review-security.md`