### PR TITLE
feat(http-services): record target labels in requests

### DIFF
--- a/.legion/tasks/http-proxy-app-implementation/docs/pr-body-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/pr-body-metrics.md
@@ -1,6 +1,6 @@
 ## What
 
-为 HTTP Proxy 增加目标域名+路径维度的请求计数指标 `http_proxy_target_host_requests_total`，并在现有 handler 末尾采集 `target_host`、`target_path` 与 `result`。
+为 HTTP Proxy 扩展 `http_proxy_requests_total` 的请求计数标签，新增 `target_host` 与 `target_path`，并在现有 handler 末尾采集。
 
 ## Why
 
@@ -11,7 +11,7 @@
 - 复用 handler 内 `new URL(req.url)` 的解析结果（`parse_result`），不做二次解析。
 - `target_host` 使用解析结果规范化或固定占位符（`ip`/`invalid`）。
 - `target_path` 使用 `parse_result.pathname`，为空则 `/`。
-- `result` 仅基于 handler 抛错与错误码映射，未命中统一为 `error`。
+- `error_code` 沿用现有映射逻辑，不新增 `result` 标签。
 
 ## Testing
 
@@ -23,7 +23,7 @@ rushx build
 ## Risk / Rollback
 
 - 安全审查中标注：开放代理风险与 timeout 无上限 DoS 风险为 wontfix（见安全审查报告）。
-- 回滚：移除 `http_proxy_target_host_requests_total` 的注册与计数逻辑，并回滚相关测试。
+- 回滚：移除 `http_proxy_requests_total` 的 `target_host`/`target_path` 采集逻辑，并回滚相关测试。
 
 ## Links
 

--- a/.legion/tasks/http-proxy-app-implementation/docs/pr-body.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/pr-body.md
@@ -1,6 +1,6 @@
 ## What
 
-- Add target host/path metrics for HTTP proxy requests in `@yuants/http-services`
+- Add target host/path labels to `http_proxy_requests_total` in `@yuants/http-services`
 
 ## Why
 
@@ -8,7 +8,7 @@
 
 ## How
 
-- Register `http_proxy_target_host_requests_total` with `target_host`, `target_path`, `result` labels
+- Extend `http_proxy_requests_total` with `target_host` and `target_path` labels
 - Map results from existing handler error codes; derive host/path from `new URL(req.url)` parse result
 - Extend tests to cover target_path defaulting, labels propagation, and invalid_url cases
 - Update Grafana dashboard with target host/path panels and filters
@@ -20,7 +20,7 @@
 ## Risk / Rollback
 
 - Risk: `target_path` may increase metric cardinality; monitor and apply normalization/filters if needed
-- Rollback: remove the `http_proxy_target_host_requests_total` registration and sampling logic
+- Rollback: remove `target_host`/`target_path` labels from `http_proxy_requests_total` sampling logic
 
 ## Links
 

--- a/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md
@@ -2,7 +2,7 @@
 
 ## 目标与范围
 
-- 目标：为 HTTP Proxy 增加“目标域名”维度的请求计数指标，便于按域名聚合观测，不改变现有请求处理与 SSRF 行为。
+- 目标：为 HTTP Proxy 增加“目标域名 + 路径”维度的请求计数标签，便于按 host/path 聚合观测，不改变现有请求处理与 SSRF 行为。
 - 范围（Scope 绑定）：
   - 代码：`/Users/c1/Work/Yuan/libraries/http-services/src/server.ts`
   - 测试：`/Users/c1/Work/Yuan/libraries/http-services/src/__tests__/server.test.ts`
@@ -16,17 +16,16 @@
 - 设计真源：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
 - 关键设计点：
   - 指标解析仅复用 handler 内 `new URL(req.url)` 的 `parse_result`，不做二次解析。
-  - `target_host`：IP 字面量固定为 `ip`，解析失败或 hostname 为空为 `invalid`，其余按 `allowedHosts` 规范化命中则记录主机名，否则为 `disallowed`。
-  - `result`：仅基于 handler 返回/抛错与 `error.code`/等价信号映射（TIMEOUT/FORBIDDEN/INVALID_URL 等），未命中为 `error`。
-  - `allowedHosts` 仅作为基数控制（规范化匹配，含端口仅告警且不匹配）；空/缺失时不注册目标域名指标并告警。
+  - `target_host`：IP 字面量固定为 `ip`，解析失败或 hostname 为空为 `invalid`，其余按 hostname 规范化记录。
+  - `target_path`：使用 `parse_result.pathname`，为空则 `/`。
+  - `error_code` 保持现有映射逻辑，不新增 `result` 标签。
 - 可选插件产物：无。
 
 ## 改动清单
 
 - 业务逻辑（`server.ts`）：
