### PR TITLE
feat(http-services): add weighted proxy bucket acquisition

### DIFF
--- a/.legion/config.json
+++ b/.legion/config.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "currentTask": "http-services-terminalinfos-ready",
+  "currentTask": "vendor-tokenbucket-proxy-ip",
   "settings": {
     "autoRemind": true,
     "remindBeforeReset": true,
@@ -220,16 +220,16 @@
     {
       "id": "vendor-tokenbucket-proxy-ip",
       "name": "vendor-tokenbucket-proxy-ip",
-      "status": "paused",
+      "status": "active",
       "createdAt": "2026-02-03T16:40:42.595Z",
-      "updatedAt": "2026-02-05T11:41:19.733Z"
+      "updatedAt": "2026-02-13T16:19:38.955Z"
     },
     {
       "id": "http-services-terminalinfos-ready",
       "name": "http-services-terminalinfos-ready",
-      "status": "active",
+      "status": "paused",
       "createdAt": "2026-02-05T11:41:19.733Z",
-      "updatedAt": "2026-02-05T13:24:43.631Z"
+      "updatedAt": "2026-02-07T14:17:47.617Z"
     }
   ],
   "pendingProposals": [

--- a/.legion/config.json
+++ b/.legion/config.json
@@ -222,7 +222,7 @@
       "name": "vendor-tokenbucket-proxy-ip",
       "status": "active",
       "createdAt": "2026-02-03T16:40:42.595Z",
-      "updatedAt": "2026-02-13T16:19:38.955Z"
+      "updatedAt": "2026-03-05T09:57:57.230Z"
     },
     {
       "id": "http-services-terminalinfos-ready",

--- a/.legion/config.json
+++ b/.legion/config.json
@@ -222,7 +222,7 @@
       "name": "vendor-tokenbucket-proxy-ip",
       "status": "active",
       "createdAt": "2026-02-03T16:40:42.595Z",
-      "updatedAt": "2026-03-05T09:57:57.230Z"
+      "updatedAt": "2026-03-05T12:17:12.798Z"
     },
     {
       "id": "http-services-terminalinfos-ready",

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -2131,3 +2131,96 @@
 2026-02-05T13:11:19.363Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/walkthrough.md,success
 2026-02-05T13:11:25.140Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,addFile: .legion/tasks/http-services-terminalinfos-ready/docs/pr-body.md,success
 2026-02-05T13:24:43.640Z,legion_update_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,progress.completed: 已推送分支 `legion/http-services-terminalinfos-ready` 并创建 PR：https://github.com/No-Trade-No-Life/Yuan/pull/2565。,success
+2026-02-07T14:17:24.199Z,legion_get_status,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-07T14:17:40.720Z,legion_list_tasks,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,,success
+2026-02-07T14:17:47.625Z,legion_switch_task,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,taskId: vendor-tokenbucket-proxy-ip,success
+2026-02-07T14:17:50.444Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:17:50.444Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-07T14:19:37.389Z,legion_read_context,http-proxy-service,HTTP Proxy Service 实现,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:19:37.409Z,legion_read_context,http-proxy-app-implementation,HTTP Proxy App Implementation,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:19:37.409Z,legion_read_context,http-services-terminalinfos-ready,http-services-terminalinfos-ready,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:19:50.133Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 调研 tokenBucket util、http-services/http-proxy、vendor-binance 现状并形成约束清单,success
+2026-02-07T14:19:50.133Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 生成并迭代 RFC：多 IP 下按权重避免限流的负载均衡方案,success
+2026-02-07T14:19:50.134Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 完成设计门禁：更新 plan.md RFC 链接并等待用户确认,success
+2026-02-07T14:20:09.067Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDecision: 本轮沿用任务 vendor-tokenbucket-proxy-ip，RFC 输出路径固定为 `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`，设计目标升级为“多 IP 下按权重自动负载均衡并降低限流冲突”。,success
+2026-02-07T14:20:42.545Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:20:42.548Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-07T14:23:33.308Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:23:34.982Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:25:19.773Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDecision: 在进入实现前，RFC 必须先闭环 4 条 blocking（接口输入、错误归属、回滚模式、R10 可测性）。,success
+2026-02-07T14:25:28.151Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 修订 RFC：为 acquireProxyBucket 补齐 bucket options 输入来源（参数或回调），消除 helper 调用 tokenBucket 的配置歧义,success
+2026-02-07T14:25:28.151Z,legion_update_tasks,,,Claude,addDiscoveredTask: 修订 RFC：补充错误码阶段归属表，封闭 E_PROXY_TARGET_NOT_FOUND 与 E_PROXY_REQUEST_FAILED 边界,success
+2026-02-07T14:25:28.153Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 修订 RFC：重写 R10/T-R10 为可观测可断言行为（冲突 options 计数器/日志与返回语义）,success
+2026-02-07T14:25:28.154Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 修订 RFC：收敛灰度/回滚模式命名与开关取值，明确 legacy_rr_single_try / rr_multi_try / helper_acquire_proxy_bucket,success
+2026-02-07T14:25:46.281Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-07T14:26:01.554Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:26:01.569Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-07T14:28:46.308Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:28:46.339Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:30:35.770Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDecision: 复审阶段维持 NEEDS_CHANGES，最小修复集仅保留 1 项（统一 R10/T-R10 规范强度）。,success
+2026-02-07T14:30:40.653Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addTask: 修订 RFC：统一 R10 与 T-R10 的规范强度（MUST+硬断言或 SHOULD+软断言）,success
+2026-02-07T14:30:40.671Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addTask: RFC 再审完成（上一轮 4 个 blocking 闭环复核）,success
+2026-02-07T14:30:44.467Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: RFC 再审完成（上一轮 4 个 blocking 闭环复核）,success
+2026-02-07T14:30:44.490Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,setCurrentTask: 修订 RFC：统一 R10 与 T-R10 的规范强度（MUST+硬断言或 SHOULD+软断言）,success
+2026-02-07T14:30:52.437Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: [RFC复审] 统一 R10 与 T-R10 规范强度后再判定 PASS,success
+2026-02-07T14:31:27.347Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:32:19.224Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:32:21.732Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-07T14:32:21.734Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-07T14:33:36.783Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 完成最新 RFC 最终只读复审：结论 PASS（可实现/可验证/可回滚均满足），审查报告已写入 `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`。,success
+2026-02-07T14:34:08.758Z,legion_update_plan,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-07T14:34:46.643Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 完成设计循环收敛：RFC 经多轮 spec-rfc/review-rfc 对抗审查，最终结论 PASS。,success
+2026-02-07T14:34:49.876Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-08T15:34:58.292Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:35:13.319Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 设计门禁：等待用户确认 RFC（确认后进入 /legion-impl）,success
+2026-02-08T15:35:45.889Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:35:45.892Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"status: open, type: all",success
+2026-02-08T15:35:45.893Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T15:36:16.068Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:36:19.377Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,setCurrentTask: 实现 `acquireProxyBucket`（可承载组优先、多候选 acquire、options 冲突检测与指标）并导出 API,success
+2026-02-08T15:48:19.342Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"addDecision: vendor-binance 采用 `requestContext.acquireWeight`（proxy=0, direct=weight）兼容旧调用点中的显式 `tokenBucket(...).acquireSync(...)`，由 helper 在 proxy 分支负责真实 acquire。",success
+2026-02-08T15:48:23.994Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 实现 `acquireProxyBucket`（可承载组优先、多候选 acquire、options 冲突检测与指标）并导出 API,success
+2026-02-08T15:48:27.220Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 补充 http-services 单测覆盖 T-R 关键断言（优先组、候选切换、空池、route 无匹配、options 冲突）并执行构建验证,success
+2026-02-08T15:48:30.413Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,setCurrentTask: 等待用户 review 本轮实现与测试结果,success
+2026-02-08T15:49:25.297Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:49:27.567Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T15:49:27.575Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-08T15:49:28.802Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:49:28.951Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:49:31.777Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T15:53:56.556Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 执行验证测试：libraries/http-services 单测+构建，apps/vendor-binance 最小构建验证,success
+2026-02-08T15:53:58.827Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 执行验证测试：libraries/http-services 单测+构建，apps/vendor-binance 最小构建验证,success
+2026-02-08T15:54:05.515Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDecision: 本轮验证结论为 PASS；当前未发现 impl-dev 或 impl-test 阻塞失败项。,success
+2026-02-08T15:57:10.809Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 补齐 T-R11：不同 baseKey 状态互不影响测试,success
+2026-02-08T15:57:10.809Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 修复 R11：acquireProxyBucket 轮询游标按 baseKey 隔离,success
+2026-02-08T15:57:10.810Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 安全修复：acquireSync 仅对容量不足错误 fallback，其他错误 fail-closed,success
+2026-02-08T15:57:10.811Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 安全修复：bucketOptionsFingerprintByKey 增加容量上限与淘汰策略,success
+2026-02-08T15:57:10.811Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 安全修复：为 proxy terminal 增加可信 terminal allowlist 校验（fail-closed）,success
+2026-02-08T15:57:10.812Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T15:59:57.681Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T16:00:00.305Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T16:00:00.380Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T16:00:02.443Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T16:00:02.919Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T16:00:08.163Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T16:00:08.175Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-08T16:16:19.264Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"progress.completed: 验证执行（http-services 单测）：`npx heft test --clean` @ `libraries/http-services`，4 suites/34 total（30 passed, 0 failed），通过。",success
+2026-02-08T16:16:22.930Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 测试执行：重新验证 libraries/http-services（单测/构建）与 vendor-binance（构建）,success
+2026-02-08T16:16:25.317Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 测试执行：重新验证 libraries/http-services（单测/构建）与 vendor-binance（构建）,success
+2026-02-08T16:16:39.543Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addTask: 测试执行：重新验证 libraries/http-services（单测/构建）与 vendor-binance（构建）,success
+2026-02-08T16:19:38.205Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T16:19:42.257Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T16:19:42.273Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-08T16:19:42.289Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T16:19:45.907Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T16:19:45.920Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-08T16:21:41.372Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addFile: docs/review-security.md,success
+2026-02-08T16:23:01.841Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-08T16:23:01.863Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"status: open, type: all",success
+2026-02-08T16:23:01.864Z,legion_read_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,"section: all, includeReviews: true",success
+2026-02-08T16:24:49.924Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 阶段 A 完成：按 RFC 在 http-services/http-proxy/vendor-binance 落地 v2（acquireProxyBucket、stage 错误边界、terminal_id 绑定、冲突计数与 fail-closed）。,success
+2026-02-08T16:40:28.918Z,legion_list_reviews,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,status: open,success
+2026-02-12T03:37:38.432Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-02-13T16:19:28.118Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 已按 Scope 仅提交实现相关代码文件并创建提交：`feat(http-services): add weighted proxy bucket acquisition`。,success
+2026-02-13T16:19:34.854Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 创建实现 PR 并记录 URL,success
+2026-02-13T16:19:38.969Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 创建实现 PR 并记录 URL,success

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -2226,3 +2226,4 @@
 2026-02-13T16:19:38.969Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 创建实现 PR 并记录 URL,success
 2026-03-05T09:49:08.839Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
 2026-03-05T09:57:57.234Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 根据外部代码评审反馈修复高优问题：proxy 模式 `acquireWeight=0` 导致 `acquireSync(0)` 触发 `SEMAPHORE_INVALID_ACQUIRE_PERMS`。,success
+2026-03-05T12:17:12.800Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 根据 reviewer 反馈对齐 tokenBucket async/sync 语义：`acquire(0)` 与 `acquireSync(0)` 均为 no-op，负数仍报错。,success

--- a/.legion/ledger.csv
+++ b/.legion/ledger.csv
@@ -2224,3 +2224,5 @@
 2026-02-13T16:19:28.118Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 已按 Scope 仅提交实现相关代码文件并创建提交：`feat(http-services): add weighted proxy bucket acquisition`。,success
 2026-02-13T16:19:34.854Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,addDiscoveredTask: 创建实现 PR 并记录 URL,success
 2026-02-13T16:19:38.969Z,legion_update_tasks,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,completeTask: 创建实现 PR 并记录 URL,success
+2026-03-05T09:49:08.839Z,legion_get_status,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,,success
+2026-03-05T09:57:57.234Z,legion_update_context,vendor-tokenbucket-proxy-ip,vendor-tokenbucket-proxy-ip,Claude,progress.completed: 根据外部代码评审反馈修复高优问题：proxy 模式 `acquireWeight=0` 导致 `acquireSync(0)` 触发 `SEMAPHORE_INVALID_ACQUIRE_PERMS`。,success

--- a/.legion/tasks/http-proxy-app-implementation/docs/pr-body-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/pr-body-metrics.md
@@ -16,7 +16,7 @@
 ## Testing
 
 ```bash
-cd /Users/c1/Work/Yuan/libraries/http-services
+cd libraries/http-services
 rushx build
 ```
 
@@ -27,7 +27,7 @@ rushx build
 
 ## Links
 
-- RFC: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
-- Walkthrough: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md`
-- Code Review: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md`
-- Security Review: `/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md`
+- RFC: `.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+- Walkthrough: `.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md`
+- Code Review: `.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md`
+- Security Review: `.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md`

--- a/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md
+++ b/.legion/tasks/http-proxy-app-implementation/docs/report-walkthrough-metrics.md
@@ -4,16 +4,16 @@
 
 - 目标：为 HTTP Proxy 增加“目标域名 + 路径”维度的请求计数标签，便于按 host/path 聚合观测，不改变现有请求处理与 SSRF 行为。
 - 范围（Scope 绑定）：
-  - 代码：`/Users/c1/Work/Yuan/libraries/http-services/src/server.ts`
-  - 测试：`/Users/c1/Work/Yuan/libraries/http-services/src/__tests__/server.test.ts`
+  - 代码：`libraries/http-services/src/server.ts`
+  - 测试：`libraries/http-services/src/__tests__/server.test.ts`
   - 设计与评审：
-    - RFC：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
-    - 代码审查：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md`
-    - 安全审查：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md`
+    - RFC：`.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+    - 代码审查：`.legion/tasks/http-proxy-app-implementation/docs/review-code-metrics.md`
+    - 安全审查：`.legion/tasks/http-proxy-app-implementation/docs/review-security-metrics.md`
 
 ## 设计摘要
 
-- 设计真源：`/Users/c1/Work/Yuan/.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
+- 设计真源：`.legion/tasks/http-proxy-app-implementation/docs/rfc-metrics.md`
 - 关键设计点：
   - 指标解析仅复用 handler 内 `new URL(req.url)` 的 `parse_result`，不做二次解析。
   - `target_host`：IP 字面量固定为 `ip`，解析失败或 hostname 为空为 `invalid`，其余按 hostname 规范化记录。
@@ -34,7 +34,7 @@
 1. 运行构建与测试（库内）：
 
 ```bash
-cd /Users/c1/Work/Yuan/libraries/http-services
+cd libraries/http-services
 rushx build
 ```
 

--- a/.legion/tasks/vendor-http-services-rollout/docs/pr-body-fix.md
+++ b/.legion/tasks/vendor-http-services-rollout/docs/pr-body-fix.md
@@ -23,7 +23,7 @@
 
 # Links
 
-- RFC: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/rfc.md`
-- Walkthrough: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md`
-- Review Code: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md`
-- Review Security: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/review-security-fix.md`
+- RFC: `.legion/tasks/vendor-http-services-rollout/docs/rfc.md`
+- Walkthrough: `.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md`
+- Review Code: `.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md`
+- Review Security: `.legion/tasks/vendor-http-services-rollout/docs/review-security-fix.md`

--- a/.legion/tasks/vendor-http-services-rollout/docs/pr-body.md
+++ b/.legion/tasks/vendor-http-services-rollout/docs/pr-body.md
@@ -23,7 +23,7 @@
 
 # Links
 
-- RFC: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/rfc.md`
-- Walkthrough: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md`
-- Review Code: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md`
-- Review Security: `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/review-security-fix.md`
+- RFC: `.legion/tasks/vendor-http-services-rollout/docs/rfc.md`
+- Walkthrough: `.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md`
+- Review Code: `.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md`
+- Review Security: `.legion/tasks/vendor-http-services-rollout/docs/review-security-fix.md`

--- a/.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md
+++ b/.legion/tasks/vendor-http-services-rollout/docs/report-walkthrough-fix.md
@@ -7,8 +7,8 @@
 
 ## 设计摘要
 
-- RFC：`/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/rfc.md`
-- 评审：`/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md`，`/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/review-security-fix.md`
+- RFC：`.legion/tasks/vendor-http-services-rollout/docs/rfc.md`
+- 评审：`.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md`，`.legion/tasks/vendor-http-services-rollout/docs/review-security-fix.md`
 - 关键设计：在 http-services 覆盖前缓存 `globalThis.__yuantsNativeFetch`，为 proxy fetch 打标记；`Terminal` 构造中优先使用稳定 native fetch，且在 `USE_HTTP_PROXY=true` 或 native fetch 不可用/被标记时跳过 public IP 获取。
 
 ## 改动清单（按模块/文件类型）

--- a/.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md
+++ b/.legion/tasks/vendor-http-services-rollout/docs/review-code-fix.md
@@ -4,7 +4,7 @@
 
 PASS
 
-基于有限信息的评审：仅审查 `libraries/http-services/src/client.ts` 与 `libraries/protocol/src/terminal.ts`，对照 RFC `/Users/c1/Work/Yuan/.legion/tasks/vendor-http-services-rollout/docs/rfc.md`。
+基于有限信息的评审：仅审查 `libraries/http-services/src/client.ts` 与 `libraries/protocol/src/terminal.ts`，对照 RFC `.legion/tasks/vendor-http-services-rollout/docs/rfc.md`。
 
 ## Blocking Issues
 

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/context.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/context.md
@@ -131,6 +131,10 @@
 - 已按 Scope 仅提交实现相关代码文件并创建提交：`feat(http-services): add weighted proxy bucket acquisition`。
 - 已推送分支 `legion/feature-proxy-bucket-v2` 到 fork。
 - 已创建上游 PR：`https://github.com/No-Trade-No-Life/Yuan/pull/2580`（head: `Thrimbda:legion/feature-proxy-bucket-v2`，base: `main`）。
+- 根据外部代码评审反馈修复高优问题：proxy 模式 `acquireWeight=0` 导致 `acquireSync(0)` 触发 `SEMAPHORE_INVALID_ACQUIRE_PERMS`。
+- 在 `libraries/utils/src/tokenBucket.ts` 将 `acquireSync(0)` 定义为 no-op，并在 `libraries/utils/src/tokenBucket.test.ts` 补充回归测试。
+- 验证通过：`npx heft test --clean`（libraries/utils）与 `rush build --to @yuants/vendor-binance`。
+- 已提交并推送修复提交：`fix(utils): treat tokenBucket acquireSync(0) as no-op`。
 
 ### 🟡 进行中
 
@@ -173,12 +177,11 @@
 
 **下次继续从这里开始：**
 
-1. 等待代码评审与 CI 结果。
-2. 如需补充说明，优先更新 `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body.md` 并同步到 PR。
+1. 等待 PR #2580 新一轮 CI 与 reviewer 复核。
 
 **注意事项：**
 
-- 本次提交严格限定在实现 Scope 内文件，未纳入 `.legion` 运行态文件（config/ledger/context/plan/tasks）。
+- 此次修复直接针对 reviewer 报告中的系统性运行时失败（proxy 模式下所有 Binance 请求前置失败）。
 
 ---
 

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/context.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/context.md
@@ -135,6 +135,9 @@
 - 在 `libraries/utils/src/tokenBucket.ts` 将 `acquireSync(0)` 定义为 no-op，并在 `libraries/utils/src/tokenBucket.test.ts` 补充回归测试。
 - 验证通过：`npx heft test --clean`（libraries/utils）与 `rush build --to @yuants/vendor-binance`。
 - 已提交并推送修复提交：`fix(utils): treat tokenBucket acquireSync(0) as no-op`。
+- 根据 reviewer 反馈对齐 tokenBucket async/sync 语义：`acquire(0)` 与 `acquireSync(0)` 均为 no-op，负数仍报错。
+- 新增/更新 utils 回归测试覆盖 zero-token async/sync 行为与负数校验。
+- 验证通过：`npx heft test --clean`（libraries/utils）；修复提交已 push 到 PR 分支。
 
 ### 🟡 进行中
 

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/context.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/context.md
@@ -86,6 +86,51 @@
 - 验证：`rush build --to @yuants/vendor-binance` 通过。
 - 在 http-services 集成测试中增加 CI/CI_RUN 跳过逻辑，避免 CI 运行 E2E/Integration。
 - Gate 测试在 HOST_URL 未设置时跳过，并延迟导入依赖，避免 fromNodeEnv 在测试加载阶段直接报错。
+- 完成现状调研：已阅读 tokenBucket util、http-services/proxy-ip、http-proxy 启动注入、vendor-binance 按 weight 限流调用链。
+- 确认当前核心行为：ip 选择为 round robin，tokenBucket 维度为 encodePath([baseKey, ip])，请求通过 labels.ip 路由。
+- 识别关键约束：tokenBucket 仅暴露 acquire/acquireSync/read，acquireSync 在令牌不足时立即抛错；Terminal 路由对多候选服务默认随机。
+- 按最新任务目标完成 RFC 覆盖重写（v2）：聚焦“按权重自动负载均衡 + 主动限流”，明确方案 A/B 对比并推荐方案 B（`acquireProxyBucket`）。
+- 在 RFC 中补齐 Problem/Constraints（3 条调研事实）、状态机、数据模型、错误语义、可观测性、Testability（R1-R12）与回滚到 RR 策略。
+- 已同步更新 `plan.md` 摘要（核心流程/接口变更/文件清单/验证策略）并在 `tasks.md` 勾选“RFC 生成完成”。
+- 完成 v2 RFC 剃刀原则对抗审查并落盘报告：`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`。
+- 审查结论更新为 NEEDS_CHANGES，识别 4 项 blocking：接口输入不足、错误码边界重叠、回滚目标冲突、R10/T-R10 不可测。
+- 已按 latest review 完成 RFC 最小修订并闭环 4 个 blocking：
+  - `acquireProxyBucket` 明确 options 来源为 `getBucketOptions(baseKey)`，禁止隐式默认 options。
+  - 新增错误阶段归属表（`pool|acquire|route|request`），封闭 `E_PROXY_TARGET_NOT_FOUND` 与 `E_PROXY_REQUEST_FAILED` 边界。
+  - 固化灰度/回滚模式命名：`legacy_rr_single_try`、`rr_multi_try`、`helper_acquire_proxy_bucket`，并写明默认/灰度/回滚值和 30 分钟验证窗口。
+  - 将 R10/T-R10 改为可观测行为：`bucket_options_conflict_total` 计数 + `E_BUCKET_OPTIONS_CONFLICT` 返回语义。
+- 同步更新 `plan.md` 摘要与 `tasks.md` 进展记录，保持 RFC 作为设计真源。
+- 完成 RFC 再次对抗复审（聚焦上一轮 4 个 blocking 闭环与新增阻塞识别），结论为 NEEDS_CHANGES。
+- 复审确认已闭环：options 来源、错误阶段归属边界、灰度/回滚模式命名与操作窗口。
+- 识别新增 blocking：R10 为 SHOULD 而 T-R10 为硬断言，规范强度冲突导致可实现/可验证不一致。
+- 复审报告已写入 `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`。
+- 已完成 RFC 最小修订：将 R10 升级为 MUST，并同步将 Goals 中“可承载组优先”由 SHOULD 升级为 MUST，消除与 T-R10 硬断言的规范强度歧义。
+- 完成最新 RFC 最终只读复审：结论 PASS（可实现/可验证/可回滚均满足），审查报告已写入 `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`。
+- 本轮无必须修正项，仅保留 3 条可选优化建议（T-R10 并发判定锚点、模式开关配置落点、观测样例字段）。
+- 完成设计循环收敛：RFC 经多轮 spec-rfc/review-rfc 对抗审查，最终结论 PASS。
+- 已更新 plan.md 的 RFC 真源链接、摘要、范围与阶段，Scope 收敛到 http-services/http-proxy/vendor-binance。
+- 完成 http-services v2 helper：`acquireProxyBucket(input)`（强制 `getBucketOptions(baseKey)`、可承载组优先、候选失败切换、全失败 `E_PROXY_BUCKET_EXHAUSTED`、空池 `E_PROXY_TARGET_NOT_FOUND`、options 冲突 `E_BUCKET_OPTIONS_CONFLICT` + `bucket_options_conflict_total`）。
+- 完成 http-services route/request 阶段错误语义：`fetch` 路由异常归类为 `E_PROXY_TARGET_NOT_FOUND`（stage=route），代理响应失败归类为 `E_PROXY_REQUEST_FAILED`（stage=request）。
+- 完成 vendor-binance 接入：`createRequestContext(baseKey, weight)` 在代理模式改用 helper 获取 `{ip,bucketKey}`；public/private API 统一使用 `requestContext.bucketKey` 与 `requestContext.acquireWeight`，确保 key/路由同源并避免重复扣减。
+- 新增并通过单测：`proxy-ip.test.ts` 覆盖优先组、高权重选择、失败切换、空池、全失败、options 冲突；`client.test.ts` 覆盖 route/request 错误码边界。
+- 验证通过：`npx heft test --clean`（libraries/http-services）；`rush build --to @yuants/vendor-binance`。
+- 验证执行（http-services 单测）：`npx heft test --clean` @ `libraries/http-services`，4 suites/31 tests，0 失败。
+- 验证执行（http-services 构建）：`npm run build` @ `libraries/http-services`，通过（含 test+api-extractor+post-build）。
+- 验证执行（vendor-binance 最小构建）：`npm run build` @ `apps/vendor-binance`，通过（Jest 0 suites, code 0；TypeScript/API Extractor 通过）。
+- 交叉验证（依赖图构建）：`rush build --to @yuants/vendor-binance` @ repo root，通过（20/20 from cache）。
+- 验证执行（http-services 单测）：`npx heft test --clean` @ `libraries/http-services`，4 suites/34 total（30 passed, 0 failed），通过。
+- 验证执行（http-services 构建）：`npm run build` @ `libraries/http-services`，通过（heft test + API Extractor + post-build 全流程完成）。
+- 验证执行（vendor-binance 构建）：`npm run build` @ `apps/vendor-binance`，通过（Jest 0 suites code 0，TypeScript/API Extractor 通过）。
+- 完成最新代码只读安全复审并确认此前 3 个 blocking 已闭环。
+- 基于最新实现生成并落盘 walkthrough：`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md`。
+- 基于最新实现生成并落盘 PR Body 建议：`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body-impl.md`。
+- 汇总结论：实现验收通过（http-services 单测 4 suites/35 total/0 failed；定向构建通过；review-code PASS；review-security PASS）。
+- 阶段 A 完成：按 RFC 在 http-services/http-proxy/vendor-binance 落地 v2（acquireProxyBucket、stage 错误边界、terminal_id 绑定、冲突计数与 fail-closed）。
+- 阶段 B 完成：复测通过（heft test + rush build）且 review-code/review-security 最终均为 PASS。
+- 阶段 C 完成：生成 impl 版 walkthrough 与 PR body（report-walkthrough-impl.md / pr-body-impl.md）。
+- 已按 Scope 仅提交实现相关代码文件并创建提交：`feat(http-services): add weighted proxy bucket acquisition`。
+- 已推送分支 `legion/feature-proxy-bucket-v2` 到 fork。
+- 已创建上游 PR：`https://github.com/No-Trade-No-Life/Yuan/pull/2580`（head: `Thrimbda:legion/feature-proxy-bucket-v2`，base: `main`）。
 
 ### 🟡 进行中
 
@@ -119,6 +164,8 @@
 | bench 默认仅允许本地 HOST_URL；远端需显式 ALLOW_REMOTE_HOST=true。                                                                                                                          | 避免共享 Host 干扰与外部请求导致 bench 失败。                                                                                                            | 始终使用 HOST_URL（可能引入外部流量与噪声）                                                                                            | 2026-02-04 |
 | Bench failure classified as impl-dev (proxy-ip watch undefined), not impl-test.                                                                                                             | Stack trace points to runtime undefined access in `ensureProxyIpWatch` before selector benchmark assertions run; no evidence of test assertion mismatch. | If environment variables or host setup are required for bench, could be env issue; currently error occurs before host-dependent steps. | 2026-02-05 |
 | 安全问题暂不处理：集群处于可信环境，ip_source 信任边界不再阻塞当前工作。                                                                                                                    | 用户明确表示安全暂时不要管，可信环境内运行。                                                                                                             | 补齐 Host 侧鉴权/签名或白名单机制                                                                                                      | 2026-02-05 |
+| 推荐 v2 采用方案 B（`http-services.acquireProxyBucket`），方案 A 作为最小侵入/回滚路径。                                                                                                    | 集中维护候选选择、acquire 失败切换与 cooldown，可统一错误语义与观测，并保证 `bucketKey.ip` 与 `labels.ip` 同源。                                         | 仅在 vendor 内做 RR+多次 acquire（实现快但会重复逻辑、行为易分叉）。                                                                   | 2026-02-07 |
+| 最新 RFC 修订中固定 `acquireProxyBucket` 的 options 来源为 `getBucketOptions(baseKey)`，并以错误阶段归属表封闭错误边界。                                                                    | 消除 helper 隐式默认 options 漂移与 route/request 错分，保证实现一致性与测试稳定性。                                                                     | 继续保留模糊 options 来源与宽泛请求失败归类（风险：实现歧义、断言不稳定）。                                                            | 2026-02-07 |
 
 ---
 
@@ -126,14 +173,13 @@
 
 **下次继续从这里开始：**
 
-1. Walkthrough 与 PR Body 已生成：`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough.md`、`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body.md`（rollout 版本同目录）。
-2. 如需继续验证，可补充运行包级 `rushx test` 或指定测试集。
-3. 如要收敛安全建议，优先处理 public_ip 缺失的 fallback 隔离与 proxy 路由日志补齐。
+1. 等待代码评审与 CI 结果。
+2. 如需补充说明，优先更新 `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body.md` 并同步到 PR。
 
 **注意事项：**
 
-- 构建输出无错误，仅提示 Node 版本未测试（Node.js 24.11.0）。
+- 本次提交严格限定在实现 Scope 内文件，未纳入 `.legion` 运行态文件（config/ledger/context/plan/tasks）。
 
 ---
 
-_最后更新: 2026-02-05 00:47 by Claude_
+_最后更新: 2026-02-09 by OpenCode_

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body-impl.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body-impl.md
@@ -1,0 +1,29 @@
+# Summary
+
+- 在 `http-services` 落地 `acquireProxyBucket`，实现“可承载组优先 + 候选失败切换”的主动限流选择逻辑，统一 options 来源并新增冲突保护。
+- 在 `client.fetch` 明确 route/request 阶段错误边界：route 统一 `E_PROXY_TARGET_NOT_FOUND`，request 统一 `E_PROXY_REQUEST_FAILED`。
+- 在 `vendor-binance` 接入统一 request context：代理模式使用 helper 返回的 `{ip, terminalId, bucketKey}`，直连模式使用 `public_ip` 维度；确保限流 key 与 `labels.ip` 路由一致。
+- 在 `http-proxy` 仅接受 `ip_source=http-services` 的标签注入，收敛 proxy 路由信任边界。
+
+# Testing
+
+- `cd libraries/http-services && npx heft test --clean` ✅ (4 suites, 35 total, 0 failed)
+- `rush build --to @yuants/vendor-binance --to @yuants/app-http-proxy` ✅
+- review 结果：`review-code PASS`，`review-security PASS`
+
+# Risks
+
+- `TRUSTED_HTTP_PROXY_TERMINAL_IDS` 配置缺失/错误会触发 fail-closed（`E_PROXY_TARGET_NOT_FOUND`）。
+- 直连场景 `public_ip` 缺失会降级到 `public-ip-unknown`，存在跨终端共享桶风险。
+- 同 `bucketKey` options 来源不一致时会触发 `E_BUCKET_OPTIONS_CONFLICT` 并中断请求。
+
+# Rollback
+
+- 回滚到上一稳定版本，恢复旧版 proxy 选择/限流路径。
+- 如需快速止血，优先切回旧代理调用逻辑并持续观察 `E_PROXY_TARGET_NOT_FOUND`、`E_PROXY_BUCKET_EXHAUSTED`、请求成功率。
+
+# Links
+
+- RFC: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+- Review RFC: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`
+- Walkthrough: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md`

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body-impl.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/pr-body-impl.md
@@ -24,6 +24,6 @@
 
 # Links
 
-- RFC: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
-- Review RFC: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`
-- Walkthrough: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md`
+- RFC: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+- Review RFC: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`
+- Walkthrough: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md`

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md
@@ -16,8 +16,8 @@
 
 ## 设计摘要
 
-- RFC：`/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
-- 最终 RFC 复审：`/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`
+- RFC：`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+- 最终 RFC 复审：`.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`
 - 方案主线（问题 -> 方案）：
   - 问题：旧流程先 RR 选 IP 再单次 `acquireSync(weight)`，对实时余量不敏感，导致高权重请求更易失败、全局容量利用不足。
   - 方案：在 `http-services` 集中提供 `acquireProxyBucket`，先按 `read() >= weight` 的候选优先尝试，再 fallback 到其余候选；并把 route/request 错误阶段化，避免语义混淆。

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough-impl.md
@@ -1,0 +1,119 @@
+# Walkthrough Report - vendor-tokenbucket-proxy-ip (impl)
+
+## 目标与范围
+
+- 目标：落地 RFC v2 方案，在代理模式下实现“按权重优先可承载组 + 逐候选主动 acquire”的限流与路由一体化，确保 `bucketKey` 与 `labels.ip` 同源。
+- 范围（绑定本轮 Scope）：
+  - `libraries/http-services/src/proxy-ip.ts`
+  - `libraries/http-services/src/client.ts`
+  - `libraries/http-services/src/__tests__/proxy-ip.test.ts`
+  - `libraries/http-services/src/__tests__/client.test.ts`
+  - `libraries/http-services/etc/http-services.api.md`
+  - `apps/http-proxy/src/index.ts`
+  - `apps/vendor-binance/src/api/client.ts`
+  - `apps/vendor-binance/src/api/public-api.ts`
+  - `apps/vendor-binance/src/api/private-api.ts`
+
+## 设计摘要
+
+- RFC：`/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+- 最终 RFC 复审：`/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md`
+- 方案主线（问题 -> 方案）：
+  - 问题：旧流程先 RR 选 IP 再单次 `acquireSync(weight)`，对实时余量不敏感，导致高权重请求更易失败、全局容量利用不足。
+  - 方案：在 `http-services` 集中提供 `acquireProxyBucket`，先按 `read() >= weight` 的候选优先尝试，再 fallback 到其余候选；并把 route/request 错误阶段化，避免语义混淆。
+  - 一致性：vendor 仅消费 `{ ip, terminalId, bucketKey }` 结果，确保限流 key、路由标签与实际代理出口绑定。
+
+## 关键实现（按模块）
+
+### 1) http-services: proxy 选择与主动限流
+
+- `libraries/http-services/src/proxy-ip.ts`
+  - 新增 `acquireProxyBucket(input)`：
+    - 强制 `getBucketOptions(baseKey)` 作为 options 唯一来源；缺失时返回 `E_BUCKET_OPTIONS_CONFLICT`。
+    - 只在可信代理集合中选目标（`TRUSTED_HTTP_PROXY_TERMINAL_IDS` + `ip_source=http-services`）。
+    - 按 `baseKey` 维护独立 RR 光标，先试 `available >= weight` 的候选，再试其余候选。
+    - `SEMAPHORE_INSUFFICIENT_PERMS` 视为可恢复容量不足，自动切下个候选；全部失败返回 `E_PROXY_BUCKET_EXHAUSTED`。
+  - 新增 options 冲突防护：
+    - 对同 `bucketKey` 记录 options 指纹，冲突时递增 `bucket_options_conflict_total{base_key,bucket_key}` 并返回 `E_BUCKET_OPTIONS_CONFLICT`。
+  - 保留并增强 proxy IP 缓存与信任边界：
+    - `listHTTPProxyIps`/watcher 缓存、dispose 清理、缺失标签限频日志。
+
+### 2) http-services: route/request 错误阶段化
+
+- `libraries/http-services/src/client.ts`
+  - 路由失败（`requestForResponse` 抛错）统一映射 `E_PROXY_TARGET_NOT_FOUND`，`stage=route`。
+  - 代理响应异常（`code != 0` 或无 data）统一映射 `E_PROXY_REQUEST_FAILED`，`stage=request`。
+
+### 3) http-services: 测试与 API 导出
+
+- `libraries/http-services/src/__tests__/proxy-ip.test.ts`
+  - 覆盖优先组选择、acquire 失败切换、空池、全失败、options 冲突、baseKey 隔离、allowlist fail-closed、内部异常映射、同 IP 绑定 trusted terminal。
+- `libraries/http-services/src/__tests__/client.test.ts`
+  - 覆盖 route/request 错误码边界，验证阶段语义。
+- `libraries/http-services/etc/http-services.api.md`
+  - API report 同步新增 `acquireProxyBucket`、`AcquireProxyBucketInput`、`AcquireProxyBucketResult`。
+
+### 4) http-proxy: 标签可信来源收敛
+
+- `apps/http-proxy/src/index.ts`
+  - 启动时 `computeAndInjectProxyIp` 注入本机出口 IP。
+  - 仅当 `ip_source === http-services` 时才下发 `labels.ip`，否则记录告警并跳过，避免不可信标签参与路由。
+
+### 5) vendor-binance: 请求上下文统一接入
+
+- `apps/vendor-binance/src/api/client.ts`
+  - 新增 `createRequestContext(baseKey, weight)`：
+    - 代理模式：调用 `acquireProxyBucket`，返回 `{ ip, terminalId, bucketKey, acquireWeight: 0 }`，避免重复扣减。
+    - 直连模式：使用 `public_ip`（缺失则 `public-ip-unknown` + 限频日志），并本地执行 acquire。
+  - 请求发送时把 `labels.ip`（可选带 `terminal_id`）写入 `fetch`，确保路由与 key 对齐。
+- `apps/vendor-binance/src/api/public-api.ts`
+- `apps/vendor-binance/src/api/private-api.ts`
+  - 全量 API 调用统一改为使用 `requestContext.bucketKey` 与 `requestContext.acquireWeight`。
+
+## 如何验证
+
+### 命令
+
+```bash
+cd libraries/http-services && npx heft test --clean
+rush build --to @yuants/vendor-binance --to @yuants/app-http-proxy
+```
+
+### 预期结果
+
+- `libraries/http-services`：通过（4 suites, 35 total, 0 failed）。
+- repo 定向构建：通过（`@yuants/vendor-binance` 与 `@yuants/app-http-proxy`）。
+- 复审结论：`review-code PASS`，`review-security PASS`。
+
+## Benchmark 结果或门槛说明
+
+- 本轮实现未新增独立 benchmark 产物，且未提供可复现的 impl 基准数据。
+- 门槛说明：以功能正确性与回归安全为主，验收门槛由单测通过 + 定向构建通过 + code/security review PASS 组成。
+
+## 可观测性
+
+- 冲突与错误：
+  - `bucket_options_conflict_total{base_key,bucket_key}`（options 漂移检测）。
+  - error payload 统一包含 `stage` 与 `reason`，用于区分 `pool/acquire/route/request`。
+- Binance 侧业务指标：
+  - `binance_api_request_total`。
+  - `binance_api_used_weight`。
+- 运行日志：
+  - `http-services` 对空 allowlist、未信任 terminal、缺失/不可信 IP 标签做限频日志。
+  - `http-proxy` 启动时打印最终 labels，便于确认 `labels.ip` 注入状态。
+
+## 风险与回滚
+
+- 风险：
+  - `TRUSTED_HTTP_PROXY_TERMINAL_IDS` 未配置或配置错误时会 fail-closed，导致 `E_PROXY_TARGET_NOT_FOUND`。
+  - `public_ip` 缺失时落到 `public-ip-unknown`，可能带来跨终端桶共享。
+  - 同 `bucketKey` 配置不一致会触发冲突终止（`E_BUCKET_OPTIONS_CONFLICT`），需排查配置来源。
+- 回滚：
+  - 优先回滚到上一稳定版本（恢复旧 RR/旧 key 行为）。
+  - 若需保守运行，可短期将代理链路切换到旧调用路径并观察错误率恢复。
+
+## 未决项与下一步
+
+- 为 `public-ip-unknown` 提供更强隔离 fallback（如拼接 terminal 维度）以降低串桶风险。
+- 补充 impl 级 benchmark（高并发 + 多权重混合流量）并固化阈值。
+- 把 `stage/error_code` 聚合看板接入告警策略，形成完整 SLO 回归门禁。

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md
@@ -1,6 +1,6 @@
 # RFC 对抗审查报告: Proxy IP TokenBucket v2（最终只读复审）
 
-目标文档: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+目标文档: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
 审查日期: 2026-02-07
 原则: 奥卡姆剃刀（逐条质疑必要性/假设/边界/复杂度，优先最小复杂度收敛）
 

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md
@@ -1,35 +1,45 @@
-# RFC 对抗审查报告: TokenBucket Proxy IP Key
+# RFC 对抗审查报告: Proxy IP TokenBucket v2（最终只读复审）
 
-目标文档: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
-审查日期: 2026-02-04
-原则: 奥卡姆剃刀（质疑必要性、假设、边界、复杂度）
+目标文档: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+审查日期: 2026-02-07
+原则: 奥卡姆剃刀（逐条质疑必要性/假设/边界/复杂度，优先最小复杂度收敛）
 
-## 结论概述
+## 结论
 
-本次聚焦“error_code 归属表”闭环与阶段归属一致性。`E_PUBLIC_IP_MISSING` 已从错误码集合移除并降级为直连场景日志/指标，error_code 边界与阶段归属已封闭；归属表覆盖 `resolveHTTPProxyTarget` 与发送阶段全部错误码。当前无阻塞。
+`PASS`
 
-## 必须修正
+当前文本已满足进入设计门禁的三个必要条件：
 
-（无）
+- 可实现：输入边界、状态机、错误阶段、模式切换都已收敛为可编码约束。
+- 可验证：`R1-R15` 与 `T-R1-T-R15` 一一映射，负例断言覆盖关键失败路径。
+- 可回滚：模式命名、默认/灰度/回滚值与观测窗口已明确定义，可执行回切。
 
-## 可选优化
+## 关键收敛检查（只读结论）
 
-1. 明确 `E_PROXY_REQUEST_FAILED` 的边界与归一化口径
+1. 设计必要性
 
-- 质疑: 该错误码仅在“发送阶段才可能产生”，但未说明由哪个层面归一化网络错误（http-services 还是 vendor）。
-- 最小修改建议: 在“错误码归属”或接口注记中补一句“仅由 `fetchViaHTTPProxyTarget` 统一映射产生，resolve 阶段不得返回该码”，避免实现重复映射或遗漏。
+- `acquireProxyBucket` 作为统一入口保留，避免 vendor 侧重复实现与语义漂移，复杂度收益比成立。
 
-2. 将“候选枚举 MUST”提升到 Behavior Requirements
+2. 设计假设与边界
 
-- 质疑: 枚举 MUST 目前在接口注记中，可能被忽略而落回单 target 解析，破坏 no_service/no_match 区分。
-- 最小修改建议: 在 R20/R21 后追加一句“候选枚举 MUST 基于 `resolveTargetServicesSync`（或等价接口）”。
+- options 来源固定为 `getBucketOptions(baseKey)`，消除了 helper 隐式默认配置的歧义。
+- 错误边界通过 `pool|acquire|route|request` 归属表与 `R14/R15` 封闭，无跨阶段吞并。
 
-## 可实现性/可验证性/可回滚性检查
+3. 复杂度控制
 
-- 可实现性: error_code 归属表覆盖完整，resolve 枚举前提已说明。
-- 可验证性: 归属表闭环，测试可覆盖 resolve/发送阶段边界与错误映射。
-- 可回滚性: 无新增开关，仅代码回退即可。
+- 三模式并存但职责清晰：`helper_acquire_proxy_bucket`（目标）、`rr_multi_try`（默认）、`legacy_rr_single_try`（回滚）。
+- 未引入中心化状态或新持久化依赖，保持实现最小侵入。
 
-## 阻塞判断
+## 可选优化（非阻塞）
 
-无阻塞。
+1. 为 `T-R10` 增加并发判定锚点
+
+- 建议在测试描述中明确“以候选构造时 `read()` 快照分组”为断言基准，减少高并发抖动。
+
+2. 明确模式开关配置落点
+
+- 建议在 Rollout 补一行“配置键路径/环境变量名”，降低运维误配概率。
+
+3. 补充最小观测样例
+
+- 建议在 Observability 增加 1 条示例日志字段（`stage,error_code,base_key,ip`），便于跨团队对齐。

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md
@@ -1,275 +1,258 @@
-# RFC: TokenBucket Proxy IP Key
+# RFC: Proxy IP TokenBucket v2（按权重负载均衡 + 主动限流）
 
-Status: Draft
-Target: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
-Date: 2026-02-04
+Status: Draft (Design Only)
+Target Path: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+Date: 2026-02-07
 
 ## Abstract
 
-为 USE_HTTP_PROXY 场景下的 vendor tokenBucket key 增加“目标 http-proxy 终端 ip 标签”维度，确保限流按真实出口 IP 生效，并保证 key 与实际代理路由一致。
+本文定义多 `http-proxy` IP 场景下的 v2 协议：在发送请求前先完成 IP 选择与令牌获取，优先尝试可承载当前 `weight` 的 bucket，降低 `acquireSync(weight)` 失败与上游 429 概率。本文是实现阶段唯一设计真源。
 
 ## Motivation
 
-当前 tokenBucket key 多以 host 或固定 key 作为维度。在 USE_HTTP_PROXY=true 时，请求会通过 app-http-proxy 终端出网，真实出口 IP 与 key 不一致，导致限流失真。
+现网流程是先 RR 选 IP，再对该 IP 执行一次 `acquireSync(weight)`。在多 IP、混合权重流量下，该流程对实时余量不敏感，导致局部耗尽与全局容量浪费。
+
+### Problem / Constraints（来自现状调研）
+
+1. `tokenBucket` 以 `bucketId` 全局共享；同 `bucketId` 后续 options 会被忽略；`acquireSync(tokens)` 令牌不足即抛错；`read()` 无 ETA。
+2. `fetch` 使用 `labels.ip` 路由；当 `labels.ip` 无匹配目标时会在路由阶段失败。
+3. 现网 vendor 的 bucket options 来源在 vendor 侧，若 helper 使用隐式默认 options 会与现网容量语义漂移。
 
 ## Goals & Non-Goals
 
 ### Goals
 
-- 在 USE_HTTP_PROXY=true 时，tokenBucket key 必须包含“目标 proxy 终端的 ip 标签”。
-- 在非代理场景下使用本机 `terminal.terminalInfo.tags.public_ip`。
-- key 的 ip 维度必须与请求使用的 `labels.ip` 一致。
-- 先在 vendor-binance 落地验证，再推广到其他 vendor。
+- 在 `USE_HTTP_PROXY=true` 时，请求 MUST 在发送前完成“选 IP + acquire”。
+- 调度 MUST 优先尝试“当前 `read() >= weight` 的候选组”，再尝试其余候选组。
+- `bucketKey` 中 IP 与 `fetch.labels.ip` MUST 同源，确保限流与路由一致。
+- 首次落地 `apps/vendor-binance`，随后 MAY 推广到其他 vendor。
 
 ### Non-Goals
 
-- 不改变现有 tokenBucket 限流算法与配额。
-- 不改变 HTTPProxy 的负载均衡策略。
-- 不引入新的跨进程存储或配置项。
+- 不修改 `tokenBucket` 底层算法与 semaphore 机制。
+- 不改造交易所业务语义（签名、业务错误处理、业务重试）。
+- 不引入中心化存储；调度状态仅进程内维护。
 
 ## Definitions
 
-- BaseKey: 现有 vendor 使用的 tokenBucket key 基础部分（host/固定字符串/拼接结果）。
-- Proxy IP Label: 由 `@yuants/http-services` 计算并注入到 http-proxy 终端的 `terminalInfo.tags.ip`（语义为真实出口公网 IP）。
-- Proxy IP Pool: 从所有 http-proxy 终端收集到的 `ip` 列表（来自 http-services 计算注入的 `tags.ip`）。
-- Proxy IP Selector: 位于 `@yuants/http-services` 的 helper，用 round robin 从 `Proxy IP Pool` 选取一个 ip。
-- Proxy IP Tagger: 位于 `@yuants/http-services` 的 helper，负责计算出口 ip 并写入 http-proxy 终端 `terminalInfo.tags.ip`。
-- Local Public IP: 本机 `terminal.terminalInfo.tags.public_ip`。
+- `BaseKey`: 现网 vendor 的限流基键。
+- `IPPool`: 当前可用 proxy IP 集合，来源于 `http-services`。
+- `BucketKey`: `encodePath([BaseKey, ip])`。
+- `BucketOptionsSource`: bucket options 来源函数，定义为 `getBucketOptions(baseKey)`。
+- `Stage`: 错误归属阶段，取值 `{pool|acquire|route|request}`。
+- `Mode`: 灰度模式，固定为 `legacy_rr_single_try` / `rr_multi_try` / `helper_acquire_proxy_bucket`。
 
-## 问题陈述与影响
+## Protocol Overview（端到端流程）
 
-当 USE_HTTP_PROXY=true 时，请求实际出网由 HTTPProxy 终端完成，但 tokenBucket key 仍以 BaseKey 或本机 IP 作为维度，导致：
+1. vendor 计算 `baseKey` 与 `weight`，并传入 `getBucketOptions(baseKey)`。
+2. `USE_HTTP_PROXY=true` 时，helper 拉取 `IPPool` 并过滤非法/重复 IP。
+3. helper 按“可承载组优先”构造候选顺序：先 `read() >= weight` 组，再其余组。
+4. helper 对候选逐个执行 `acquireSync(weight)`；成功即返回 `{ ip, bucketKey }`。
+5. helper 成功后，vendor MUST 使用返回 `ip` 写入 `labels.ip` 并发起请求。
+6. 失败按阶段映射错误码，不允许跨阶段吞并错误码。
 
-- 对同一出口 IP 的请求被拆散进多个 bucket，限流失真。
-- 在多 proxy 终端轮转时，单一 bucket 聚合多个出口 IP，误触限流。
-- 代理侧真实负载与 vendor 侧限流统计不一致，影响诊断与稳定性。
+## 设计选项与推荐
 
-## Protocol Overview
+### 方案 A：`rr_multi_try`
 
-1. 构造 vendor 请求 `req`。
-2. 若 `USE_HTTP_PROXY=true`，枚举所有 HTTPProxy 终端并收集 `terminalInfo.tags.ip` 形成 `Proxy IP Pool`。
-3. 用 `Proxy IP Selector`（round robin）选取一个 ip。
-4. 以 `BaseKey` 与选取的 ip 生成 tokenBucket key：`encodePath([BaseKey, ip])`。
-5. 通过 http-services 的 `fetch` 发送请求，并在 `labels.ip` 中携带该 ip 进行路由。
-6. 若 `USE_HTTP_PROXY=false`，使用 `terminal.terminalInfo.tags.public_ip` 作为 ip 维度并直连发送。
+- RR 产出候选顺序，逐个尝试 acquire，失败切下一候选。
+- 优点：改动较小。
+- 缺点：状态分散在 vendor，易产生行为漂移。
 
-## Behavior Requirements
+### 方案 B：`helper_acquire_proxy_bucket`（推荐）
 
-- R1: 当 `USE_HTTP_PROXY=true` 时，tokenBucket key MUST 为 `encodePath([BaseKey, ProxyIp])`。
-- R2: 当 `USE_HTTP_PROXY=false` 时，tokenBucket key MUST 为 `encodePath([BaseKey, LocalPublicIp])`。
-- R3: `Proxy IP Pool` MUST 由所有 HTTPProxy 终端的 `terminalInfo.tags.ip` 构成。
-- R4: 若 `Proxy IP Pool` 为空，MUST 返回 `E_PROXY_TARGET_NOT_FOUND` 且不得发送请求。
-- R5: 选取的 `Proxy IP` MUST 通过 `labels.ip` 传递给 http-services `fetch` 用于路由。
-- R6: 直连场景下若 `terminal.terminalInfo.tags.public_ip` 缺失，MUST 使用 `public-ip-unknown` 并记录可观测日志并限频。
-- R7: BaseKey 的生成规则 MUST 保持现有行为不变，仅作为 `encodePath([BaseKey, ip])` 的第一段。
-- R8: 同一 `tags.ip` 对应多个 proxy 终端允许随机路由。
+- 在 `libraries/http-services` 提供统一 helper，集中维护候选选择、cooldown、错误映射、观测。
+- vendor 仅消费 `{ip, bucketKey}` 并发请求。
+
+### 方案 C：`legacy_rr_single_try`（仅回滚）
+
+- 现网旧行为：RR 选一个 IP，只尝试一次 acquire。
+- 不推荐继续演进，仅用于故障回滚。
 
 ## State Machine
 
 States:
 
-- S0 Init
-- S1 DetermineProxyMode
-- S2 SelectProxyIp
-- S3 BuildTokenBucketKey
-- S4 SendRequest
-- S5 HandleResponse
-- S6 Error
+- `S0_INIT`: 输入 `(baseKey, weight, terminal, getBucketOptions)`。
+- `S1_POOL_READY`: 得到有效 `IPPool`。
+- `S2_SELECT`: 构造候选顺序（可承载组优先 + cooldown 过滤）。
+- `S3_ACQUIRE`: 对候选执行 `acquireSync(weight)`。
+- `S4_ROUTE`: 写入 `labels.ip` 并由 `fetch` 路由。
+- `S5_REQUEST`: 已路由到目标代理，执行请求。
+- `S_DONE`: 请求完成。
+- `S_ERR`: 错误终态。
 
 Transitions:
 
-- S0 -> S1: 请求构建完成。
-- S1 -> S2: `USE_HTTP_PROXY=true`。
-- S1 -> S3: `USE_HTTP_PROXY=false`。
-- S2 -> S3: 成功从 `Proxy IP Pool` 选取 `Proxy IP`。
-- S2 -> S6: `Proxy IP Pool` 为空。
-- S3 -> S4: tokenBucket key 生成完成。
-- S4 -> S5: 请求完成（成功或受控失败）。
-- S4 -> S6: 网络/代理不可达等不可恢复错误。
+- `S0_INIT -> S1_POOL_READY`: 进入 proxy 分支。
+- `S1_POOL_READY -> S_ERR`: `IPPool` 为空（`E_PROXY_TARGET_NOT_FOUND`）。
+- `S1_POOL_READY -> S2_SELECT`: 有候选。
+- `S2_SELECT -> S_ERR`: 候选遍历完（`E_PROXY_BUCKET_EXHAUSTED`）。
+- `S2_SELECT -> S3_ACQUIRE`: 选到下一候选。
+- `S3_ACQUIRE -> S2_SELECT`: acquire 不足或可恢复失败。
+- `S3_ACQUIRE -> S4_ROUTE`: acquire 成功。
+- `S4_ROUTE -> S_ERR`: 路由无匹配（`E_PROXY_TARGET_NOT_FOUND`）。
+- `S4_ROUTE -> S5_REQUEST`: 路由成功。
+- `S5_REQUEST -> S_ERR`: 代理网络/上游失败（`E_PROXY_REQUEST_FAILED`）。
+- `S5_REQUEST -> S_DONE`: 请求完成。
 
 ## Data Model
 
-### TokenBucketKey
+### AcquireProxyBucketInput
 
-- 结构: `encodePath([BaseKey, ip])`
-- BaseKey: string，沿用现有 vendor 规则。
-- ip: string
-  - 代理场景: 从 `Proxy IP Pool` 选取的 ip
-  - 直连场景: `terminal.terminalInfo.tags.public_ip`，缺失为 `public-ip-unknown`
-- 约束: 使用 `encodePath` 避免分隔符冲突（禁止直接 `:` 拼接）。
+```ts
+type AcquireProxyBucketInput = {
+  baseKey: string;
+  weight: number;
+  terminal: ITerminal;
+  getBucketOptions: (baseKey: string) => TokenBucketOptions;
+};
+```
 
-### Proxy IP Pool
+- 兼容策略：本 RFC 在“`bucketOptions` 直接传入 / `getBucketOptions(baseKey)` 回调”二选一中固定采用回调方案。
+- 约束：调用方若为固定 options，MUST 通过回调返回常量；MUST NOT 使用 helper 内置隐式默认 options。
 
-- 结构: `string[]`
-- 来源: 从所有 HTTPProxy 终端的 `terminalInfo.tags.ip` 汇总
-- 约束: 去重后使用 round robin 选择
+### BucketRuntimeState
 
-### 兼容策略
+- `bucketKey: string`
+- `tokensAvailable: number`
+- `lastAcquireResult: "ok" | "insufficient" | "error"`
+- `cooldownUntil?: number`
 
-- 缺失标签不会阻断请求，仅直连场景使用 `public-ip-unknown` 兜底并记录日志。
-- 代理场景无 ip 候选时返回 `E_PROXY_TARGET_NOT_FOUND`。
-- key 文本会新增 ip 维度（直连与代理均变更）；计数器结构不变。
+### 冲突观测
 
-## 方案设计
+- `bucket_options_conflict_total{base_key,bucket_key}`: counter
+- 触发条件：同 `bucketKey` 首次 options 与后续 options 指纹不一致。
 
-### 关键设计点：基于 ip 路由
+## Requirements
 
-HTTPProxy 本身支持基于 labels 路由。这里不固定具体 target，而是先选定一个出口 IP，再通过 `labels.ip` 让代理侧路由到匹配 IP 的节点（允许随机）。
-
-### 方案 A（推荐）：在 `@yuants/http-services` 增加 proxy ip 选择 helper
-
-- 新增 helper：枚举所有 HTTPProxy 终端 ip，并用 round robin 选择 ip。
-- 调用方流程：
-  - 枚举 ip 池 -> round robin 选 ip -> 用 ip 生成 key -> fetch + labels.ip 路由。
-
-labels.ip 用于路由与观测，不固定具体 target。
-
-> [REVIEW] proxy_ip_hint 是什么东西？为什么要有？
-
-> [RESPONSE] 已采纳“仅用 labels.ip 路由”的方向，proxy_ip_hint 相关设计已移除，改为 ip 池 + round robin 选择。
-> [STATUS:resolved]
-
-> [REVIEW] 我要的流程是：通过 terminal Info resolve 出来所有的 http-proxy 的 ip（可以做这个假设）然后在这一堆 IP 中使用一个 helper function（你可以定义在 http-services 这个包里）来 round robin 选取 ip，然后放到 fetch 里请求，这样就行了，不用加那么多复杂的东西。
-
-> [RESPONSE] 已采纳并调整：删除固定 target/绑定逻辑，新增 http-services helper 枚举 HTTPProxy 的 ip 池并 round robin 选取，调用 fetch 时仅通过 labels.ip 路由。
-> [STATUS:resolved]
-
-优点:
-
-- 复用统一逻辑，避免 vendor 重复实现。
-- round robin 选 ip 简单可控，符合“按出口 IP 限流”诉求。
-
-缺点:
-
-- 需要修改 `@yuants/http-services` API（新增 helper，非破坏式）。
-
-### 方案 B：在 vendor 内直接枚举 ip + round robin
-
-- vendor 端自行枚举 HTTPProxy ip 池并 round robin 选择 ip。
-- 调用 http-services `fetch`，通过 `labels.ip` 路由。
-
-优点:
-
-- 不修改公共库，影响面更小。
-
-缺点:
-
-- 多处重复逻辑，易产生行为差异。
-- vendor 需理解底层协议，提升维护成本。
-
-### 推荐方案
-
-优先采用方案 A，以共享 helper 统一 ip 选择逻辑并保持一致性；若落地期评估为高风险，可短期采用方案 B 作为过渡。
-
-> [REVIEW] 其实 http-proxy fetch 是支持 label 选择的（其中必定含有 ip label）约等于支持 target，你加上这个信息重新思考一下？
-
-> [RESPONSE] 已纳入设计：使用 labels.ip 路由，不再固定 target；通过 helper 选出 ip 后直接调用 fetch。
-> [STATUS:resolved]
-
-> [REVIEW] 我认为你不需要新增 fetchViaHTTPProxyTarget 这个接口，直接在现有的 fetch 里加上 labels.ip 就行了。fetch 里本来就支持 labels 选择 target 的。
-
-> [RESPONSE] 已采纳“不新增接口”：不增加新 fetch API，直接使用现有 fetch 的 labels 路由；通过 helper 选出 ip 后填入 labels.ip。
-
-> [STATUS:resolved]
-
-> [REVIEW] 同 IP 多 proxy 根本没意义，外界只会对 IP 限流，所以我说的这种 fetch 加 labels ip 就够了
-
-> [RESPONSE] 已采纳：同 IP 多 proxy 允许随机路由，不再要求确定性选择；fetch 仅需用 labels.ip 做路由即可。RFC 中所有“确定性选择”已删除/改为“允许随机”。
-> [STATUS:resolved]
+- `R1` 代理模式下，helper MUST 在请求发送前完成 IP 选择与 `acquireSync(weight)`。
+- `R2` helper MUST 使用 `getBucketOptions(baseKey)` 作为唯一 options 来源。
+- `R3` helper MUST NOT 使用隐式默认 options；options 来源 MUST 与现网 vendor 一致。
+- `R4` 被选中 IP 的 `bucketKey` MUST 为 `encodePath([baseKey, ip])`。
+- `R5` 请求 `labels.ip` MUST 与 `bucketKey` 的 ip 完全一致。
+- `R6` 单次请求若某 IP acquire 失败，MUST 尝试下一候选 IP。
+- `R7` 候选全部失败时，MUST 返回 `E_PROXY_BUCKET_EXHAUSTED`，且 MUST NOT 外发请求。
+- `R8` `IPPool` 为空时，MUST 返回 `E_PROXY_TARGET_NOT_FOUND`。
+- `R9` `SEMAPHORE_INSUFFICIENT_PERMS` MUST 映射为可恢复容量失败，不得作为未分类系统异常抛出。
+- `R10` helper MUST 先尝试 `read() >= weight` 候选组，再尝试其余候选组。
+- `R11` 对同一 `baseKey`，helper MUST 维护独立选择状态，避免跨桶串扰。
+- `R12` 同 `bucketKey` 出现 options 冲突时，helper MUST 增加 `bucket_options_conflict_total`，并 MUST 返回 `E_BUCKET_OPTIONS_CONFLICT` 终止本次流程。
+- `R13` `USE_HTTP_PROXY=false` 时，MUST 保持现有直连限流路径，不进入 proxy 调度。
 
 ## Error Semantics
 
-- E_PROXY_TARGET_NOT_FOUND: 未发现任何 HTTPProxy 服务或 `Proxy IP Pool` 为空。可恢复性: 可重试（依赖服务注册）。
-- E_PROXY_REQUEST_FAILED: 代理请求失败。可恢复性: 依据原有重试策略决定；不得自动回退直连。
+### 错误阶段归属表
 
-错误语义映射:
+| stage     | 触发条件                              | MUST 返回错误码             | 可恢复性         |
+| --------- | ------------------------------------- | --------------------------- | ---------------- |
+| `pool`    | 无可用 proxy 服务或 `IPPool` 为空     | `E_PROXY_TARGET_NOT_FOUND`  | 可重试（长退避） |
+| `acquire` | 候选均 acquire 失败 / cooldown 不可用 | `E_PROXY_BUCKET_EXHAUSTED`  | 可重试（短退避） |
+| `acquire` | 同 `bucketKey` options 冲突           | `E_BUCKET_OPTIONS_CONFLICT` | 需修配置后重试   |
+| `route`   | `labels.ip` 无匹配或路由解析失败      | `E_PROXY_TARGET_NOT_FOUND`  | 可重试（长退避） |
+| `request` | 已路由后代理网络/上游失败             | `E_PROXY_REQUEST_FAILED`    | 按既有策略重试   |
 
-- `Proxy IP Pool` 为空 -> E_PROXY_TARGET_NOT_FOUND。
-- 发送阶段失败 -> E_PROXY_REQUEST_FAILED。
+### 边界封闭规则
 
-错误码归属:
+- `R14` route 阶段失败（含 `labels.ip` 无匹配）MUST 映射为 `E_PROXY_TARGET_NOT_FOUND`。
+- `R15` `E_PROXY_REQUEST_FAILED` MUST 仅允许在 request 阶段产生。
 
-- Proxy IP Selector 仅返回: `E_PROXY_TARGET_NOT_FOUND`
-- 发送阶段才可能产生: `E_PROXY_REQUEST_FAILED`
-- 直连场景 public_ip 缺失仅记录日志（不作为 error_code 返回）
+### 重试语义
+
+- `E_PROXY_BUCKET_EXHAUSTED` SHOULD 使用短退避 + 抖动重试。
+- `E_PROXY_TARGET_NOT_FOUND` SHOULD 使用长退避并触发告警。
+- `E_PROXY_REQUEST_FAILED` MAY 按 vendor 既有请求重试策略执行。
+- `E_BUCKET_OPTIONS_CONFLICT` MUST NOT 自动重试。
 
 ## Security Considerations
 
-- 必须验证 `terminalInfo.tags.ip` 为可信来源（仅由 `provideHTTPProxyService` 注入）。
-- `terminalInfo.tags.ip` 的计算与注入由 `@yuants/http-services` 统一负责，app-http-proxy 不再自行计算。
-- 过滤/校验 `ip` 标签，避免非预期注入导致 key 膨胀或日志污染。
-- `labels.ip` 用于路由与观测，应避免外部输入污染。
-- 若同一出口 IP 映射多个 proxy 终端，允许随机路由。
-- 避免将 `ip` 与敏感信息拼接到可外部访问的日志中。
-- 防止过度分桶（大量 proxy 标签变化）导致 tokenBucket 资源耗尽；需要监控 key cardinality。
-
-## Observability
-
-- 缺失 `ip`/`public_ip` 的日志必须限频（建议每 terminal 每小时一次）。
-- 记录 tokenBucket key cardinality 的最小监控（例如每分钟 key 数量与 TopN 桶占比）。
-- 记录 `E_PROXY_TARGET_NOT_FOUND` 计数，用于识别 proxy 池为空或服务未注册。
-- 记录 ip 池缓存命中/刷新次数，用于观察缓存有效性。
-- 当发现 HTTPProxy 终端缺失 `tags.ip` 时，记录一次结构化日志（限频）。
-
-> [REVIEW] 给你一点上下文：如果需要的话，可以使用 @yuants/cache 库来做这个缓存。具体你是闲的时候决定
+- `labels.ip` MUST 仅来自 helper 选择结果，不接受外部透传。
+- proxy IP 来源 MUST 限定 `ip_source=http-services`。
+- IP 文本 MUST 通过格式校验（IPv4/IPv6）；非法值不得参与 `bucketKey`。
+- MUST 控制 key cardinality，防止异常标签放大 bucket 数量。
+- MUST 对错误日志做限频，避免失败风暴导致资源耗尽。
 
 ## Backward Compatibility & Rollout
 
-- 新 key 维度在代理与直连均启用（直连场景将新增 `public_ip` 维度）。
-- 迁移步骤：
-  1. vendor-binance 落地方案 A（或 B 过渡）。
-  2. 在 binance 验证 key 分桶与出口 IP 一致后推广到其他 vendor。
-- 回滚策略：代码版本回退到旧 key 逻辑（不新增额外开关）。
+### 模式命名（固定）
+
+- `legacy_rr_single_try`: 现网旧行为，仅单次 acquire。
+- `rr_multi_try`: 方案 A，RR 候选 + 多次 acquire。
+- `helper_acquire_proxy_bucket`: 方案 B，统一 helper。
+
+### 默认值 / 灰度值 / 回滚值
+
+- 默认值（新部署）: `rr_multi_try`。
+- 灰度值（目标）: `helper_acquire_proxy_bucket`。
+- 回滚值（故障）: `legacy_rr_single_try`。
+
+### 最小可执行灰度步骤
+
+1. 在 `vendor-binance` 选定 1-2 个高频 endpoint，模式从 `rr_multi_try` 切到 `helper_acquire_proxy_bucket`。
+2. 连续观测 30 分钟窗口：`E_PROXY_BUCKET_EXHAUSTED`、`E_PROXY_TARGET_NOT_FOUND`、429、请求成功率。
+3. 指标劣化超阈值时，5 分钟内切回 `legacy_rr_single_try`，并保留同窗口对比数据。
+
+## Observability
+
+必须输出以下指标：
+
+- `proxy_bucket_acquire_total{base_key,ip,result}`。
+- `proxy_bucket_fallback_total{base_key}`（候选切换次数）。
+- `proxy_request_total{base_key,ip,status_code}`。
+- `proxy_error_total{stage,error_code,base_key}`。
+- `bucket_options_conflict_total{base_key,bucket_key}`。
+
+要求：错误类指标 MUST 包含 `stage={pool|acquire|route|request}` 与 `error_code` 维度。
 
 ## Testability
 
-每条 MUST 行为必须有可映射断言：
+每条 MUST 需求映射测试断言：
 
-- R1: 代理场景下 key 等于 `encodePath([BaseKey, ProxyIp])`。
-- R2: 直连场景下 key 等于 `encodePath([BaseKey, LocalPublicIp])`。
-- R3: `Proxy IP Pool` 由所有 HTTPProxy 终端 `tags.ip` 构成。
-- R4: `Proxy IP Pool` 为空时返回 `E_PROXY_TARGET_NOT_FOUND` 且不发送请求。
-- R5: 选取的 ip 通过 `labels.ip` 传入 fetch 路由。
-- R6: 缺失 `public_ip` 时 key 使用 `public-ip-unknown`。
-- R7: BaseKey 未被改变，且仅作为 `encodePath` 的第一段。
-- R8: 多 target 共享同一 ip 时允许随机路由。
+- `T-R1`: 发送前必须先拿到 `{ip,bucketKey}`。
+- `T-R2`: helper 使用 `getBucketOptions(baseKey)`；缺失回调时构造失败。
+- `T-R3`: helper 无隐式默认 options；来源与现网 vendor 提供值一致。
+- `T-R4`: `bucketKey == encodePath([baseKey, ip])`。
+- `T-R5`: `labels.ip` 与 `bucketKey` 的 ip 一致。
+- `T-R6`: 首候选 acquire 失败后切换次候选并成功。
+- `T-R7`: 候选全失败返回 `E_PROXY_BUCKET_EXHAUSTED` 且无外发请求。
+- `T-R8`: 空池返回 `E_PROXY_TARGET_NOT_FOUND`。
+- `T-R9`: `SEMAPHORE_INSUFFICIENT_PERMS` 被映射为容量失败。
+- `T-R10`: 存在 `read() >= weight` 候选时优先尝试该组。
+- `T-R11`: 不同 `baseKey` 的状态互不影响。
+- `T-R12`: 同 `bucketKey` options 冲突时，`bucket_options_conflict_total` +1 且返回 `E_BUCKET_OPTIONS_CONFLICT`。
+- `T-R13`: 非 proxy 模式不触发 proxy 调度。
+- `T-R14` (负例): acquire 成功后若 `labels.ip` 无匹配，必须返回 `E_PROXY_TARGET_NOT_FOUND`。
+- `T-R15` (负例): request 阶段之前不得返回 `E_PROXY_REQUEST_FAILED`。
+
+覆盖场景至少包括：高权重请求、多 IP 余量不均、IP 下线、空池、route 无匹配、options 冲突。
 
 ## Open Questions
 
-1. `terminalInfo.tags.ip` 的来源一致性是否需要在 http-proxy 端强制校验？
-2. helper 命名是否与现有 http-services 命名风格保持一致？
+1. `cooldown` 参数是否需要按交易所或 endpoint 分层配置（当前先固定默认值）？
+2. `acquireProxyBucket` 是否需要返回 `attemptedIps` 用于调试追踪（不影响主流程）？
 
 ## Plan
 
 ### 核心流程
 
-1. 代理场景：
-   - 若缓存有效：使用缓存 ip 池；否则重新枚举并刷新缓存。
-   - round robin 选 ip -> 用 ip 生成 key -> fetch + labels.ip 路由。
-2. 直连场景：读取 `terminal.terminalInfo.tags.public_ip` -> 拼接 key -> 直连请求。
+1. 在 `http-services` 暴露统一入口：`acquireProxyBucket(input)`，强制 `getBucketOptions` 输入。
+2. helper 执行：`IPPool` 获取 -> 可承载组优先 -> acquire 多次尝试 -> 返回 `{ip,bucketKey}` 或标准错误。
+3. vendor 仅消费返回值并发请求，错误按阶段归属表统一处理。
 
 ### 接口定义
 
-- `@yuants/http-services`:
-  - `computeAndInjectProxyIp(terminal): Promise<string>`
-  - `listHTTPProxyIps(terminal): string[]`
-  - `selectHTTPProxyIpRoundRobin(terminal): string`
-  - `fetch(input, init: IHTTPProxyFetchInit): Promise<Response>`（已支持 labels）
+- `listHTTPProxyIps(terminal): string[]`（现有）
+- `selectHTTPProxyIpRoundRobinAsync(terminal): Promise<string>`（现有，回滚模式保留）
+- `acquireProxyBucket(input: AcquireProxyBucketInput): { ip: string; bucketKey: string } | throws ProxyBucketError`（新增）
 
-注: `computeAndInjectProxyIp` 在 http-proxy 终端启动时执行，写入 `terminalInfo.tags.ip`。
-注: `listHTTPProxyIps` 基于 `terminal.terminalInfos` 枚举所有 HTTPProxy 终端并支持缓存。
-注: 缓存在 HTTPProxy 终端新增或减少时刷新（可基于服务发现事件或定时重算）。
-注: helper 内部维护 round robin 状态，保持调用方无状态。
+### 文件变更明细（设计范围）
 
-### 文件变更明细
-
-- `libraries/http-services/src/client.ts` 新增 ip 计算注入、枚举、缓存与 round robin helper。
-- `apps/http-proxy/src/index.ts` 移除本地 ip 计算，改用 http-services helper。
-- `apps/vendor-binance/src/api/*.ts` 修改 tokenBucket key 生成与请求路径。
-- 推广到 `apps/vendor-aster/src/api/*.ts` 等同逻辑。
+- `libraries/http-services`: 增加 `acquireProxyBucket` 与冲突观测、阶段错误映射。
+- `apps/vendor-binance`: 接入 helper 与模式开关（仅设计约束，不含实现细节）。
+- `apps/http-proxy`: 维持 `tags.ip + ip_source=http-services` 契约。
 
 ### 验证策略
 
-- 本地最小验证：单元测试或 mock，覆盖 R1-R7。
-- 运行 binance 最小自测，确认 key 中 ip 与 labels.ip 一致。
-- 灰度启用 USE_HTTP_PROXY，对比限流日志与出口 IP 统计。
+1. 单测覆盖 `T-R1` 到 `T-R15`（含两条负例）。
+2. 集成测试验证 `bucketKey.ip == labels.ip` 与 stage 错误码边界。
+3. 灰度验证按 30 分钟窗口执行，出现劣化按回滚值切换。

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md
@@ -1,7 +1,7 @@
 # RFC: Proxy IP TokenBucket v2（按权重负载均衡 + 主动限流）
 
 Status: Draft (Design Only)
-Target Path: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+Target Path: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
 Date: 2026-02-07
 
 ## Abstract

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/plan.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/plan.md
@@ -5,53 +5,47 @@ SLUG: vendor-tokenbucket-proxy-ip
 
 ## RFC
 
-- 设计真源: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
+- 设计真源: `/Users/c1/Work/Yuan/.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
 
 ## 摘要
 
-- 核心流程: 代理场景枚举 HTTPProxy ip 池并 round robin 选 ip，key 使用该 ip，fetch 通过 labels.ip 路由；直连用 `terminal.terminalInfo.tags.public_ip`。
-- 接口变更: `@yuants/http-services` 增加 ip 枚举/选择 helper，并统一注入 `terminalInfo.tags.ip`。
-- 文件变更清单: `libraries/http-services/src/client.ts`、`apps/http-proxy/src/index.ts` 与各 vendor API 文件。
-- 验证策略: 覆盖 R1-R7 的最小测试 + binance 自测对比 labels.ip 与出口 IP。
+- 核心流程: v2 在发送前按 `weight` 做“可承载组优先”候选选择并逐个 `acquireSync`；成功后以同源 ip 写入 `bucketKey` 与 `labels.ip`，并按 stage 归属错误码。
+- 接口变更: 新增 `acquireProxyBucket(input)`，强制 `getBucketOptions(baseKey)` 作为 options 来源；灰度模式固定 `legacy_rr_single_try` / `rr_multi_try` / `helper_acquire_proxy_bucket`。
+- 文件变更清单: 设计范围限定 `libraries/http-services`、`apps/http-proxy`、`apps/vendor-binance`，后续可推广到其他 vendor。
+- 验证策略: 以 RFC `R1-R15` 为验收，重点覆盖高权重、多 IP 余量不均、IP 下线、空池、route 无匹配与 options 冲突。
 
 ## 目标
 
-为各 vendor 的 tokenBucket key 增加“目标 http-proxy 终端 ip 标签”维度，保证 USE_HTTP_PROXY 场景按实际出口 IP 限流，并先在 Binance 落地后推广到其他 vendor。
+设计并评审多 http-proxy IP 下按 weight 自动负载均衡的 tokenBucket v2 方案，确保 key 与路由同源并可灰度回滚。
 
 ## 要点
 
-- 梳理 USE_HTTP_PROXY 场景下 http-services 的路由机制与可获取的目标 terminal 标签
-- 定义 tokenBucket key 规范：baseKey + 目标 terminal ip（代理）或自身 terminal.tags.public_ip（直连）
-- Binance 先行改造并验证 key 拼接逻辑与请求路由一致
-- 推广到 aster/hyperliquid/gate/bitget/huobi/okx，保持一致性与最小侵入
-- 必要时补充共享 helper（避免多处复制逻辑）
+- 以 tokenBucket 现有约束为前提（acquireSync 立即失败、read 无 ETA、bucketId 首次 options 生效）设计可执行调度。
+- 在发送请求前完成 IP 选择与 acquire，确保 bucketKey 的 ip 与 labels.ip 同源。
+- 优先在 vendor-binance 落地 v2 helper，保留 rr_multi_try/legacy 回滚模式。
+- 用 stage 化错误语义与可观测指标闭环（pool/acquire/route/request）。
+- 以 R1-R15 与 T-R1..T-R15 作为设计验收门槛。
 
 ## 范围
 
+- libraries/http-services/src/proxy-ip.ts
+- libraries/http-services/src/index.ts
+- libraries/http-services/src/client.ts
+- apps/http-proxy/src/index.ts
 - apps/vendor-binance/src/api/client.ts
 - apps/vendor-binance/src/api/public-api.ts
 - apps/vendor-binance/src/api/private-api.ts
-- apps/vendor-aster/src/api/public-api.ts
-- apps/vendor-aster/src/api/private-api.ts
-- apps/vendor-bitget/src/api/client.ts
-- apps/vendor-gate/src/api/http-client.ts
-- apps/vendor-huobi/src/api/public-api.ts
-- apps/vendor-huobi/src/api/private-api.ts
-- apps/vendor-hyperliquid/src/api/client.ts
-- apps/vendor-hyperliquid/src/api/rate-limit.ts
-- apps/vendor-okx/src/api/public-api.ts
-- apps/vendor-okx/src/api/private-api.ts
-- libraries/http-services/src/client.ts
-- libraries/protocol/src/client.ts
+- .legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md
+- .legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-rfc.md
 
 ## 阶段概览
 
-1. **调研** - 1 个任务
-2. **设计** - 2 个任务
-3. **实现** - 2 个任务
-4. **验证** - 1 个任务
-5. **评审与报告** - 1 个任务
+1. **调研与约束收敛** - 1 个任务
+2. **RFC 设计与对抗审查循环** - 1 个任务
+3. **设计门禁确认（等待用户批准）** - 1 个任务
+4. **实现（用户批准后）** - 1 个任务
+5. **验证与报告** - 1 个任务
 
 ---
 
-_创建于: 2026-02-04 | 最后更新: 2026-02-05_
+_创建于: 2026-02-04 | 最后更新: 2026-02-07_

--- a/.legion/tasks/vendor-tokenbucket-proxy-ip/tasks.md
+++ b/.legion/tasks/vendor-tokenbucket-proxy-ip/tasks.md
@@ -1,5 +1,6 @@
 # tasks
 
+- [x] RFC 生成完成
 - [x] RFC 对抗审查（候选枚举 MUST 与 error_code 归属表闭环）
 - [x] 修订 RFC：明确 resolveHTTPProxyTarget 候选枚举来源为 MUST
 - [x] 修订 RFC：闭环 `E_PUBLIC_IP_MISSING` error_code 归属（移除或明确归属/返回）
@@ -7,3 +8,13 @@
 - [x] Walkthrough 报告生成完成（bench）
 - [x] Walkthrough 报告生成完成（rollout）
 - [x] PR Body 建议生成完成（rollout）
+- [x] Walkthrough 报告生成完成（impl）
+- [x] PR Body 建议生成完成（impl）
+- [x] 修订 RFC：按 review 闭环 4 个 blocking（options 来源、错误阶段归属、灰度回滚模式、R10/T-R10 可测）
+- [x] RFC 再审完成（复核上一轮 4 个 blocking 闭环）
+- [x] RFC 修订待办：统一 R10 与 T-R10 规范强度（MUST+硬断言或 SHOULD+软断言）
+- [x] RFC 最终只读复审完成（结论 PASS）
+- [x] 设计门禁：等待用户确认 RFC（确认后进入 /legion-impl）
+- [x] 阶段 A：工程实现完成（http-services/http-proxy/vendor-binance + 单测）
+- [x] 阶段 B：验证与审查完成（run-tests PASS / review-code PASS / review-security PASS）
+- [x] 阶段 C：报告生成完成（report-walkthrough-impl.md / pr-body-impl.md）

--- a/apps/http-proxy/src/index.ts
+++ b/apps/http-proxy/src/index.ts
@@ -22,6 +22,7 @@ import { fromEvent, merge, take, tap } from 'rxjs';
   } else if (ip) {
     console.info(formatTime(Date.now()), '[http-proxy] ip tag source not trusted, skip labels.ip');
   }
+  labels.terminal_id = terminal.terminal_id;
   labels.hostname = HOSTNAME;
   console.info(formatTime(Date.now()), '[http-proxy] labels:', labels);
   const options = {

--- a/apps/vendor-binance/src/api/private-api.ts
+++ b/apps/vendor-binance/src/api/private-api.ts
@@ -1,7 +1,6 @@
 import { scopeError, tokenBucket } from '@yuants/utils';
 
 import {
-  buildTokenBucketKey,
   createRequestContext,
   getDefaultCredential,
   getTokenBucketOptions,
@@ -264,12 +263,15 @@ export const getUnifiedAccountInfo = async (
   const endpoint = 'https://papi.binance.com/papi/v1/account';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext('order/unified/minute', weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions('order/unified/minute')).acquireSync(weight),
+    () =>
+      tokenBucket(bucketKey, getTokenBucketOptions('order/unified/minute')).acquireSync(
+        requestContext.acquireWeight,
+      ),
   );
   return requestPrivate<IUnifiedAccountInfo | IApiError>(
     credential,
@@ -295,12 +297,15 @@ export const getUnifiedUmAccount = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/account';
   const url = new URL(endpoint);
   const weight = 5;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext('order/unified/minute', weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions('order/unified/minute')).acquireSync(weight),
+    () =>
+      tokenBucket(bucketKey, getTokenBucketOptions('order/unified/minute')).acquireSync(
+        requestContext.acquireWeight,
+      ),
   );
   return requestPrivate<IUnifiedUmAccount | IApiError>(
     credential,
@@ -329,8 +334,8 @@ export const getUnifiedUmOpenOrders = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/openOrders';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 1 : 40;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     {
@@ -342,7 +347,7 @@ export const getUnifiedUmOpenOrders = async (
       weight,
       hasSymbol: !!params?.symbol,
     },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IUnifiedUmOpenOrder[]>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -365,12 +370,12 @@ export const getUnifiedAccountBalance = async (
   const endpoint = 'https://papi.binance.com/papi/v1/balance';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IUnifiedAccountBalanceEntry[] | IApiError>(
     credential,
@@ -397,12 +402,12 @@ export const getSpotAccountInfo = async (
   const endpoint = 'https://api.binance.com/api/v3/account';
   const url = new URL(endpoint);
   const weight = 20;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<ISpotAccountInfo | IApiError>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -423,8 +428,8 @@ export const getSpotOpenOrders = async (
   const endpoint = 'https://api.binance.com/api/v3/openOrders';
   const url = new URL(endpoint);
   const weight = params?.symbol ? 6 : 80;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     {
@@ -436,7 +441,7 @@ export const getSpotOpenOrders = async (
       weight,
       hasSymbol: !!params?.symbol,
     },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<ISpotOrder[] | IApiError>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -474,12 +479,12 @@ export const postSpotOrder = async (
   const endpoint = 'https://api.binance.com/api/v3/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<ISpotNewOrderResponse | IApiError>(
     credential,
@@ -510,12 +515,12 @@ export const deleteSpotOrder = async (
   const endpoint = 'https://api.binance.com/api/v3/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'DELETE', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<ISpotOrder | IApiError>(credential, 'DELETE', endpoint, params, requestContext);
 };
@@ -544,12 +549,12 @@ export const postAssetTransfer = async (
   const endpoint = 'https://api.binance.com/sapi/v1/asset/transfer';
   const url = new URL(endpoint);
   const weight = 900;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IAssetTransferResponse | IApiError>(
     credential,
@@ -575,12 +580,12 @@ export const postUnifiedAccountAutoCollection = async (credential: ICredential):
   const endpoint = 'https://papi.binance.com/papi/v1/auto-collection';
   const url = new URL(endpoint);
   const weight = 750;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<{ msg: string }>(credential, 'POST', endpoint, undefined, requestContext);
 };
@@ -605,12 +610,12 @@ export const getDepositAddress = async (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/deposit/address';
   const url = new URL(endpoint);
   const weight = 10;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IDepositAddress>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -634,12 +639,12 @@ export const getSubAccountList = async (
   const endpoint = 'https://api.binance.com/sapi/v1/sub-account/list';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<ISubAccountListResponse | IApiError>(
     credential,
@@ -674,12 +679,12 @@ export const postWithdraw = async (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/withdraw/apply';
   const url = new URL(endpoint);
   const weight = 600;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<{ id: string } | IApiError>(credential, 'POST', endpoint, params, requestContext);
 };
@@ -711,12 +716,12 @@ export const getWithdrawHistory = async (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/withdraw/history';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IWithdrawRecord[]>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -744,12 +749,12 @@ export const getDepositHistory = async (
   const endpoint = 'https://api.binance.com/sapi/v1/capital/deposit/hisrec';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IDepositRecord[]>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -781,12 +786,12 @@ export const postUmOrder = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey('order/unified/minute', requestContext.ip);
+  const requestContext = await createRequestContext('order/unified/minute', weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_UNIFIED_ORDER_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IUnifiedUmOrderResponse | IApiError>(
     credential,
@@ -808,12 +813,12 @@ export const deleteUmOrder = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey('order/unified/minute', requestContext.ip);
+  const requestContext = await createRequestContext('order/unified/minute', weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_UNIFIED_ORDER_API_RATE_LIMIT',
     { method: 'DELETE', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IUnifiedUmOrderResponse | IApiError>(
     credential,
@@ -846,12 +851,12 @@ export const getUMIncome = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/income';
   const url = new URL(endpoint);
   const weight = 30;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IUMIncomeRecord[]>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -878,12 +883,12 @@ export const getAccountIncome = async (
   const endpoint = 'https://fapi.binance.com/fapi/v1/income';
   const url = new URL(endpoint);
   const weight = 30;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IAccountIncomeRecord[]>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -925,12 +930,12 @@ export const postSpotOrderCancelReplace = async (
   const endpoint = 'https://api.binance.com/api/v3/order/cancelReplace';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<ISpotNewOrderResponse | IApiError>(
     credential,
@@ -965,12 +970,12 @@ export const putUmOrder = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/order';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'PUT', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IUnifiedUmOrderResponse | IApiError>(
     credential,
@@ -1002,12 +1007,12 @@ export const getMarginAllPairs = async (params?: { symbol?: string }): Promise<I
   const endpoint = 'https://api.binance.com/sapi/v1/margin/allPairs';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<IMarginPair[]>(credential, 'GET', endpoint, params, requestContext);
 };
@@ -1030,12 +1035,12 @@ export const getMarginNextHourlyInterestRate = async (params: {
   const endpoint = 'https://api.binance.com/sapi/v1/margin/next-hourly-interest-rate';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<
     {
@@ -1068,12 +1073,12 @@ export const getMarginInterestRateHistory = async (params: {
   const endpoint = 'https://api.binance.com/sapi/v1/margin/interestRateHistory';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<
     {
@@ -1104,12 +1109,12 @@ export const getUserAsset = async (
   const endpoint = 'https://api.binance.com/sapi/v3/asset/getUserAsset';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<
     | {
@@ -1144,12 +1149,12 @@ export const getFundingAsset = async (
   const endpoint = 'https://api.binance.com/sapi/v1/asset/get-funding-asset';
   const url = new URL(endpoint);
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'POST', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<
     | {
@@ -1187,12 +1192,12 @@ export const getUmAccountTradeList = async (
   const endpoint = 'https://papi.binance.com/papi/v1/um/userTrades';
   const url = new URL(endpoint);
   const weight = 5;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(url.host, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPrivate<
     | {

--- a/apps/vendor-binance/src/api/public-api.ts
+++ b/apps/vendor-binance/src/api/public-api.ts
@@ -1,5 +1,5 @@
 import { scopeError, tokenBucket } from '@yuants/utils';
-import { buildTokenBucketKey, createRequestContext, getTokenBucketOptions, requestPublic } from './client';
+import { createRequestContext, getTokenBucketOptions, requestPublic } from './client';
 
 export interface IFutureExchangeFilter extends Record<string, string | number | boolean | undefined> {
   filterType: string;
@@ -113,13 +113,14 @@ export interface IMarginPair {
 export const getFutureExchangeInfo = async (): Promise<IFutureExchangeInfo> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/exchangeInfo';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<IFutureExchangeInfo>('GET', endpoint, undefined, requestContext);
 };
@@ -139,9 +140,10 @@ export const getFutureFundingRate = async (params: {
 }): Promise<IFutureFundingRateEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/fundingRate';
   const url = new URL(endpoint);
+  const baseKey = `${url.host}fundingRate`;
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host + 'fundingRate', requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
@@ -150,7 +152,7 @@ export const getFutureFundingRate = async (params: {
         capacity: 500,
         refillAmount: 500,
         refillInterval: 300_000,
-      }).acquireSync(weight),
+      }).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<IFutureFundingRateEntry[]>('GET', endpoint, params, requestContext);
 };
@@ -165,9 +167,10 @@ export const getFutureFundingRate = async (params: {
 export const getFutureFundingInfo = async (): Promise<IFutureFundingInfoEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/fundingInfo';
   const url = new URL(endpoint);
+  const baseKey = `${url.host}fundingRate`;
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host + 'fundingRate', requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
@@ -176,7 +179,7 @@ export const getFutureFundingInfo = async (): Promise<IFutureFundingInfoEntry[]>
         capacity: 500,
         refillAmount: 500,
         refillInterval: 300_000,
-      }).acquireSync(weight),
+      }).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<IFutureFundingInfoEntry[]>('GET', endpoint, undefined, requestContext);
 };
@@ -195,9 +198,10 @@ export const getFuturePremiumIndex = async (params: {
 }): Promise<IFuturePremiumIndexEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/premiumIndex';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = params?.symbol ? 1 : 10;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     {
@@ -209,7 +213,7 @@ export const getFuturePremiumIndex = async (params: {
       weight,
       hasSymbol: !!params?.symbol,
     },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<IFuturePremiumIndexEntry[]>('GET', endpoint, params, requestContext);
 };
@@ -228,9 +232,10 @@ export const getFutureBookTicker = async (params?: {
 }): Promise<IFutureBookTickerEntry[]> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/ticker/bookTicker';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = params?.symbol ? 2 : 5;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     {
@@ -242,7 +247,7 @@ export const getFutureBookTicker = async (params?: {
       weight,
       hasSymbol: !!params?.symbol,
     },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<IFutureBookTickerEntry[]>('GET', endpoint, params, requestContext);
 };
@@ -259,13 +264,14 @@ export const getFutureBookTicker = async (params?: {
 export const getFutureOpenInterest = async (params: { symbol: string }): Promise<IFutureOpenInterest> => {
   const endpoint = 'https://fapi.binance.com/fapi/v1/openInterest';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = 1;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<IFutureOpenInterest>('GET', endpoint, params, requestContext);
 };
@@ -287,9 +293,10 @@ export interface ISpotBookTickerEntry {
 export const getSpotBookTicker = async (params?: { symbol?: string }): Promise<ISpotBookTickerEntry[]> => {
   const endpoint = 'https://api.binance.com/api/v3/ticker/bookTicker';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = params?.symbol ? 2 : 4;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     {
@@ -301,7 +308,7 @@ export const getSpotBookTicker = async (params?: { symbol?: string }): Promise<I
       weight,
       hasSymbol: !!params?.symbol,
     },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<ISpotBookTickerEntry[]>('GET', endpoint, params, requestContext);
 };
@@ -354,13 +361,14 @@ export interface ISpotExchangeInfo {
 export const getSpotExchangeInfo = async (): Promise<ISpotExchangeInfo> => {
   const endpoint = 'https://api.binance.com/api/v3/exchangeInfo';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = 20;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic<ISpotExchangeInfo>('GET', endpoint, undefined, requestContext);
 };
@@ -384,13 +392,14 @@ export const getSpotTickerPrice = async (params?: {
 > => {
   const endpoint = 'https://api.binance.com/api/v3/ticker/price';
   const url = new URL(endpoint);
+  const baseKey = url.host;
   const weight = params?.symbol ? 2 : 4;
-  const requestContext = await createRequestContext();
-  const bucketKey = buildTokenBucketKey(url.host, requestContext.ip);
+  const requestContext = await createRequestContext(baseKey, weight);
+  const bucketKey = requestContext.bucketKey;
   scopeError(
     'BINANCE_API_RATE_LIMIT',
     { method: 'GET', endpoint, host: url.host, path: url.pathname, bucketId: bucketKey, weight },
-    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(weight),
+    () => tokenBucket(bucketKey, getTokenBucketOptions(url.host)).acquireSync(requestContext.acquireWeight),
   );
   return requestPublic('GET', endpoint, params, requestContext);
 };

--- a/common/changes/@yuants/app-http-proxy/legion-feature-proxy-bucket-v2_2026-03-05-09-48.json
+++ b/common/changes/@yuants/app-http-proxy/legion-feature-proxy-bucket-v2_2026-03-05-09-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/app-http-proxy",
+      "comment": "add weighted proxy bucket acquisition",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/app-http-proxy"
+}

--- a/common/changes/@yuants/http-services/legion-feature-proxy-bucket-v2_2026-03-05-09-48.json
+++ b/common/changes/@yuants/http-services/legion-feature-proxy-bucket-v2_2026-03-05-09-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/http-services",
+      "comment": "add weighted proxy bucket acquisition",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/http-services"
+}

--- a/common/changes/@yuants/utils/legion-feature-proxy-bucket-v2_2026-03-05-12-28.json
+++ b/common/changes/@yuants/utils/legion-feature-proxy-bucket-v2_2026-03-05-12-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/utils",
+      "comment": "fix acquire 0 issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/utils"
+}

--- a/common/changes/@yuants/vendor-binance/legion-feature-proxy-bucket-v2_2026-03-05-09-48.json
+++ b/common/changes/@yuants/vendor-binance/legion-feature-proxy-bucket-v2_2026-03-05-09-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yuants/vendor-binance",
+      "comment": "add weighted proxy bucket acquisition",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@yuants/vendor-binance"
+}

--- a/libraries/http-services/etc/http-services.api.md
+++ b/libraries/http-services/etc/http-services.api.md
@@ -6,6 +6,25 @@
 
 import { IServiceOptions } from '@yuants/protocol';
 import { Terminal } from '@yuants/protocol';
+import { TokenBucketOptions } from '@yuants/utils';
+
+// @public (undocumented)
+export const acquireProxyBucket: (input: AcquireProxyBucketInput) => AcquireProxyBucketResult;
+
+// @public (undocumented)
+export type AcquireProxyBucketInput = {
+    baseKey: string;
+    weight: number;
+    terminal: Terminal;
+    getBucketOptions: (baseKey: string) => TokenBucketOptions;
+};
+
+// @public (undocumented)
+export type AcquireProxyBucketResult = {
+    ip: string;
+    terminalId: string;
+    bucketKey: string;
+};
 
 // @public (undocumented)
 export const computeAndInjectProxyIp: (terminal: Terminal, options?: {

--- a/libraries/http-services/src/__tests__/client.test.ts
+++ b/libraries/http-services/src/__tests__/client.test.ts
@@ -65,4 +65,31 @@ describe('fetch', () => {
     expect(response.ok).toBe(true);
     expect(response.status).toBe(200);
   });
+
+  it('should map route stage failure to E_PROXY_TARGET_NOT_FOUND', async () => {
+    jest
+      .spyOn(terminal.client, 'requestForResponse')
+      .mockRejectedValue(new Error('NO_TERMINAL_AVAILABLE_FOR_REQUEST'));
+
+    await expect(
+      fetch('https://api.example.com/data', {
+        labels: { ip: '10.0.0.1' },
+        terminal,
+      }),
+    ).rejects.toThrow('E_PROXY_TARGET_NOT_FOUND');
+  });
+
+  it('should map request stage failure to E_PROXY_REQUEST_FAILED', async () => {
+    jest.spyOn(terminal.client, 'requestForResponse').mockResolvedValue({
+      code: 500,
+      message: 'FETCH_FAILED',
+    } as any);
+
+    await expect(
+      fetch('https://api.example.com/data', {
+        labels: { ip: '10.0.0.1' },
+        terminal,
+      }),
+    ).rejects.toThrow('E_PROXY_REQUEST_FAILED');
+  });
 });

--- a/libraries/http-services/src/__tests__/proxy-ip.test.ts
+++ b/libraries/http-services/src/__tests__/proxy-ip.test.ts
@@ -1,0 +1,367 @@
+import { Terminal } from '@yuants/protocol';
+
+jest.mock('@yuants/utils', () => {
+  const actual = jest.requireActual('@yuants/utils');
+  return {
+    ...actual,
+    tokenBucket: jest.fn(),
+  };
+});
+
+import { acquireProxyBucket } from '../proxy-ip';
+import { encodePath, tokenBucket } from '@yuants/utils';
+
+const TRUSTED_PROXY_TERMINAL_IDS_ENV = 'TRUSTED_HTTP_PROXY_TERMINAL_IDS';
+
+type MockBucket = {
+  read: () => number;
+  acquireSync: (tokens: number) => void;
+};
+
+const mockTokenBucket = tokenBucket as unknown as jest.Mock;
+
+const originalTrustedProxyTerminalIds = process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV];
+
+const createTerminal = (terminalId: string, ips: string[]): Terminal =>
+  ({
+    terminal_id: terminalId,
+    terminalInfos: ips.map((ip, index) => ({
+      terminal_id: `${terminalId}-proxy-${index + 1}`,
+      tags: { ip, ip_source: 'http-services' },
+      serviceInfo: {
+        [`HTTPProxy-${index + 1}`]: {
+          method: 'HTTPProxy',
+          schema: { type: 'object' },
+        },
+      },
+    })),
+  } as unknown as Terminal);
+
+const allowTerminalProxies = (terminal: Terminal): void => {
+  const trustedTerminalIds = terminal.terminalInfos.map((info) => info.terminal_id).join(',');
+  process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV] = trustedTerminalIds;
+};
+
+describe('acquireProxyBucket', () => {
+  beforeEach(() => {
+    mockTokenBucket.mockReset();
+    delete process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV];
+  });
+
+  afterAll(() => {
+    if (originalTrustedProxyTerminalIds === undefined) {
+      delete process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV];
+    } else {
+      process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV] = originalTrustedProxyTerminalIds;
+    }
+  });
+
+  it('should prioritize candidates with read() >= weight', () => {
+    const terminal = createTerminal('terminal-priority', ['10.0.0.1', '10.0.0.2', '10.0.0.3']);
+    allowTerminalProxies(terminal);
+    const attempts: string[] = [];
+    const bucketsByKey = new Map<string, MockBucket>([
+      [
+        encodePath(['priority-base', '10.0.0.1']),
+        {
+          read: () => 1,
+          acquireSync: () => {
+            attempts.push('10.0.0.1');
+          },
+        },
+      ],
+      [
+        encodePath(['priority-base', '10.0.0.2']),
+        {
+          read: () => 20,
+          acquireSync: () => {
+            attempts.push('10.0.0.2');
+          },
+        },
+      ],
+      [
+        encodePath(['priority-base', '10.0.0.3']),
+        {
+          read: () => 10,
+          acquireSync: () => {
+            attempts.push('10.0.0.3');
+          },
+        },
+      ],
+    ]);
+
+    mockTokenBucket.mockImplementation((bucketKey: string) => {
+      const bucket = bucketsByKey.get(bucketKey);
+      if (!bucket) throw new Error(`Unexpected bucket key: ${bucketKey}`);
+      return bucket;
+    });
+
+    const result = acquireProxyBucket({
+      baseKey: 'priority-base',
+      weight: 5,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+
+    expect(result.ip).toBe('10.0.0.2');
+    expect(attempts[0]).toBe('10.0.0.2');
+    expect(attempts).toEqual(['10.0.0.2']);
+  });
+
+  it('should switch to next candidate when acquireSync fails', () => {
+    const terminal = createTerminal('terminal-switch', ['10.0.1.1', '10.0.1.2']);
+    allowTerminalProxies(terminal);
+    const attempts: string[] = [];
+    const bucketsByKey = new Map<string, MockBucket>([
+      [
+        encodePath(['switch-base', '10.0.1.1']),
+        {
+          read: () => 10,
+          acquireSync: () => {
+            attempts.push('10.0.1.1');
+            throw new Error('SEMAPHORE_INSUFFICIENT_PERMS: no quota');
+          },
+        },
+      ],
+      [
+        encodePath(['switch-base', '10.0.1.2']),
+        {
+          read: () => 10,
+          acquireSync: () => {
+            attempts.push('10.0.1.2');
+          },
+        },
+      ],
+    ]);
+
+    mockTokenBucket.mockImplementation((bucketKey: string) => {
+      const bucket = bucketsByKey.get(bucketKey);
+      if (!bucket) throw new Error(`Unexpected bucket key: ${bucketKey}`);
+      return bucket;
+    });
+
+    const result = acquireProxyBucket({
+      baseKey: 'switch-base',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+
+    expect(result.ip).toBe('10.0.1.2');
+    expect(attempts).toEqual(['10.0.1.1', '10.0.1.2']);
+  });
+
+  it('should throw E_PROXY_TARGET_NOT_FOUND when pool is empty', () => {
+    const terminal = createTerminal('terminal-empty', []);
+    process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV] = 'terminal-empty-proxy-1';
+
+    expect(() =>
+      acquireProxyBucket({
+        baseKey: 'empty-base',
+        weight: 1,
+        terminal,
+        getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+      }),
+    ).toThrow('E_PROXY_TARGET_NOT_FOUND');
+  });
+
+  it('should throw E_PROXY_BUCKET_EXHAUSTED when all candidates fail', () => {
+    const terminal = createTerminal('terminal-exhausted', ['10.0.2.1', '10.0.2.2']);
+    allowTerminalProxies(terminal);
+    const bucketsByKey = new Map<string, MockBucket>([
+      [
+        encodePath(['exhausted-base', '10.0.2.1']),
+        {
+          read: () => 3,
+          acquireSync: () => {
+            throw new Error('SEMAPHORE_INSUFFICIENT_PERMS: no quota');
+          },
+        },
+      ],
+      [
+        encodePath(['exhausted-base', '10.0.2.2']),
+        {
+          read: () => 3,
+          acquireSync: () => {
+            throw new Error('SEMAPHORE_INSUFFICIENT_PERMS: no quota');
+          },
+        },
+      ],
+    ]);
+
+    mockTokenBucket.mockImplementation((bucketKey: string) => {
+      const bucket = bucketsByKey.get(bucketKey);
+      if (!bucket) throw new Error(`Unexpected bucket key: ${bucketKey}`);
+      return bucket;
+    });
+
+    expect(() =>
+      acquireProxyBucket({
+        baseKey: 'exhausted-base',
+        weight: 10,
+        terminal,
+        getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+      }),
+    ).toThrow('E_PROXY_BUCKET_EXHAUSTED');
+  });
+
+  it('should throw E_BUCKET_OPTIONS_CONFLICT for same bucketKey options mismatch', () => {
+    const terminal = createTerminal('terminal-conflict', ['10.0.3.1']);
+    allowTerminalProxies(terminal);
+
+    mockTokenBucket.mockImplementation(() => {
+      return {
+        read: () => 10,
+        acquireSync: () => {},
+      };
+    });
+
+    acquireProxyBucket({
+      baseKey: 'conflict-base',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+
+    expect(() =>
+      acquireProxyBucket({
+        baseKey: 'conflict-base',
+        weight: 1,
+        terminal,
+        getBucketOptions: () => ({ capacity: 200, refillAmount: 200, refillInterval: 60_000 }),
+      }),
+    ).toThrow('E_BUCKET_OPTIONS_CONFLICT');
+  });
+
+  it('should maintain independent round robin cursor for different baseKey', () => {
+    const terminal = createTerminal('terminal-r11', ['10.0.4.1', '10.0.4.2']);
+    allowTerminalProxies(terminal);
+
+    mockTokenBucket.mockImplementation(() => {
+      return {
+        read: () => 10,
+        acquireSync: () => {},
+      };
+    });
+
+    const keyA1 = acquireProxyBucket({
+      baseKey: 'base-A',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+    const keyB1 = acquireProxyBucket({
+      baseKey: 'base-B',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+    const keyA2 = acquireProxyBucket({
+      baseKey: 'base-A',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+    const keyB2 = acquireProxyBucket({
+      baseKey: 'base-B',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+
+    expect(keyA1.ip).toBe('10.0.4.1');
+    expect(keyB1.ip).toBe('10.0.4.1');
+    expect(keyA2.ip).toBe('10.0.4.2');
+    expect(keyB2.ip).toBe('10.0.4.2');
+  });
+
+  it('should fail closed when trusted terminal allowlist is empty', () => {
+    const terminal = createTerminal('terminal-allowlist-empty', ['10.0.5.1']);
+
+    mockTokenBucket.mockImplementation(() => {
+      return {
+        read: () => 10,
+        acquireSync: () => {},
+      };
+    });
+
+    expect(() =>
+      acquireProxyBucket({
+        baseKey: 'allowlist-base',
+        weight: 1,
+        terminal,
+        getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+      }),
+    ).toThrow('E_PROXY_TARGET_NOT_FOUND');
+  });
+
+  it('should throw E_PROXY_ACQUIRE_INTERNAL_ERROR for unexpected acquire errors', () => {
+    const terminal = createTerminal('terminal-acquire-error', ['10.0.6.1']);
+    allowTerminalProxies(terminal);
+
+    mockTokenBucket.mockImplementation(() => {
+      return {
+        read: () => 10,
+        acquireSync: () => {
+          throw new Error('unexpected runtime error');
+        },
+      };
+    });
+
+    expect(() =>
+      acquireProxyBucket({
+        baseKey: 'acquire-error-base',
+        weight: 1,
+        terminal,
+        getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+      }),
+    ).toThrow('E_PROXY_ACQUIRE_INTERNAL_ERROR');
+  });
+
+  it('should bind selected result to trusted terminalId when same ip appears multiple times', () => {
+    const terminal = {
+      terminal_id: 'terminal-binding',
+      terminalInfos: [
+        {
+          terminal_id: 'trusted-proxy',
+          tags: { ip: '10.0.7.1', ip_source: 'http-services' },
+          serviceInfo: {
+            HTTPProxyA: {
+              method: 'HTTPProxy',
+              schema: { type: 'object' },
+            },
+          },
+        },
+        {
+          terminal_id: 'untrusted-proxy',
+          tags: { ip: '10.0.7.1', ip_source: 'http-services' },
+          serviceInfo: {
+            HTTPProxyB: {
+              method: 'HTTPProxy',
+              schema: { type: 'object' },
+            },
+          },
+        },
+      ],
+    } as unknown as Terminal;
+
+    process.env[TRUSTED_PROXY_TERMINAL_IDS_ENV] = 'trusted-proxy';
+
+    mockTokenBucket.mockImplementation(() => {
+      return {
+        read: () => 10,
+        acquireSync: () => {},
+      };
+    });
+
+    const result = acquireProxyBucket({
+      baseKey: 'binding-base',
+      weight: 1,
+      terminal,
+      getBucketOptions: () => ({ capacity: 100, refillAmount: 100, refillInterval: 60_000 }),
+    });
+
+    expect(result.ip).toBe('10.0.7.1');
+    expect(result.terminalId).toBe('trusted-proxy');
+  });
+});

--- a/libraries/utils/src/tokenBucket.test.ts
+++ b/libraries/utils/src/tokenBucket.test.ts
@@ -25,9 +25,16 @@ describe('tokenBucket', () => {
       tb[Symbol.dispose]();
     });
 
-    it('should throw error when acquiring zero or negative tokens', async () => {
+    it('should treat acquire(0) as no-op', async () => {
       const tb = tokenBucket('test-7');
-      await expect(tb.acquire(0)).rejects.toThrow('TOKEN_BUCKET_INVALID_ACQUIRE_TOKENS');
+      expect(tb.read()).toBe(1);
+      await tb.acquire(0);
+      expect(tb.read()).toBe(1);
+      tb[Symbol.dispose]();
+    });
+
+    it('should throw error when acquiring negative tokens', async () => {
+      const tb = tokenBucket('test-7-negative');
       await expect(tb.acquire(-1)).rejects.toThrow('TOKEN_BUCKET_INVALID_ACQUIRE_TOKENS');
       tb[Symbol.dispose]();
     });

--- a/libraries/utils/src/tokenBucket.test.ts
+++ b/libraries/utils/src/tokenBucket.test.ts
@@ -37,6 +37,15 @@ describe('tokenBucket', () => {
       await expect(tb.acquire(3)).rejects.toThrow('TOKEN_BUCKET_INSUFFICIENT_CAPACITY');
       tb[Symbol.dispose]();
     });
+
+    it('should treat acquireSync(0) as no-op', () => {
+      const tb = tokenBucket('test-sync-zero', { capacity: 2 });
+      expect(tb.read()).toBe(2);
+      tb.acquireSync(0);
+      expect(tb.read()).toBe(2);
+      expect(() => tb.acquireSync(-1)).toThrow('SEMAPHORE_INVALID_ACQUIRE_PERMS');
+      tb[Symbol.dispose]();
+    });
   });
 
   describe('token refill', () => {

--- a/libraries/utils/src/tokenBucket.ts
+++ b/libraries/utils/src/tokenBucket.ts
@@ -144,8 +144,13 @@ export const tokenBucket = (bucketId: string, options: TokenBucketOptions = {}):
   }
 
   const acquire = async (tokens: number = 1, signal?: AbortSignal): Promise<void> => {
+    // 0 令牌请求为 no-op，便于在条件分支中统一调用 acquire/acquireSync
+    if (tokens === 0) {
+      return;
+    }
+
     // 请求的令牌数必须为正整数
-    if (tokens <= 0) {
+    if (tokens < 0) {
       throw newError('TOKEN_BUCKET_INVALID_ACQUIRE_TOKENS', { bucketId, tokens });
     }
     // 请求的令牌数不能超过容量，否则永远无法满足请求

--- a/libraries/utils/src/tokenBucket.ts
+++ b/libraries/utils/src/tokenBucket.ts
@@ -162,6 +162,7 @@ export const tokenBucket = (bucketId: string, options: TokenBucketOptions = {}):
   };
 
   const acquireSync = (tokens: number = 1): void => {
+    if (tokens === 0) return;
     sem.acquireSync(tokens);
   };
 


### PR DESCRIPTION
# What

- Rollout vendor 侧 tokenBucket key 增加出口 IP 维度，USE_HTTP_PROXY 时通过 labels.ip 路由到对应 proxy 出口。

# Why

- 现有 key 与真实出口 IP 不一致，导致限流失真与诊断困难；需要对齐 key 与路由。

# How

- 各 vendor 的 tokenBucket key 使用 `encodePath([BaseKey, ip])`。
- USE_HTTP_PROXY 场景以 labels.ip 路由；直连场景使用 `public_ip` fallback。

# Testing

- `rush build`

# Risk / Rollback

- 风险：`public_ip` 缺失时 `public-ip-unknown` 可能造成多终端共享桶；proxy 池为空时请求失败。
- 回滚：版本回退至旧 key 逻辑。

# Links

- RFC: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/rfc.md`
- Walkthrough: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/report-walkthrough.md`
- Code Review: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-code-rollout.md`
- Security Review: `.legion/tasks/vendor-tokenbucket-proxy-ip/docs/review-security-rollout.md`
