### PR TITLE
feat(vendor-huobi): add IOC FOK swap order support

### DIFF
--- a/apps/vendor-huobi/src/services/orders/listOrders.ts
+++ b/apps/vendor-huobi/src/services/orders/listOrders.ts
@@ -1,5 +1,6 @@
 import { IOrder } from '@yuants/data-order';
 import { getSwapOpenOrders, ICredential } from '../../api/private-api';
+import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
 
 export const listSwapOrders = async (credential: ICredential): Promise<IOrder[]> => {
   const orders: IOrder[] = [];
@@ -17,17 +18,7 @@ export const listSwapOrders = async (credential: ICredential): Promise<IOrder[]>
         order_id: v.order_id_str,
         account_id: `huobi/swap`, // Placeholder, will be adjusted if needed
         product_id: v.contract_code,
-        order_type: ['lightning'].includes(v.order_price_type)
-          ? 'MARKET'
-          : ['limit', 'opponent', 'post_only', 'optimal_5', 'optimal_10', 'optimal_20'].includes(
-              v.order_price_type,
-            )
-          ? 'LIMIT'
-          : ['fok'].includes(v.order_price_type)
-          ? 'FOK'
-          : v.order_price_type.includes('ioc')
-          ? 'IOC'
-          : 'STOP', // unreachable code
+        order_type: mapHuobiSwapOrderToOrderType(v.order_price_type),
         order_direction:
           v.direction === 'open'
             ? v.offset === 'buy'

--- a/apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts
+++ b/apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts
@@ -1,7 +1,7 @@
 import { IOrder } from '@yuants/data-order';
 
 export const mapHuobiSwapOrderToOrderType = (orderPriceType?: string): IOrder['order_type'] => {
-  if (orderPriceType === 'lightning' || orderPriceType === 'market') return 'MARKET';
+  if (['lightning', 'market'].includes(orderPriceType ?? '')) return 'MARKET';
   if (orderPriceType === 'fok') return 'FOK';
   if (orderPriceType?.includes('ioc')) return 'IOC';
   return 'LIMIT';

--- a/apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts
+++ b/apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts
@@ -1,0 +1,8 @@
+import { IOrder } from '@yuants/data-order';
+
+export const mapHuobiSwapOrderToOrderType = (orderPriceType?: string): IOrder['order_type'] => {
+  if (orderPriceType === 'lightning' || orderPriceType === 'market') return 'MARKET';
+  if (orderPriceType === 'fok') return 'FOK';
+  if (orderPriceType?.includes('ioc')) return 'IOC';
+  return 'LIMIT';
+};

--- a/apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts
+++ b/apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts
@@ -1,0 +1,17 @@
+import { IOrder } from '@yuants/data-order';
+
+export const mapSwapOrderTypeToHuobi = (orderType?: IOrder['order_type']) => {
+  if (orderType === 'MARKET') return { order_price_type: 'market' };
+  if (orderType === 'LIMIT') return { order_price_type: 'limit' };
+  if (orderType === 'IOC') return { order_price_type: 'ioc' };
+  if (orderType === 'FOK') return { order_price_type: 'fok' };
+  throw new Error(`Unsupported order_type: ${orderType}`);
+};
+
+export const mapUnionSwapOrderTypeToHuobi = (orderType?: IOrder['order_type']) => {
+  if (orderType === 'MARKET') return { type: 'market' as const };
+  if (orderType === 'LIMIT') return { type: 'limit' as const };
+  if (orderType === 'IOC') return { type: 'limit' as const, time_in_force: 'ioc' as const };
+  if (orderType === 'FOK') return { type: 'limit' as const, time_in_force: 'fok' as const };
+  throw new Error(`Unsupported order_type: ${orderType}`);
+};

--- a/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
@@ -1,5 +1,47 @@
+import { encodePath } from '@yuants/utils';
 import { mapSwapOrderTypeToHuobi, mapUnionSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
 import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
+
+jest.mock('../../api/private-api', () => ({
+  getCrossMarginLoanInfo: jest.fn(),
+  getSpotAccountBalance: jest.fn(),
+  getSwapCrossPositionInfo: jest.fn(),
+  postSwapOrder: jest.fn(),
+  postUnionAccountSwapOrder: jest.fn(),
+}));
+
+jest.mock('../../api/public-api', () => ({
+  getSpotTick: jest.fn(),
+}));
+
+jest.mock('../exchange', () => ({
+  accountModeCache: {
+    query: jest.fn(),
+  },
+}));
+
+jest.mock('../product', () => ({
+  productCache: {
+    query: jest.fn(),
+  },
+}));
+
+jest.mock('../uid', () => ({
+  superMarginAccountUidCache: {
+    query: jest.fn(),
+  },
+}));
+
+const { getSwapCrossPositionInfo, postSwapOrder } =
+  require('../../api/private-api') as typeof import('../../api/private-api');
+const { accountModeCache } = require('../exchange') as typeof import('../exchange');
+const { submitOrder } = require('./submitOrder') as typeof import('./submitOrder');
+
+const mockGetSwapCrossPositionInfo = getSwapCrossPositionInfo as jest.MockedFunction<
+  typeof getSwapCrossPositionInfo
+>;
+const mockPostSwapOrder = postSwapOrder as jest.MockedFunction<typeof postSwapOrder>;
+const mockAccountModeQuery = accountModeCache.query as jest.MockedFunction<typeof accountModeCache.query>;
 
 describe('Huobi swap order type mappings', () => {
   test('maps MARKET LIMIT IOC and FOK for normal swap accounts', () => {
@@ -26,5 +68,98 @@ describe('mapHuobiSwapOrderToOrderType', () => {
     expect(mapHuobiSwapOrderToOrderType('optimal_20_ioc')).toBe('IOC');
     expect(mapHuobiSwapOrderToOrderType('fok')).toBe('FOK');
     expect(mapHuobiSwapOrderToOrderType('post_only')).toBe('LIMIT');
+  });
+});
+
+describe('submitOrder normal swap account order type mapping', () => {
+  const credential = { access_key: 'ak', secret_key: 'sk' };
+  const product_id = encodePath('HUOBI', 'SWAP', 'BTC-USDT');
+
+  beforeEach(() => {
+    process.env.BROKER_ID = 'broker-id';
+    mockAccountModeQuery.mockResolvedValue(0);
+    mockGetSwapCrossPositionInfo.mockResolvedValue({
+      status: 'ok',
+      ts: 1,
+      data: [
+        {
+          symbol: 'BTC',
+          contract_code: 'BTC-USDT',
+          volume: 1,
+          available: 1,
+          frozen: 0,
+          cost_open: 10000,
+          cost_hold: 10000,
+          profit_unreal: 0,
+          profit_rate: 0,
+          lever_rate: 20,
+          position_margin: 100,
+          direction: 'buy',
+          profit: 0,
+          last_price: 12345,
+          margin_asset: 'USDT',
+          margin_mode: 'cross',
+          margin_account: 'BTC-USDT',
+          contract_type: 'swap',
+          pair: 'BTC-USDT',
+          business_type: 'swap',
+          position_mode: 'single',
+          adl_risk_percent: '0',
+        },
+      ],
+    });
+    mockPostSwapOrder.mockResolvedValue({
+      status: 'ok',
+      ts: 1,
+      data: { order_id: 1, order_id_str: '1' },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('uses ioc order_price_type for IOC normal swap orders', async () => {
+    await submitOrder(credential, {
+      product_id,
+      order_type: 'IOC',
+      order_direction: 'OPEN_LONG',
+      volume: 1,
+      price: 12345,
+    } as any);
+
+    expect(mockPostSwapOrder).toHaveBeenCalledWith(credential, {
+      contract_code: 'BTC-USDT',
+      contract_type: 'swap',
+      price: 12345,
+      volume: 1,
+      offset: 'open',
+      direction: 'buy',
+      lever_rate: 20,
+      order_price_type: 'ioc',
+      channel_code: 'broker-id',
+    });
+  });
+
+  test('uses fok order_price_type for FOK normal swap orders', async () => {
+    await submitOrder(credential, {
+      product_id,
+      order_type: 'FOK',
+      order_direction: 'OPEN_LONG',
+      volume: 1,
+      price: 12345,
+    } as any);
+
+    expect(mockPostSwapOrder).toHaveBeenCalledWith(credential, {
+      contract_code: 'BTC-USDT',
+      contract_type: 'swap',
+      price: 12345,
+      volume: 1,
+      offset: 'open',
+      direction: 'buy',
+      lever_rate: 20,
+      order_price_type: 'fok',
+      channel_code: 'broker-id',
+    });
   });
 });

--- a/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
@@ -1,0 +1,24 @@
+import { mapSwapOrderTypeToHuobi, mapUnionSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
+import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
+
+describe('Huobi swap order type mappings', () => {
+  test('maps IOC and FOK for normal swap accounts', () => {
+    expect(mapSwapOrderTypeToHuobi('IOC')).toEqual({ order_price_type: 'ioc' });
+    expect(mapSwapOrderTypeToHuobi('FOK')).toEqual({ order_price_type: 'fok' });
+  });
+
+  test('maps IOC and FOK for unified swap accounts', () => {
+    expect(mapUnionSwapOrderTypeToHuobi('IOC')).toEqual({ type: 'limit', time_in_force: 'ioc' });
+    expect(mapUnionSwapOrderTypeToHuobi('FOK')).toEqual({ type: 'limit', time_in_force: 'fok' });
+  });
+});
+
+describe('mapHuobiSwapOrderToOrderType', () => {
+  test('maps Huobi order_price_type values back to Yuan order types', () => {
+    expect(mapHuobiSwapOrderToOrderType('lightning')).toBe('MARKET');
+    expect(mapHuobiSwapOrderToOrderType('limit')).toBe('LIMIT');
+    expect(mapHuobiSwapOrderToOrderType('ioc')).toBe('IOC');
+    expect(mapHuobiSwapOrderToOrderType('optimal_20_ioc')).toBe('IOC');
+    expect(mapHuobiSwapOrderToOrderType('fok')).toBe('FOK');
+  });
+});

--- a/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
@@ -119,6 +119,50 @@ describe('submitOrder normal swap account order type mapping', () => {
     jest.clearAllMocks();
   });
 
+  test('uses market order_price_type for MARKET normal swap orders', async () => {
+    await submitOrder(credential, {
+      product_id,
+      order_type: 'MARKET',
+      order_direction: 'OPEN_LONG',
+      volume: 1,
+      price: 12345,
+    } as any);
+
+    expect(mockPostSwapOrder).toHaveBeenCalledWith(credential, {
+      contract_code: 'BTC-USDT',
+      contract_type: 'swap',
+      price: 12345,
+      volume: 1,
+      offset: 'open',
+      direction: 'buy',
+      lever_rate: 20,
+      order_price_type: 'market',
+      channel_code: 'broker-id',
+    });
+  });
+
+  test('uses limit order_price_type for LIMIT normal swap orders', async () => {
+    await submitOrder(credential, {
+      product_id,
+      order_type: 'LIMIT',
+      order_direction: 'OPEN_LONG',
+      volume: 1,
+      price: 12345,
+    } as any);
+
+    expect(mockPostSwapOrder).toHaveBeenCalledWith(credential, {
+      contract_code: 'BTC-USDT',
+      contract_type: 'swap',
+      price: 12345,
+      volume: 1,
+      offset: 'open',
+      direction: 'buy',
+      lever_rate: 20,
+      order_price_type: 'limit',
+      channel_code: 'broker-id',
+    });
+  });
+
   test('uses ioc order_price_type for IOC normal swap orders', async () => {
     await submitOrder(credential, {
       product_id,

--- a/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
@@ -19,10 +19,12 @@ describe('Huobi swap order type mappings', () => {
 
 describe('mapHuobiSwapOrderToOrderType', () => {
   test('maps Huobi order_price_type values back to Yuan order types', () => {
+    expect(mapHuobiSwapOrderToOrderType('market')).toBe('MARKET');
     expect(mapHuobiSwapOrderToOrderType('lightning')).toBe('MARKET');
     expect(mapHuobiSwapOrderToOrderType('limit')).toBe('LIMIT');
     expect(mapHuobiSwapOrderToOrderType('ioc')).toBe('IOC');
     expect(mapHuobiSwapOrderToOrderType('optimal_20_ioc')).toBe('IOC');
     expect(mapHuobiSwapOrderToOrderType('fok')).toBe('FOK');
+    expect(mapHuobiSwapOrderToOrderType('post_only')).toBe('LIMIT');
   });
 });

--- a/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
@@ -2,12 +2,16 @@ import { mapSwapOrderTypeToHuobi, mapUnionSwapOrderTypeToHuobi } from './mapSwap
 import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
 
 describe('Huobi swap order type mappings', () => {
-  test('maps IOC and FOK for normal swap accounts', () => {
+  test('maps MARKET LIMIT IOC and FOK for normal swap accounts', () => {
+    expect(mapSwapOrderTypeToHuobi('MARKET')).toEqual({ order_price_type: 'market' });
+    expect(mapSwapOrderTypeToHuobi('LIMIT')).toEqual({ order_price_type: 'limit' });
     expect(mapSwapOrderTypeToHuobi('IOC')).toEqual({ order_price_type: 'ioc' });
     expect(mapSwapOrderTypeToHuobi('FOK')).toEqual({ order_price_type: 'fok' });
   });
 
-  test('maps IOC and FOK for unified swap accounts', () => {
+  test('maps MARKET LIMIT IOC and FOK for unified swap accounts', () => {
+    expect(mapUnionSwapOrderTypeToHuobi('MARKET')).toEqual({ type: 'market', time_in_force: undefined });
+    expect(mapUnionSwapOrderTypeToHuobi('LIMIT')).toEqual({ type: 'limit', time_in_force: undefined });
     expect(mapUnionSwapOrderTypeToHuobi('IOC')).toEqual({ type: 'limit', time_in_force: 'ioc' });
     expect(mapUnionSwapOrderTypeToHuobi('FOK')).toEqual({ type: 'limit', time_in_force: 'fok' });
   });

--- a/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
@@ -5,6 +5,7 @@ import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
 jest.mock('../../api/private-api', () => ({
   getCrossMarginLoanInfo: jest.fn(),
   getSpotAccountBalance: jest.fn(),
+  getSwapOpenOrders: jest.fn(),
   getSwapCrossPositionInfo: jest.fn(),
   postSwapOrder: jest.fn(),
   postUnionAccountSwapOrder: jest.fn(),
@@ -32,15 +33,20 @@ jest.mock('../uid', () => ({
   },
 }));
 
-const { getSwapCrossPositionInfo, postSwapOrder } =
+const { getSwapCrossPositionInfo, getSwapOpenOrders, postSwapOrder, postUnionAccountSwapOrder } =
   require('../../api/private-api') as typeof import('../../api/private-api');
 const { accountModeCache } = require('../exchange') as typeof import('../exchange');
+const { listSwapOrders } = require('./listOrders') as typeof import('./listOrders');
 const { submitOrder } = require('./submitOrder') as typeof import('./submitOrder');
 
 const mockGetSwapCrossPositionInfo = getSwapCrossPositionInfo as jest.MockedFunction<
   typeof getSwapCrossPositionInfo
 >;
+const mockGetSwapOpenOrders = getSwapOpenOrders as jest.MockedFunction<typeof getSwapOpenOrders>;
 const mockPostSwapOrder = postSwapOrder as jest.MockedFunction<typeof postSwapOrder>;
+const mockPostUnionAccountSwapOrder = postUnionAccountSwapOrder as jest.MockedFunction<
+  typeof postUnionAccountSwapOrder
+>;
 const mockAccountModeQuery = accountModeCache.query as jest.MockedFunction<typeof accountModeCache.query>;
 
 describe('Huobi swap order type mappings', () => {
@@ -205,5 +211,123 @@ describe('submitOrder normal swap account order type mapping', () => {
       order_price_type: 'fok',
       channel_code: 'broker-id',
     });
+  });
+});
+
+describe('submitOrder unified swap account order type mapping', () => {
+  const credential = { access_key: 'ak', secret_key: 'sk' };
+  const product_id = encodePath('HUOBI', 'SWAP', 'BTC-USDT');
+
+  beforeEach(() => {
+    process.env.BROKER_ID = 'broker-id';
+    mockAccountModeQuery.mockResolvedValue(1);
+    mockPostUnionAccountSwapOrder.mockResolvedValue({
+      code: 200,
+      message: 'ok',
+      data: { order_id: 1, order_id_str: '1' },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([
+    ['IOC', 'ioc'],
+    ['FOK', 'fok'],
+  ])('uses %s time_in_force for unified swap orders', async (orderType, timeInForce) => {
+    await submitOrder(credential, {
+      product_id,
+      order_type: orderType,
+      order_direction: 'OPEN_LONG',
+      volume: 1,
+      price: 12345,
+    } as any);
+
+    expect(mockPostUnionAccountSwapOrder).toHaveBeenCalledWith(credential, {
+      contract_code: 'BTC-USDT',
+      margin_mode: 'cross',
+      price: 12345,
+      volume: 1,
+      position_side: 'both',
+      side: 'buy',
+      type: 'limit',
+      time_in_force: timeInForce,
+      channel_code: 'broker-id',
+      reduce_only: 0,
+    });
+  });
+});
+
+describe('listSwapOrders order type mapping', () => {
+  const credential = { access_key: 'ak', secret_key: 'sk' };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('maps Huobi order_price_type values back to Yuan order types', async () => {
+    mockGetSwapOpenOrders
+      .mockResolvedValueOnce({
+        status: 'ok',
+        data: {
+          orders: [
+            {
+              order_id_str: '1',
+              contract_code: 'BTC-USDT',
+              order_price_type: 'lightning',
+              direction: 'open',
+              offset: 'buy',
+              volume: 1,
+              created_at: 1,
+              price: 100,
+              trade_volume: 0,
+            },
+            {
+              order_id_str: '2',
+              contract_code: 'BTC-USDT',
+              order_price_type: 'limit',
+              direction: 'open',
+              offset: 'buy',
+              volume: 1,
+              created_at: 2,
+              price: 200,
+              trade_volume: 0,
+            },
+            {
+              order_id_str: '3',
+              contract_code: 'BTC-USDT',
+              order_price_type: 'ioc',
+              direction: 'open',
+              offset: 'buy',
+              volume: 1,
+              created_at: 3,
+              price: 300,
+              trade_volume: 0,
+            },
+            {
+              order_id_str: '4',
+              contract_code: 'BTC-USDT',
+              order_price_type: 'fok',
+              direction: 'open',
+              offset: 'buy',
+              volume: 1,
+              created_at: 4,
+              price: 400,
+              trade_volume: 0,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        status: 'ok',
+        data: {
+          orders: [],
+        },
+      });
+
+    const orders = await listSwapOrders(credential);
+
+    expect(orders.map((v) => v.order_type)).toEqual(['MARKET', 'LIMIT', 'IOC', 'FOK']);
   });
 });

--- a/apps/vendor-huobi/src/services/orders/submitOrder.ts
+++ b/apps/vendor-huobi/src/services/orders/submitOrder.ts
@@ -14,6 +14,7 @@ import { getSpotTick } from '../../api/public-api';
 import { productCache } from '../product';
 import { superMarginAccountUidCache } from '../uid';
 import { accountModeCache } from '../exchange';
+import { mapSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
 
 /**
  * 处理 swap 账户订单提交
@@ -66,7 +67,7 @@ async function handleSwapOrder(order: IOrder, credential: ICredential): Promise<
       order.order_direction === 'OPEN_LONG' || order.order_direction === 'CLOSE_SHORT' ? 'buy' : 'sell',
     // dynamically adjust the leverage
     lever_rate,
-    order_price_type: order.order_type === 'MARKET' ? 'market' : 'limit',
+    ...mapSwapOrderTypeToHuobi(order.order_type),
     channel_code: process.env.BROKER_ID,
   };
 

--- a/apps/vendor-huobi/src/services/orders/submitOrder.ts
+++ b/apps/vendor-huobi/src/services/orders/submitOrder.ts
@@ -14,7 +14,7 @@ import { getSpotTick } from '../../api/public-api';
 import { productCache } from '../product';
 import { superMarginAccountUidCache } from '../uid';
 import { accountModeCache } from '../exchange';
-import { mapSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
+import { mapSwapOrderTypeToHuobi, mapUnionSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
 
 /**
  * 处理 swap 账户订单提交
@@ -24,6 +24,7 @@ async function handleUnionAccountSwapOrder(
   credential: ICredential,
 ): Promise<{ order_id: string }> {
   const [, instType, contractCode] = decodePath(order.product_id);
+  const orderTypeParams = mapUnionSwapOrderTypeToHuobi(order.order_type);
   const params = {
     contract_code: contractCode,
     margin_mode: 'cross',
@@ -31,7 +32,7 @@ async function handleUnionAccountSwapOrder(
     volume: order.volume,
     position_side: 'both',
     side: order.order_direction === 'OPEN_LONG' || order.order_direction === 'CLOSE_SHORT' ? 'buy' : 'sell',
-    type: order.order_type === 'MARKET' ? 'market' : 'limit',
+    ...orderTypeParams,
     channel_code: process.env.BROKER_ID,
     reduce_only: order.is_close ? 1 : 0,
   };

--- a/common/changes/@yuants/vendor-huobi/feat-huobi-ioc-fok_2026-04-21-14-28.json
+++ b/common/changes/@yuants/vendor-huobi/feat-huobi-ioc-fok_2026-04-21-14-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "add IOC/FOK order type support for Huobi swap order submission and listOrders readback mapping",
+      "type": "patch",
+      "packageName": "@yuants/vendor-huobi"
+    }
+  ],
+  "packageName": "@yuants/vendor-huobi",
+  "email": "41898282+github-actions[bot]@users.noreply.github.com"
+}

--- a/docs/superpowers/plans/2026-04-21-huobi-ioc-fok.md
+++ b/docs/superpowers/plans/2026-04-21-huobi-ioc-fok.md
@@ -1,0 +1,312 @@
+# HUOBI IOC/FOK Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 `@yuants/vendor-huobi` 增加 `SWAP` 的 `IOrder.order_type = 'IOC' | 'FOK'` 下单支持，并让 `listSwapOrders` 稳定回填 `order_type`。
+
+**Architecture:** 把 Huobi `SWAP` 的订单类型语义拆成两个小型纯映射：提交侧统一生成普通合约账户与统一账户所需的下单字段，回读侧统一根据 `order_price_type` 还原 Yuan `order_type`。然后让 `submitOrder.ts` 与 `listOrders.ts` 共用这些 helper，并用最小 Jest 测试锁住普通账户、统一账户、回读三条链路。
+
+**Tech Stack:** TypeScript, Heft/Jest, Rush, API Extractor
+
+---
+
+### Task 1: 建立 Huobi SWAP 订单类型映射 helper 与测试
+
+**Files:**
+
+- Create: `apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts`
+- Create: `apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts`
+- Create: `apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts`
+
+- [ ] **Step 1: 写提交映射失败测试**
+
+```ts
+import { mapSwapOrderTypeToHuobi, mapUnionSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
+
+describe('Huobi swap order type mappings', () => {
+  test('maps IOC and FOK for normal swap accounts', () => {
+    expect(mapSwapOrderTypeToHuobi('IOC')).toEqual({ order_price_type: 'ioc' });
+    expect(mapSwapOrderTypeToHuobi('FOK')).toEqual({ order_price_type: 'fok' });
+  });
+
+  test('maps IOC and FOK for unified swap accounts', () => {
+    expect(mapUnionSwapOrderTypeToHuobi('IOC')).toEqual({ type: 'limit', time_in_force: 'ioc' });
+    expect(mapUnionSwapOrderTypeToHuobi('FOK')).toEqual({ type: 'limit', time_in_force: 'fok' });
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认红灯**
+
+Run: `./node_modules/.bin/heft test --test-path-pattern order-type-mapping`
+Expected: FAIL，提示找不到 `./mapSwapOrderTypeToHuobi` 或对应导出不存在。
+
+- [ ] **Step 3: 写回读映射失败测试**
+
+```ts
+import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
+
+describe('mapHuobiSwapOrderToOrderType', () => {
+  test('maps Huobi order_price_type values back to Yuan order types', () => {
+    expect(mapHuobiSwapOrderToOrderType('lightning')).toBe('MARKET');
+    expect(mapHuobiSwapOrderToOrderType('limit')).toBe('LIMIT');
+    expect(mapHuobiSwapOrderToOrderType('ioc')).toBe('IOC');
+    expect(mapHuobiSwapOrderToOrderType('optimal_20_ioc')).toBe('IOC');
+    expect(mapHuobiSwapOrderToOrderType('fok')).toBe('FOK');
+  });
+});
+```
+
+- [ ] **Step 4: 实现最小 helper**
+
+```ts
+import { IOrder } from '@yuants/data-order';
+
+export const mapSwapOrderTypeToHuobi = (orderType?: IOrder['order_type']) => {
+  if (orderType === 'MARKET') return { order_price_type: 'market' };
+  if (orderType === 'LIMIT') return { order_price_type: 'limit' };
+  if (orderType === 'IOC') return { order_price_type: 'ioc' };
+  if (orderType === 'FOK') return { order_price_type: 'fok' };
+  throw new Error(`Unsupported order_type: ${orderType}`);
+};
+
+export const mapUnionSwapOrderTypeToHuobi = (orderType?: IOrder['order_type']) => {
+  if (orderType === 'MARKET') return { type: 'market' as const, time_in_force: undefined };
+  if (orderType === 'LIMIT') return { type: 'limit' as const, time_in_force: undefined };
+  if (orderType === 'IOC') return { type: 'limit' as const, time_in_force: 'ioc' };
+  if (orderType === 'FOK') return { type: 'limit' as const, time_in_force: 'fok' };
+  throw new Error(`Unsupported order_type: ${orderType}`);
+};
+```
+
+```ts
+import { IOrder } from '@yuants/data-order';
+
+export const mapHuobiSwapOrderToOrderType = (orderPriceType?: string): IOrder['order_type'] => {
+  if (orderPriceType === 'lightning' || orderPriceType === 'market') return 'MARKET';
+  if (orderPriceType === 'fok') return 'FOK';
+  if (orderPriceType?.includes('ioc')) return 'IOC';
+  return 'LIMIT';
+};
+```
+
+- [ ] **Step 5: 运行测试确认绿灯**
+
+Run: `./node_modules/.bin/heft test --test-path-pattern order-type-mapping`
+Expected: PASS，3 tests passed。
+
+- [ ] **Step 6: 提交 helper 与测试**
+
+```bash
+git add apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+git commit -m "test(huobi): cover ioc fok order type mappings"
+```
+
+### Task 2: 接入普通合约账户 submitOrder 的 IOC/FOK 映射
+
+**Files:**
+
+- Modify: `apps/vendor-huobi/src/services/orders/submitOrder.ts`
+- Reuse: `apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts`
+- Modify: `apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts`
+
+- [ ] **Step 1: 为普通合约账户写失败测试**
+
+```ts
+jest.mock('../../api/private-api', () => ({
+  getSwapCrossPositionInfo: jest.fn(),
+  postSwapOrder: jest.fn(),
+  postUnionAccountSwapOrder: jest.fn(),
+}));
+
+test.each([
+  ['IOC', 'ioc'],
+  ['FOK', 'fok'],
+])('submitOrder sends normal swap %s orders with order_price_type=%s', async (orderType, orderPriceType) => {
+  // mock getSwapCrossPositionInfo + postSwapOrder
+  // call submitOrder with product_id=encodePath('HUOBI', 'SWAP', 'BTC-USDT')
+  // assert postSwapOrder payload contains { order_price_type: orderPriceType, price: 12345 }
+});
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `./node_modules/.bin/heft test --test-path-pattern order-type-mapping`
+Expected: FAIL，提示 `order_price_type` 仍为 `limit`，或 `Unsupported order_type: IOC/FOK`。
+
+- [ ] **Step 3: 让普通合约账户复用共享 helper**
+
+```ts
+import { mapSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
+
+const orderTypeParams = mapSwapOrderTypeToHuobi(order.order_type);
+
+const params = {
+  contract_code: contractCode,
+  contract_type: 'swap',
+  price: order.price,
+  volume: order.volume,
+  offset: order.order_direction === 'OPEN_LONG' || order.order_direction === 'OPEN_SHORT' ? 'open' : 'close',
+  direction:
+    order.order_direction === 'OPEN_LONG' || order.order_direction === 'CLOSE_SHORT' ? 'buy' : 'sell',
+  lever_rate,
+  ...orderTypeParams,
+  channel_code: process.env.BROKER_ID,
+};
+```
+
+- [ ] **Step 4: 保持价格和方向逻辑不变**
+
+Expected:
+
+- `price` 仍直接透传 `order.price`
+- `volume`、`offset`、`direction`、`lever_rate` 行为不变
+- 仅把 `order_price_type` 从内联三元表达式切换为 helper
+
+- [ ] **Step 5: 运行测试确认通过**
+
+Run: `./node_modules/.bin/heft test --test-path-pattern order-type-mapping`
+Expected: PASS。
+
+- [ ] **Step 6: 提交普通合约账户 submitOrder 改动**
+
+```bash
+git add apps/vendor-huobi/src/services/orders/submitOrder.ts apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+git commit -m "feat(huobi): support ioc fok for swap orders"
+```
+
+### Task 3: 接入统一账户 submitOrder 与 listOrders 回读闭环
+
+**Files:**
+
+- Modify: `apps/vendor-huobi/src/services/orders/submitOrder.ts`
+- Modify: `apps/vendor-huobi/src/services/orders/listOrders.ts`
+- Reuse: `apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts`
+- Reuse: `apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts`
+- Modify: `apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts`
+
+- [ ] **Step 1: 为统一账户 submitOrder 写失败测试**
+
+```ts
+test.each([
+  ['IOC', 'ioc'],
+  ['FOK', 'fok'],
+])('submitOrder sends unified swap %s orders with time_in_force=%s', async (orderType, timeInForce) => {
+  // mock accountModeCache.query to return 1
+  // mock postUnionAccountSwapOrder
+  // assert payload contains { type: 'limit', time_in_force: timeInForce, price: 12345 }
+});
+```
+
+- [ ] **Step 2: 为 listOrders 回填写失败测试**
+
+```ts
+test('listSwapOrders maps order_price_type back to Yuan order types', async () => {
+  // mock getSwapOpenOrders to return rows with:
+  // { order_price_type: 'lightning' }
+  // { order_price_type: 'limit' }
+  // { order_price_type: 'ioc' }
+  // { order_price_type: 'fok' }
+  // expect order_type to be MARKET / LIMIT / IOC / FOK
+});
+```
+
+- [ ] **Step 3: 运行测试确认失败**
+
+Run: `./node_modules/.bin/heft test --test-path-pattern order-type-mapping`
+Expected: FAIL，提示统一账户没有透传 `time_in_force`，或 `listSwapOrders` 返回值未使用共享回读 helper。
+
+- [ ] **Step 4: 让统一账户复用共享 helper**
+
+```ts
+import { mapUnionSwapOrderTypeToHuobi } from './mapSwapOrderTypeToHuobi';
+
+const orderTypeParams = mapUnionSwapOrderTypeToHuobi(order.order_type);
+
+const params = {
+  contract_code: contractCode,
+  margin_mode: 'cross',
+  price: order.price,
+  volume: order.volume,
+  position_side: 'both',
+  side: order.order_direction === 'OPEN_LONG' || order.order_direction === 'CLOSE_SHORT' ? 'buy' : 'sell',
+  ...orderTypeParams,
+  channel_code: process.env.BROKER_ID,
+  reduce_only: order.is_close ? 1 : 0,
+};
+```
+
+- [ ] **Step 5: 让 listOrders 复用共享回读 helper**
+
+```ts
+import { mapHuobiSwapOrderToOrderType } from './mapHuobiSwapOrderToOrderType';
+
+order_type: mapHuobiSwapOrderToOrderType(v.order_price_type),
+```
+
+- [ ] **Step 6: 运行测试确认通过**
+
+Run: `./node_modules/.bin/heft test --test-path-pattern order-type-mapping`
+Expected: PASS。
+
+- [ ] **Step 7: 提交统一账户与回读闭环改动**
+
+```bash
+git add apps/vendor-huobi/src/services/orders/submitOrder.ts apps/vendor-huobi/src/services/orders/listOrders.ts apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts apps/vendor-huobi/src/services/orders/order-type-mapping.test.ts
+git commit -m "feat(huobi): align swap ioc fok order readback"
+```
+
+### Task 4: 文档同步、change file、验证与 PR 更新
+
+**Files:**
+
+- Modify: `docs/zh-Hans/vendor-supporting.md`
+- Create: `common/changes/@yuants/vendor-huobi/*.json`
+- Verify: `docs/superpowers/specs/2026-04-21-huobi-ioc-fok-design.md`
+- Verify: `docs/superpowers/plans/2026-04-21-huobi-ioc-fok.md`
+
+- [ ] **Step 1: 更新外部能力表说明**
+
+在 `docs/zh-Hans/vendor-supporting.md` 的 HTX 注释附近补一句：
+
+```md
+> 注：HTX 合约账户下单当前支持 `LIMIT`、`MARKET`、`IOC`、`FOK`；其中统一账户的 `IOC/FOK` 通过 `type='limit' + time_in_force` 实现。
+```
+
+- [ ] **Step 2: 暂存相关改动**
+
+Run: `git add apps/vendor-huobi/src docs/zh-Hans/vendor-supporting.md docs/superpowers/specs docs/superpowers/plans`
+Expected: 相关文件进入 staged。
+
+- [ ] **Step 3: 运行 `rush change` 生成 change file**
+
+Run: `rush change`
+Expected: 生成 `@yuants/vendor-huobi` 的 patch change file，描述 “add IOC/FOK order type support for Huobi swap order submission and listOrders readback mapping”。
+
+- [ ] **Step 4: 提交 change file 与文档**
+
+```bash
+git add common/changes docs/zh-Hans/vendor-supporting.md
+git commit -m "chore: add vendor-huobi change file for ioc fok"
+```
+
+- [ ] **Step 5: 运行最终验证**
+
+Run: `./node_modules/.bin/heft test --clean`
+Expected: `apps/vendor-huobi` 包内测试通过。
+
+Run: `node common/scripts/install-run-rush.js build -t @yuants/vendor-huobi`
+Expected: 若再次被 `@yuants/http-services` 的既有集成测试阻塞，则在结果中明确标记为仓库基线问题，而不是 Huobi IOC/FOK 回归。
+
+- [ ] **Step 6: 推送分支并更新 PR**
+
+```bash
+git push
+```
+
+在 PR 中补充验证结果：
+
+```md
+- `./node_modules/.bin/heft test --clean`（apps/vendor-huobi） ✅
+- `node common/scripts/install-run-rush.js build -t @yuants/vendor-huobi` ⚠️ blocked by pre-existing `@yuants/http-services` integration test failure
+```

--- a/docs/superpowers/specs/2026-04-21-huobi-ioc-fok-design.md
+++ b/docs/superpowers/specs/2026-04-21-huobi-ioc-fok-design.md
@@ -1,0 +1,150 @@
+# HUOBI IOC/FOK Design
+
+## 背景
+
+Yuan 的 `IOrder.order_type` 已定义 `IOC` 与 `FOK` 语义，但 `apps/vendor-huobi` 当前 `SWAP` 下单只区分 `MARKET` 与其他限价单：普通合约账户在 `submitOrder.ts` 中把非市价单统一映射到 `order_price_type='limit'`，统一账户把非市价单统一映射到 `type='limit'`。这会导致上层传入 `IOrder.order_type = 'IOC' | 'FOK'` 时，Huobi vendor 无法把成交时效透传给交易所。
+
+同时，`apps/vendor-huobi/src/services/orders/listOrders.ts` 虽然已经根据 `order_price_type` 粗略区分 `IOC/FOK`，但这套规则散落在回读逻辑里，没有与提交侧共享，普通合约账户与统一账户的提交规则也没有统一定义。用户已确认本次需求只做 `SWAP`，并要求同时补齐提交与查询回填，形成语义闭环。
+
+## 目标
+
+- 在 `apps/vendor-huobi` 中支持使用 `IOrder.order_type = 'IOC' | 'FOK'` 提交 `SWAP` 订单。
+- 同时覆盖 `SWAP` 的普通合约账户与统一账户下单链路。
+- 在 `listSwapOrders` 回读链路中，稳定回填 `IOC | FOK | LIMIT | MARKET`。
+- 保持现有 `LIMIT` / `MARKET` 行为不变，改动范围限定在 `apps/vendor-huobi`。
+
+## 非目标
+
+- 不改动 `SUPER-MARGIN` 下单逻辑。
+- 不扩展 `MAKER` 语义，也不把 `post_only` 映射升级为 `MAKER`。
+- 不改动撤单、改单、成交补录、账户或行情能力。
+- 不做跨 vendor 抽象或公共订单映射重构。
+
+## 方案比较
+
+### 方案 A：提取最小共享 helper，再接入 submitOrder 和 listOrders
+
+把 Huobi `SWAP` 的订单类型映射拆成小型纯函数：提交侧分别处理普通合约账户与统一账户的参数映射，回读侧统一根据 `order_price_type` 回填 Yuan `order_type`。
+
+优点：
+
+- 提交与回读规则集中，普通账户和统一账户不会各自漂移。
+- 纯函数易于做最小单测，适合按 TDD 小步推进。
+- 文件改动仍然很小，能保持本次需求聚焦。
+
+缺点：
+
+- 会多 1-2 个小文件和对应测试。
+
+### 方案 B：只在 submitOrder.ts 和 listOrders.ts 内联改动
+
+直接在现有文件中追加 `IOC/FOK` 分支，不抽 helper。
+
+优点：
+
+- 表面上新增文件更少。
+
+缺点：
+
+- 普通账户、统一账户、回读三处规则继续分散。
+- 以后如果再调 `order_price_type` / `time_in_force`，很容易漏改某一条链路。
+
+### 方案 C：只补提交，不补回读
+
+优点：
+
+- 改动最少。
+
+缺点：
+
+- 不满足用户已确认的“提交与查询语义闭环”。
+
+## 最终方案
+
+采用方案 A：提取最小共享 helper，在 `apps/vendor-huobi/src/services/orders/` 内统一管理 `SWAP` 的 `IOC/FOK` 提交与回读映射，再让 `submitOrder.ts` 与 `listOrders.ts` 复用这些规则。
+
+## 影响文件
+
+- `apps/vendor-huobi/src/services/orders/submitOrder.ts`
+  - 普通合约账户复用共享 helper 生成 `order_price_type`。
+  - 统一账户复用共享 helper 生成 `type` 与 `time_in_force`。
+- `apps/vendor-huobi/src/services/orders/listOrders.ts`
+  - 不再内联判断 `order_price_type`，改为调用共享回读 helper。
+- `apps/vendor-huobi/src/services/orders/mapSwapOrderTypeToHuobi.ts`
+  - 新增：根据 Yuan `order_type` 分别生成普通合约账户与统一账户需要的下单字段。
+- `apps/vendor-huobi/src/services/orders/mapHuobiSwapOrderToOrderType.ts`
+  - 新增：根据 Huobi `order_price_type` 回填 Yuan `order_type`。
+- `apps/vendor-huobi/src/services/orders/*.test.ts`
+  - 新增最小测试，覆盖提交映射与回读映射。
+- `docs/zh-Hans/vendor-supporting.md`
+  - 同步补充 HTX `SWAP` IOC/FOK 支持说明。
+
+## 详细设计
+
+### 1. 普通合约账户下单映射
+
+`postSwapOrder` 继续使用 `order_price_type` 表示成交时效。本次只做增量扩展：
+
+- `MARKET -> 'market'`
+- `LIMIT -> 'limit'`
+- `IOC -> 'ioc'`
+- `FOK -> 'fok'`
+
+其他字段如 `price`、`volume`、`offset`、`direction`、`lever_rate` 保持现有逻辑不变。`IOC/FOK` 和 `LIMIT` 一样继续走带价格的限价单路径，不借机改动数量或杠杆逻辑。
+
+### 2. 统一账户下单映射
+
+`postUnionAccountSwapOrder` 当前通过 `type` 区分 `market` 与 `limit`，同时 API 已暴露可选 `time_in_force` 字段。本次规则为：
+
+- `MARKET -> type='market'`
+- `LIMIT -> type='limit'`
+- `IOC -> type='limit', time_in_force='ioc'`
+- `FOK -> type='limit', time_in_force='fok'`
+
+这样可以保持现有 `LIMIT` 与 `MARKET` 行为不变，同时把 `IOC/FOK` 明确建模为“带价格的限价单 + 成交时效”。
+
+### 3. 回读映射
+
+`listSwapOrders` 当前读取 Huobi `order_price_type`，本次把它收敛为共享纯函数，规则如下：
+
+- `lightning` 或 `market` -> `MARKET`
+- `limit` / `opponent` / `post_only` / `optimal_5` / `optimal_10` / `optimal_20` -> `LIMIT`
+- `fok` -> `FOK`
+- 包含 `ioc` 的值 -> `IOC`
+
+这里刻意保持 `post_only -> LIMIT`，不扩展成 `MAKER`，因为本次需求没有承诺 `MAKER` 语义闭环，避免把范围扩大成另一轮行为变更。
+
+### 4. 测试策略
+
+遵循 TDD，先写失败测试，再补最小实现：
+
+- 纯映射测试：
+  - 普通合约账户 `IOC/FOK` 分别映射到 `ioc/fok`
+  - 统一账户 `IOC/FOK` 分别映射到 `type='limit' + time_in_force='ioc'|'fok'`
+  - 回读时 `order_price_type='ioc'|'optimal_20_ioc'|'fok'` 能映射回 `IOC|FOK`
+- 提交链路测试：
+  - 普通合约账户 `submitOrder` 在 `IOC/FOK` 时透传正确 `order_price_type`
+  - 统一账户 `submitOrder` 在 `IOC/FOK` 时透传正确 `time_in_force`
+  - `MARKET/LIMIT` 既有行为不回归
+- 回读链路测试：
+  - `listSwapOrders` 返回的 `order_type` 对 `MARKET/LIMIT/IOC/FOK` 映射正确
+
+### 5. 错误处理
+
+- 若调用方传入未知 `order_type`，仍保持显式抛错，避免错误地下发成普通限价单。
+- 若 Huobi 返回未知 `order_price_type`，维持当前保守回退行为，不在本次引入新的 vendor 专属枚举。
+
+## 验证策略
+
+- 在新增测试上执行红绿循环，确认每个测试先失败再通过。
+- 运行 `rush build -t @yuants/vendor-huobi` 做包级验证。
+- 当前 worktree 基线已确认：`rush build -t @yuants/vendor-huobi` 会被仓库现有的 `@yuants/http-services` 集成测试阻塞，错误为 `Host did not start on port 57505 within 10000ms`，与 Huobi IOC/FOK 改动无关；后续验证需继续把它标记为基线问题。
+
+## 提交策略
+
+- 提交 1：新增失败测试与共享映射 helper。
+- 提交 2：普通合约账户 `submitOrder` 接入 IOC/FOK。
+- 提交 3：统一账户 `submitOrder` + `listOrders` 回读闭环。
+- 提交 4：`rush change`、文档同步、验证结果与 PR。
+
+每个提交都保持可独立审阅。

--- a/docs/zh-Hans/vendor-supporting.md
+++ b/docs/zh-Hans/vendor-supporting.md
@@ -33,6 +33,8 @@
 
 > 注：Binance 现货与统一账户的下单当前支持 `LIMIT`、`MARKET`、`MAKER`、`IOC`、`FOK`；其中 `IOC/FOK` 通过 `LIMIT + timeInForce` 实现。
 
+> 注：HTX 合约账户下单当前支持 `LIMIT`、`MARKET`、`IOC`、`FOK`；其中统一账户的 `IOC/FOK` 通过 `type='limit' + time_in_force` 实现。
+
 ## 行情数据接口
 
 | 交易所      | 品种类别    | 实时报价 | K 线数据 | 深度数据 | 利率数据 |


### PR DESCRIPTION
## Summary
- add Huobi SWAP IOC/FOK submit support for both normal swap and unified account paths
- align `listSwapOrders` readback with shared order type mapping helpers and focused Jest coverage
- add Huobi design/plan docs, vendor support note, and Rush change file

## Verification
- `./node_modules/.bin/heft test --clean` in `apps/vendor-huobi` ✅ (`10 passed, 0 failed`)
- `node common/scripts/install-run-rush.js build -t @yuants/vendor-huobi` ⚠️ blocked by pre-existing `@yuants/http-services` integration failure: `Host did not start on port 62504 within 10000ms`