-  - 新增指标 `http_proxy_target_host_requests_total`，注册条件与计数点落在请求生命周期末尾。
-  - 增加 `target_host` 与 `result` 解析逻辑，复用 `parse_result` 与错误码映射。
-  - 对 `allowedHosts` 进行规范化匹配，含端口的配置仅告警且不参与匹配。
+  - 扩展 `http_proxy_requests_total` 标签，新增 `target_host`/`target_path`。
+  - 增加 `target_host` 与 `target_path` 解析逻辑，复用 `parse_result` 与错误码映射。
 - 单元测试（`server.test.ts`）：
   - 覆盖 `invalid_url`/空 hostname/IP 字面量/allowedHosts 端口告警等指标行为。
 
@@ -51,7 +50,7 @@ rushx build
 
 ## 可观测性（metrics/logging）
 
-- 新增指标：`http_proxy_target_host_requests_total{target_host,result}`。
+- 扩展指标：`http_proxy_requests_total{target_host,target_path}`。
 - 相关指标仍保留：`http_proxy_requests_total`、`http_proxy_request_duration_seconds`、`http_proxy_active_requests`、`http_proxy_errors_total`。
 - 日志：
   - allowedHosts 为空/缺失时输出一次告警并禁用 target_host 指标。
@@ -61,10 +60,10 @@ rushx build
 ## 风险与回滚
 
 - 风险：
-  - 安全审查中对 `allowedHosts` 为空导致开放代理风险、`req.timeout` 无上限的 DoS 风险标记为 wontfix（见安全审查报告）。
-  - 日志中可能包含被阻断的 hostname（潜在信息泄露风险）。
+  - 安全审查中对开放代理风险、`req.timeout` 无上限的 DoS 风险标记为 wontfix（见安全审查报告）。
+  - `target_path` 可能带来较高基数与潜在路径泄露风险（建议后续归一化）。
 - 回滚：
-  - 删除/禁用 `http_proxy_target_host_requests_total` 的注册与计数点（`server.ts`），并回滚相关测试断言。
+  - 删除 `http_proxy_requests_total` 的 `target_host`/`target_path` 采集逻辑（`server.ts`），并回滚相关测试断言。
 
 ## 未决项与下一步
 

--- a/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md
@@ -15,5 +15,5 @@ PASS（基于有限信息的评审；已审查文件：`libraries/http-services/
 
 ## 修复指导
 
-- `libraries/http-services/src/__tests__/server.test.ts`：将 `mockMetrics.counter.mock.results[0]`/`[1]` 替换为 `getCounterMetric(mockMetrics, 'http_proxy_requests_total')`、`getCounterMetric(mockMetrics, 'http_proxy_errors_total')`、`getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total')`，消除顺序依赖。
+- `libraries/http-services/src/__tests__/server.test.ts`：将 `mockMetrics.counter.mock.results[0]`/`[1]` 替换为 `getCounterMetric(mockMetrics, 'http_proxy_requests_total')`、`getCounterMetric(mockMetrics, 'http_proxy_errors_total')`，消除顺序依赖。
 - `libraries/http-services/src/server.ts` 或 `rfc-metrics.md`：补充一句“`target_path` 仅为 `pathname`，不包含 query/fragment”，与 R25 的安全说明对齐。

--- a/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-本 RFC 定义 HTTP Proxy 服务的“目标域名 + 路径”流量统计指标。指标解析 MUST 仅复用 handler 内 `new URL(req.url)` 的解析结果（`parse_result`），不得二次解析。RFC 删除 scheme 白名单约束，仅依赖 `new URL` 的解析成功与否；非 absolute-form 仍因解析失败归 `invalid_url`。解析成功但 `hostname` 为空（如 `file:`/`mailto:`）视为 `invalid_url`，`target_host` 固定为 `invalid`，`target_path` 固定为 `invalid`。IP 字面量目标的 `target_host` 固定为 `ip`；`result` 以 handler 抛错的 `error.code`/等价信号映射（含 `INVALID_URL`），未命中时为 `error`。指标统计与 `allowedHosts` 无关，记录所有 fetch 目标的 host 与 path。该 RFC 的 Plan 章节为工程执行的唯一设计真源。
+本 RFC 定义 HTTP Proxy 服务在 `http_proxy_requests_total` 上增加“目标域名 + 路径”维度的统计标签。指标解析 MUST 仅复用 handler 内 `new URL(req.url)` 的解析结果（`parse_result`），不得二次解析。RFC 删除 scheme 白名单约束，仅依赖 `new URL` 的解析成功与否；非 absolute-form 仍因解析失败归 `invalid_url`。解析成功但 `hostname` 为空（如 `file:`/`mailto:`）视为 `invalid_url`，`target_host` 固定为 `invalid`，`target_path` 固定为 `invalid`。IP 字面量目标的 `target_host` 固定为 `ip`。`error_code` 延续现有映射逻辑。指标统计与 `allowedHosts` 无关，记录所有 fetch 目标的 host 与 path。该 RFC 的 Plan 章节为工程执行的唯一设计真源。
 
 ## Motivation / 背景与问题
 
@@ -12,7 +12,7 @@
 
 ### Goals
 
-- 新增“目标域名 + 路径”统计指标，用于按 host/path 聚合。
+- 扩展 `http_proxy_requests_total`，新增 `target_host`/`target_path` 标签用于按 host/path 聚合。
 - 不改变现有请求处理、解析与 SSRF 行为。
 
 ### Non-Goals
@@ -30,22 +30,21 @@
 - allowedHosts: HTTP Proxy 现有配置的主机白名单（语义保持现状）。
 - target_host: 指标 label `target_host` 的最终值。
 - target_path: 指标 label `target_path` 的最终值（来自 URL pathname）。
-- result: 指标 label `result` 的分类（见 Error Semantics）。
-- effective_error_code: 抛错时用于 `result` 映射的错误码（来源见 Error Semantics）。
+- effective_error_code: 抛错时用于 `error_code` 记录的错误码（来源见 Error Semantics）。
 
 ## Protocol Overview（端到端流程）
 
-请求进入 handler 后先执行 `new URL(req.url)` 解析并进入既有 SSRF/请求流程；若解析失败则按 `invalid_url` 处理。若指标已注册，则在 handler 返回或抛错时计算 `target_host` 与 `result` 并计数一次。
+请求进入 handler 后先执行 `new URL(req.url)` 解析并进入既有 SSRF/请求流程；若解析失败则按 `invalid_url` 处理。请求结束时计算 `target_host`/`target_path` 并在 `http_proxy_requests_total` 计数一次。
 
 R1: 指标解析 MUST 仅复用 handler 内 `parse_result`，不得重新解析 `raw_url` 或构造新的 URL 实例。
 
-R2: 当 `new URL(raw_url)` 解析失败时，`parse_result` MUST 视为不存在，且 `result` MUST 进入 `invalid_url` 语义。
+R2: 当 `new URL(raw_url)` 解析失败时，`parse_result` MUST 视为不存在，`target_host`/`target_path` MUST 为 `invalid`，且 `error_code` 归一化为 `INVALID_URL`。
 
-R3: 当 `parse_result.hostname` 为空字符串时，`result` MUST 进入 `invalid_url` 语义。
+R3: 当 `parse_result.hostname` 为空字符串时，`target_host`/`target_path` MUST 为 `invalid`。
 
 R4: 本 RFC MUST NOT 引入额外 scheme 过滤或白名单；`invalid_url` 由解析失败或 hostname 为空触发。
 
-R5: 实现 MUST 注册 `http_proxy_target_host_requests_total`，且不依赖 `allowedHosts`。
+R5: 实现 MUST 在 `http_proxy_requests_total` 中追加 `target_host`/`target_path` 标签，且不依赖 `allowedHosts`。
 
 > [REVIEW] 这是谁说的？为什么 allowedHosts 缺失就不统计了？我要的就是所有的底层 fetch 要去的 host url 的 path 部分的 metrisc 统计，和安全没有什么关系，你这个想复杂了。
 >
@@ -54,18 +53,17 @@ R5: 实现 MUST 注册 `http_proxy_target_host_requests_total`，且不依赖 `a
 
 R6: 每个请求 MUST 仅计数一次，计数点 MUST 位于请求生命周期末尾（handler 已返回或抛错）。
 
-R7: `result` MUST 仅由 handler 的返回/抛错路径与既有错误语义决定；不得引入“写回成功”判定。
+R7: `error_code` MUST 仅由 handler 的返回/抛错路径与既有错误语义决定；不得引入“写回成功”判定。
 
 ## Data Model
 
-指标定义如下：
+指标定义如下（扩展现有指标）：
 
-- 名称: `http_proxy_target_host_requests_total`
+- 名称: `http_proxy_requests_total`
 - 类型: Counter
 - Labels:
-  - `target_host`: 目标主机名或固定占位符
-  - `target_path`: URL path 或固定占位符
-  - `result`: 结果分类（见 Error Semantics）
+  - 既有标签：`method`、`status_code`、`error_code`、服务 `labels`
+  - 新增标签：`target_host`、`target_path`
 
 R9: 当 `parse_result` 不存在或 `parse_result.hostname` 为空字符串时，`target_host` MUST 为 `invalid`，`target_path` MUST 为 `invalid`。
 
@@ -83,27 +81,13 @@ R17: 本 RFC MUST 复用现有错误语义，不得改变错误码与抛出逻�
 
 R18: 当 handler 抛错时，实现 MUST 计算 `effective_error_code`，来源按以下顺序尝试（仅限可检测字段）：`error.code`、`error.cause?.code`、`error.message` 的前缀（`CODE:` 形式）、`error.name`（仅用于 `AbortError`/`TimeoutError` 映射为 `TIMEOUT`）。
 
-事件 -> result 映射表：
+R19: `error_code` 标签 SHOULD 使用 `effective_error_code`（将 `ERR_INVALID_URL` 归一化为 `INVALID_URL`）；若未得到有效值，则回退 `error.message` 前缀；仍为空时使用 `FETCH_FAILED`。
 
-R19: 当 handler 抛错且 `effective_error_code` 命中以下集合时，`result` MUST 按表映射：
-
-| effective_error_code | result      |
-| -------------------- | ----------- |
-| TIMEOUT              | timeout     |
-| FORBIDDEN            | blocked     |
-| INVALID_URL          | invalid_url |
-| FETCH_FAILED         | error       |
-| RESPONSE_TOO_LARGE   | error       |
-
-R20: 当 handler 抛错且未命中 R19 时，`result` MUST 为 `error`。
-
-R21: 当 handler 正常返回且 URL 解析失败（`parse_result` 不存在）或 `parse_result.hostname` 为空时，`result` MUST 为 `invalid_url`。
-
-R22: 当 handler 正常返回且未命中 R21 时，`result` MUST 为 `ok`（无论上游状态码 2xx/4xx/5xx）。
+R20: 当 handler 正常返回时，`error_code` MUST 为 `none`。
 
 ## Security Considerations
 
-R25: 指标 MUST NOT 记录原始 URL、路径、查询参数或 IP，避免泄露敏感信息。
+R25: 指标 MUST NOT 记录原始 URL 与 query/fragment；`target_path` 仅记录 `pathname`。
 
 R26: 指标解析 MUST 复用现有 SSRF/请求解析结果，避免解析分歧导致安全绕过。
 
@@ -111,59 +95,58 @@ R27: 指标采集与 `allowedHosts` 无关，记录所有 fetch 目标的 host/p
 
 ## Backward Compatibility & Rollout
 
-R28: 新指标为新增 Counter，不影响现有 `http_proxy_requests_total` 等指标；现有仪表盘 SHOULD 保持可用。
+R28: 现有 `http_proxy_requests_total` 新增标签，旧仪表盘需补齐标签或通过 `ignoring`/`sum without` 兼容。
 
 R29: 本 RFC 不改变既有请求解析与 SSRF 行为；仅移除新增 scheme 白名单的要求，避免对请求行为产生新约束。
 
-R30: 新指标新增 `target_path` 标签，旧指标保持不变。
+R30: `http_proxy_requests_total` 新增 `target_host`/`target_path` 标签。
 
 R31: Rollout MAY 先在单个实例灰度，观察新指标时序与基数增长。
 
-R32: 回滚策略 MUST 同时删除指标注册与采集点，确保 metrics exposition 不再暴露该指标，避免空值误导。
+R32: 回滚策略 MUST 删除 `http_proxy_requests_total` 的 `target_host`/`target_path` 采集逻辑，避免新增标签继续暴露。
 
 ## Testability
 
 每条 MUST 行为均可映射到测试断言：
 
 - R1-R3: 指标解析仅复用 `parse_result`，不新增 scheme 过滤；`new URL` 失败触发 `invalid_url`。
-- R4-R7: 指标注册与计数位置固定，每请求仅计数一次。
+- R4-R7: `http_proxy_requests_total` 追加标签且计数位置固定，每请求仅计数一次。
 - R9-R13: `target_host`/`target_path` 规则可通过 label 断言验证。
-- R18-R24: `result` 映射闭合，支持 error.code/等价信号，IP 不默认 blocked。
+- R18-R20: `error_code` 采用 error.code/等价信号映射，正常返回为 `none`。
 - R27-R32: 兼容/回滚行为与告警日志可验证。
 
 最小验证用例（至少 3 条）：
 
-1. allowedHosts 规范化命中
+1. hostname 规范化
 
-   - 配置 `allowedHosts = ["Api.Example.Com."]`
    - 请求 `http://api.example.com/v1/ping`
-   - 期望：`target_host="api.example.com"`，`target_path="/v1/ping"`，`result="ok"`
+   - 期望：`target_host="api.example.com"`，`target_path="/v1/ping"`，`error_code="none"`
 
 2. 解析成功但 hostname 为空
 
    - 请求 `raw_url="file:///etc/hosts"`
-   - 期望：`parse_result.hostname==""` 视为 `invalid_url`；`target_host="invalid"`，`target_path="invalid"`
+   - 期望：`target_host="invalid"`，`target_path="invalid"`，`error_code="none"`
 
 3. IP 字面量被 SSRF 阻断
 
    - 请求 `http://127.0.0.1/`
-   - SSRF 阻断该请求且 handler 正常返回错误响应
-   - 期望：`target_host="ip"`，`result="blocked"`
+   - SSRF 阻断该请求并抛错
+   - 期望：`target_host="ip"`，`error_code="FORBIDDEN"`
 
 4. IP 字面量未被 SSRF 阻断
 
    - 请求 `http://127.0.0.1/`
    - SSRF 放行且 handler 正常返回
-   - 期望：`target_host="ip"`，`result="ok"`
+   - 期望：`target_host="ip"`，`error_code="none"`
 
 5. handler 抛错按 error.code 映射
 
    - 任意请求触发 `newError('INVALID_URL')`
-   - 期望：`result="invalid_url"`（不再映射为 `error`）
+   - 期望：`error_code="INVALID_URL"`
 
 6. allowedHosts 含端口
    - 配置 `allowedHosts=["api.example.com:443"]`
-   - 期望：该条永不匹配；若被 SSRF 阻断则 `result="blocked"`
+   - 期望：该条永不匹配；若被 SSRF 阻断则 `error_code="FORBIDDEN"`
 
 ## Open Questions
 
@@ -183,18 +166,19 @@ R32: 回滚策略 MUST 同时删除指标注册与采集点，确保 metrics exp
 - 仅使用 `parse_result`（handler 内 `new URL(req.url)` 结果）计算 `target_host` 与 `target_path`；解析失败或 hostname 为空归 `invalid`。
 - `target_host` 规则：IP 字面量固定为 `ip`；非 IP 采用 `normalized_host`（ASCII 小写 + 去尾点）。
 - `target_path` 规则：使用 `parse_result.pathname`，为空则 `/`；解析失败或 hostname 为空时为 `invalid`。
-- `result` 以 handler 抛错的 `error.code`/等价信号映射（TIMEOUT/FORBIDDEN/FETCH_FAILED/INVALID_URL/RESPONSE_TOO_LARGE）；未命中为 `error`；正常返回时为 `ok`。
+- `error_code` 维持现有映射逻辑；正常返回时为 `none`。
 
 ### 接口定义
 
-- 无新增外部接口；新增 Prometheus Counter `http_proxy_target_host_requests_total`（labels: `target_host`, `result`）。
+- 无新增外部接口；扩展 `http_proxy_requests_total` 新增 `target_host`/`target_path` 标签。
 
 ### 文件变更明细
 
-- `libraries/http-services/src/server.ts`：新增指标定义与计数逻辑（复用 `parse_result`、SSRF 结果与 handler 返回/抛错）。
-- `docs/`（如需）：更新观测指标说明与示例。
+- `libraries/http-services/src/server.ts`：扩展 `http_proxy_requests_total` 标签并在末尾采集。
+- `libraries/http-services/src/__tests__/server.test.ts`：补充 target_host/target_path 断言。
+- `libraries/http-services/grafana-dashboard.json`：新增 target_host/target_path 面板与筛选项。
 
 ### 验证策略
 
-- 单测：覆盖 `new URL(req.url)` 解析失败/hostname 为空、allowedHosts 含端口告警与不匹配、IP 字面量 target_host 固定、`error.code` 映射与 SSRF 阻断语义。
-- 手工验证：灰度实例上发起不同目标域名/不同 scheme 请求，确认 `target_host` 仅为白名单或占位符，且不新增请求行为变化。
+- 单测：覆盖 `new URL(req.url)` 解析失败/hostname 为空、target_path 采集、IP 字面量 target_host 固定、`error.code` 映射与 SSRF 阻断语义。
+- 手工验证：灰度实例上发起不同目标域名/不同 scheme 请求，确认 `target_host`/`target_path` 标签输出符合预期。

--- a/.legion/tasks/http-proxy-app-implementation/plan.md
+++ b/.legion/tasks/http-proxy-app-implementation/plan.md
@@ -9,9 +9,9 @@ RFC 为唯一设计真源：`.legion/tasks/http-proxy-app-implementation/docs/rf
 
 ## 摘要
 
-- 核心流程：仅依赖 `parse_result`，解析失败或 hostname 为空归 `invalid_url`；新增 `target_path` 维度；IP 字面量 `target_host=ip`；`result` 以 `error.code`/等价信号映射；生命周期末尾计数。
-- 接口变更：不新增外部接口，仅新增 Prometheus Counter `http_proxy_target_host_requests_total`（labels: `target_host`,`target_path`,`result`）。
-- 文件变更清单：`libraries/http-services/src/server.ts`（指标定义与采集点）、`libraries/http-services/grafana-dashboard.json`（新增 target_host/target_path 面板），必要时补充观测说明文档。
+- 核心流程：仅依赖 `parse_result`，解析失败或 hostname 为空归 `invalid_url`；新增 `target_path` 维度；IP 字面量 `target_host=ip`；`error_code` 维持现有映射；生命周期末尾计数。
+- 接口变更：不新增外部接口，扩展 `http_proxy_requests_total` 增加 `target_host`/`target_path` labels。
+- 文件变更清单：`libraries/http-services/src/server.ts`、`libraries/http-services/src/__tests__/server.test.ts`、`libraries/http-services/grafana-dashboard.json`（新增 target_host/target_path 面板），必要时补充观测说明文档。
 - 验证策略：单测覆盖 hostname 为空/解析失败、target_path 采集、`error.code` 映射（含 INVALID_URL/TIMEOUT/FORBIDDEN）、IP 不默认 blocked；手工验证 metrics 输出与基数控制。
 - TODO（后续评估）：若 `target_path` 导致高基数，考虑路径归一化/前缀过滤/分层指标策略。
 

--- a/common/changes/@yuants/http-services/legion-feature-http-proxy-request-labels_2026-02-05-14-01.json
+++ b/common/changes/@yuants/http-services/legion-feature-http-proxy-request-labels_2026-02-05-14-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add target host/path labels to http_proxy_requests_total",
+      "type": "minor",
+      "packageName": "@yuants/http-services"
+    }
+  ],
+  "packageName": "@yuants/http-services",
+  "email": "c.one@thrimbda.com"
+}

--- a/libraries/http-services/grafana-dashboard.json
+++ b/libraries/http-services/grafana-dashboard.json
@@ -408,7 +408,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (target_host) (rate(http_proxy_target_host_requests_total{target_host=~\"$target_host\", target_path=~\"$target_path\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (target_host) (rate(http_proxy_requests_total{target_host=~\"$target_host\", target_path=~\"$target_path\"}[$__rate_interval])))",
           "legendFormat": "{{ target_host }}",
           "refId": "A"
         }
@@ -445,7 +445,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(10, sum by (target_path) (rate(http_proxy_target_host_requests_total{target_host=~\"$target_host\", target_path=~\"$target_path\"}[$__rate_interval])))",
+          "expr": "topk(10, sum by (target_path) (rate(http_proxy_requests_total{target_host=~\"$target_host\", target_path=~\"$target_path\"}[$__rate_interval])))",
           "legendFormat": "{{ target_path }}",
           "refId": "A"
         }
@@ -538,7 +538,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(http_proxy_target_host_requests_total, target_host)",
+        "definition": "label_values(http_proxy_requests_total, target_host)",
         "hide": 0,
         "includeAll": true,
         "label": "Target Host",
@@ -546,7 +546,7 @@
         "name": "target_host",
         "options": [],
         "query": {
-          "query": "label_values(http_proxy_target_host_requests_total, target_host)",
+          "query": "label_values(http_proxy_requests_total, target_host)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -564,7 +564,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(http_proxy_target_host_requests_total, target_path)",
+        "definition": "label_values(http_proxy_requests_total, target_path)",
         "hide": 0,
         "includeAll": true,
         "label": "Target Path",
@@ -572,7 +572,7 @@
         "name": "target_path",
         "options": [],
         "query": {
-          "query": "label_values(http_proxy_target_host_requests_total, target_path)",
+          "query": "label_values(http_proxy_requests_total, target_path)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/libraries/http-services/src/__tests__/server.test.ts
+++ b/libraries/http-services/src/__tests__/server.test.ts
@@ -19,14 +19,6 @@ const createMockMetric = () => {
   return metric;
 };
 
-const getCounterMetric = (mockMetrics: { counter: jest.SpyInstance }, name: string) => {
-  const index = mockMetrics.counter.mock.calls.findIndex((call) => call[0] === name);
-  if (index < 0) {
-    throw new Error(`Counter ${name} was not registered`);
-  }
-  return mockMetrics.counter.mock.results[index].value;
-};
-
 describe('provideHTTPProxyService', () => {
   let terminal: Terminal;
   let mockMetrics: {
@@ -205,6 +197,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '200',
       error_code: 'none',
+      target_host: 'api.example.com',
+      target_path: '/data',
     });
     expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
@@ -259,6 +253,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '200',
       error_code: 'none',
+      target_host: 'api.example.com',
+      target_path: '/data',
     });
 
     dispose();
@@ -300,13 +296,15 @@ describe('provideHTTPProxyService', () => {
       { isAborted$: undefined },
     );
 
-    const targetHostCounter = getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total');
-    expect(targetHostCounter.labels).toHaveBeenCalledWith({
+    const requestsTotalCounter = mockMetrics.counter.mock.results[0].value;
+    expect(requestsTotalCounter.labels).toHaveBeenCalledWith({
+      method: 'GET',
+      status_code: '200',
+      error_code: 'none',
       target_host: 'api.example.com',
       target_path: '/',
-      result: 'ok',
     });
-    expect(targetHostCounter.inc).toHaveBeenCalled();
+    expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
     dispose();
   });
@@ -359,6 +357,8 @@ describe('provideHTTPProxyService', () => {
       method: 'POST',
       status_code: '201',
       error_code: 'none',
+      target_host: 'api.example.com',
+      target_path: '/data',
     });
 
     // R7: requestDuration.observe() should be called with POST method
@@ -411,6 +411,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '0',
       error_code: 'TIMEOUT',
+      target_host: 'api.example.com',
+      target_path: '/slow',
     });
     expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
@@ -460,6 +462,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '0',
       error_code: 'FETCH_FAILED',
+      target_host: 'api.example.com',
+      target_path: '/error',
     });
 
     // R9: errorsTotal.inc() should be called with error_type 'network'
@@ -504,6 +508,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '0',
       error_code: 'FORBIDDEN',
+      target_host: 'forbidden.example.com',
+      target_path: '/data',
     });
 
     // R9: errorsTotal.inc() should be called with error_type 'security'
@@ -546,6 +552,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '0',
       error_code: 'INVALID_URL',
+      target_host: 'invalid',
+      target_path: 'invalid',
     });
 
     // R9: errorsTotal.inc() should be called with error_type 'validation'
@@ -581,13 +589,15 @@ describe('provideHTTPProxyService', () => {
       ),
     ).rejects.toThrow('INVALID_URL');
 
-    const targetHostCounter = getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total');
-    expect(targetHostCounter.labels).toHaveBeenCalledWith({
+    const requestsTotalCounter = mockMetrics.counter.mock.results[0].value;
+    expect(requestsTotalCounter.labels).toHaveBeenCalledWith({
+      method: 'GET',
+      status_code: '0',
+      error_code: 'INVALID_URL',
       target_host: 'invalid',
       target_path: 'invalid',
-      result: 'invalid_url',
     });
-    expect(targetHostCounter.inc).toHaveBeenCalled();
+    expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
     dispose();
   });
@@ -633,13 +643,15 @@ describe('provideHTTPProxyService', () => {
       { isAborted$: undefined },
     );
 
-    const targetHostCounter = getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total');
-    expect(targetHostCounter.labels).toHaveBeenCalledWith({
+    const requestsTotalCounter = mockMetrics.counter.mock.results[0].value;
+    expect(requestsTotalCounter.labels).toHaveBeenCalledWith({
+      method: 'GET',
+      status_code: '200',
+      error_code: 'none',
       target_host: 'invalid',
       target_path: 'invalid',
-      result: 'invalid_url',
     });
-    expect(targetHostCounter.inc).toHaveBeenCalled();
+    expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
     dispose();
   });
@@ -670,13 +682,15 @@ describe('provideHTTPProxyService', () => {
       ),
     ).rejects.toThrow('FORBIDDEN');
 
-    const targetHostCounter = getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total');
-    expect(targetHostCounter.labels).toHaveBeenCalledWith({
+    const requestsTotalCounter = mockMetrics.counter.mock.results[0].value;
+    expect(requestsTotalCounter.labels).toHaveBeenCalledWith({
+      method: 'GET',
+      status_code: '0',
+      error_code: 'FORBIDDEN',
       target_host: 'ip',
       target_path: '/',
-      result: 'blocked',
     });
-    expect(targetHostCounter.inc).toHaveBeenCalled();
+    expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
     dispose();
   });
@@ -721,13 +735,15 @@ describe('provideHTTPProxyService', () => {
       { isAborted$: undefined },
     );
 
-    const targetHostCounter = getCounterMetric(mockMetrics, 'http_proxy_target_host_requests_total');
-    expect(targetHostCounter.labels).toHaveBeenCalledWith({
+    const requestsTotalCounter = mockMetrics.counter.mock.results[0].value;
+    expect(requestsTotalCounter.labels).toHaveBeenCalledWith({
+      method: 'GET',
+      status_code: '200',
+      error_code: 'none',
       target_host: 'ip',
       target_path: '/',
-      result: 'ok',
     });
-    expect(targetHostCounter.inc).toHaveBeenCalled();
+    expect(requestsTotalCounter.inc).toHaveBeenCalled();
 
     dispose();
   });
@@ -782,6 +798,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '0',
       error_code: 'RESPONSE_TOO_LARGE',
+      target_host: 'api.example.com',
+      target_path: '/data',
     });
 
     // R9: errorsTotal.inc() should be called with error_type 'security'
@@ -887,6 +905,8 @@ describe('provideHTTPProxyService', () => {
       method: 'GET',
       status_code: '200',
       error_code: 'none',
+      target_host: 'api.example.com',
+      target_path: '/data',
     });
 
     // R7: requestDuration.observe() should use default method 'GET'


### PR DESCRIPTION
## What

- Add target host/path labels to `http_proxy_requests_total` in `@yuants/http-services`

## Why

- Provide visibility into downstream target distribution and error patterns per host/path

## How

- Extend `http_proxy_requests_total` with `target_host` and `target_path` labels
- Map results from existing handler error codes; derive host/path from `new URL(req.url)` parse result
- Extend tests to cover target_path defaulting, labels propagation, and invalid_url cases
- Update Grafana dashboard with target host/path panels and filters

## Testing

- `cd libraries/http-services && rushx build`

## Risk / Rollback

- Risk: `target_path` may increase metric cardinality; monitor and apply normalization/filters if needed
- Rollback: remove `target_host`/`target_path` labels from `http_proxy_requests_total` sampling logic

## Links

- RFC: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
- Walkthrough: `.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md`
