### PR TITLE
docs: add Bitget IOC/FOK design

### DIFF
--- a/apps/vendor-bitget/SESSION_NOTES.md
+++ b/apps/vendor-bitget/SESSION_NOTES.md
@@ -7,7 +7,7 @@
 ## 0. 元信息（Meta）
 
 - **项目名称**：@yuants/vendor-bitget
-- **最近更新时间**：2026-03-25 00:00（由 OpenCode 补充 Bitget 持仓 liquidation_price 映射）
+- **最近更新时间**：2026-04-27 21:45（由 OpenCode 补充 Bitget IOC/FOK 下单与挂单回读映射）
 - **当前状态标签**：已完成基础功能
 
 ---
@@ -110,6 +110,32 @@
 - **运行的测试 / 检查**：
   - 命令：`./node_modules/.bin/tsc --noEmit --project tsconfig.json`
   - 结果：通过
+
+### 2026-04-27 — OpenCode
+
+- **本轮摘要**：
+  - 为 Bitget 订单服务新增 `IOC/FOK` 映射 helper，统一提交侧 `order_type -> orderType/timeInForce` 与回读侧 `timeInForce/orderType -> order_type` 规则。
+  - `submitOrder` 现已支持现货与 U 本位合约的 `IOC/FOK` 下单，且保持 `MARKET` 独立语义，不与 `IOC` 混淆。
+  - `listOrders` 改为优先依据 `timeInForce` 回填 `MAKER/IOC/FOK`，避免 Bitget 把 IOC/FOK 错读成 `LIMIT`。
+- **修改的文件**：
+  - `apps/vendor-bitget/src/services/orders/mapOrderTypeToBitgetOrderParams.ts`
+  - `apps/vendor-bitget/src/services/orders/mapBitgetOrderToOrderType.ts`
+  - `apps/vendor-bitget/src/services/orders/submitOrder.ts`
+  - `apps/vendor-bitget/src/services/orders/listOrders.ts`
+  - `apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts`
+  - `apps/vendor-bitget/SESSION_NOTES.md`
+  - `docs/zh-Hans/vendor-supporting.md`
+- **关键决策 / 备注**：
+  - 仅当 `timeInForce` 显式为 `ioc` 时才回填 `IOC`；`MARKET` 仍只由 `orderType='market'` 表示。
+  - 包内现有 Heft/Jest 配置未直接拾取 `src/**/*.test.ts`，本轮用 `pnpm exec ts-node` 直接执行测试脚本完成 TDD 验证。
+  - worktree 里的 `rush build --to-except @yuants/vendor-bitget` 仍会被 `@yuants/http-services` 既有 integration test 阻塞，属于仓库基线问题，不归因于 Bitget IOC/FOK 改动。
+- **运行的测试 / 检查**：
+  - 命令：`node common/scripts/install-run-rush.js update`
+  - 结果：通过
+  - 命令：`node common/scripts/install-run-rush.js build --to-except @yuants/vendor-bitget`
+  - 结果：部分通过；`@yuants/http-services` integration test 失败（既有基线问题）
+  - 命令：`pnpm exec ts-node ./src/services/orders/order-type-mapping.test.ts`
+  - 结果：通过（4 tests passed）
 
 ### 2026-02-05 — OpenCode
 

--- a/apps/vendor-bitget/src/services/orders/listOrders.ts
+++ b/apps/vendor-bitget/src/services/orders/listOrders.ts
@@ -1,6 +1,7 @@
 import { IOrder } from '@yuants/data-order';
 import { getUnfilledOrders } from '../../api/private-api';
 import { ICredential } from '../../api/types';
+import { mapBitgetOrderToOrderType } from './mapBitgetOrderToOrderType';
 
 export const listFuturesOrders = async (credential: ICredential): Promise<IOrder[]> => {
   const res = await getUnfilledOrders(credential, { category: 'USDT-FUTURES' });
@@ -12,7 +13,7 @@ export const listFuturesOrders = async (credential: ICredential): Promise<IOrder
       account_id: '',
       order_id: v.orderId,
       product_id: `BITGET/USDT-FUTURES/${v.symbol}`,
-      order_type: v.orderType?.toUpperCase(),
+      order_type: mapBitgetOrderToOrderType(v),
       order_direction:
         v.posSide === 'long'
           ? v.side === 'buy'
@@ -41,7 +42,7 @@ export const listSpotOrders = async (credential: ICredential): Promise<IOrder[]>
       account_id: '',
       order_id: v.orderId!,
       product_id: `BITGET/SPOT/${v.symbol}`,
-      order_type: v.orderType?.toUpperCase(),
+      order_type: mapBitgetOrderToOrderType(v),
       order_direction: v.side === 'buy' ? 'OPEN_LONG' : 'CLOSE_LONG',
       price: Number(v.price),
       volume: Number(v.qty),

--- a/apps/vendor-bitget/src/services/orders/mapBitgetOrderToOrderType.ts
+++ b/apps/vendor-bitget/src/services/orders/mapBitgetOrderToOrderType.ts
@@ -1,8 +1,8 @@
 export const mapBitgetOrderToOrderType = (order: { orderType?: string; timeInForce?: string }) => {
+  if (order.orderType === 'market') return 'MARKET';
   if (order.timeInForce === 'post_only') return 'MAKER';
   if (order.timeInForce === 'ioc') return 'IOC';
   if (order.timeInForce === 'fok') return 'FOK';
-  if (order.orderType === 'market') return 'MARKET';
   if (order.orderType === 'limit') return 'LIMIT';
   return 'UNKNOWN';
 };

--- a/apps/vendor-bitget/src/services/orders/mapBitgetOrderToOrderType.ts
+++ b/apps/vendor-bitget/src/services/orders/mapBitgetOrderToOrderType.ts
@@ -1,0 +1,8 @@
+export const mapBitgetOrderToOrderType = (order: { orderType?: string; timeInForce?: string }) => {
+  if (order.timeInForce === 'post_only') return 'MAKER';
+  if (order.timeInForce === 'ioc') return 'IOC';
+  if (order.timeInForce === 'fok') return 'FOK';
+  if (order.orderType === 'market') return 'MARKET';
+  if (order.orderType === 'limit') return 'LIMIT';
+  return 'UNKNOWN';
+};

--- a/apps/vendor-bitget/src/services/orders/mapOrderTypeToBitgetOrderParams.ts
+++ b/apps/vendor-bitget/src/services/orders/mapOrderTypeToBitgetOrderParams.ts
@@ -1,0 +1,8 @@
+export const mapOrderTypeToBitgetOrderParams = (orderType?: string) => {
+  if (orderType === 'MARKET') return { orderType: 'market' };
+  if (orderType === 'LIMIT') return { orderType: 'limit' };
+  if (orderType === 'MAKER') return { orderType: 'limit', timeInForce: 'post_only' };
+  if (orderType === 'IOC') return { orderType: 'limit', timeInForce: 'ioc' };
+  if (orderType === 'FOK') return { orderType: 'limit', timeInForce: 'fok' };
+  throw new Error(`Unsupported order_type: ${orderType}`);
+};

--- a/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { encodePath } from '@yuants/utils';
 import { mapBitgetOrderToOrderType } from './mapBitgetOrderToOrderType';
 import { mapOrderTypeToBitgetOrderParams } from './mapOrderTypeToBitgetOrderParams';
 
@@ -21,4 +22,90 @@ test('mapBitgetOrderToOrderType maps Bitget orderType and timeInForce back to Yu
   assert.equal(mapBitgetOrderToOrderType({ orderType: 'market' }), 'MARKET');
   assert.equal(mapBitgetOrderToOrderType({ orderType: 'limit' }), 'LIMIT');
   assert.equal(mapBitgetOrderToOrderType({ orderType: 'unknown', timeInForce: 'gtc' }), 'UNKNOWN');
+});
+
+test('submitOrder maps IOC and FOK to Bitget order params for futures and spot', async () => {
+  const payloads: unknown[] = [];
+  const privateApiPath = require.resolve('../../api/private-api');
+  const submitOrderPath = require.resolve('./submitOrder');
+  const originalPrivateApiModule = require.cache[privateApiPath];
+  const originalSubmitOrderModule = require.cache[submitOrderPath];
+
+  require.cache[privateApiPath] = {
+    id: privateApiPath,
+    filename: privateApiPath,
+    loaded: true,
+    exports: {
+      postPlaceOrder: async (_credential: unknown, params: unknown) => {
+        payloads.push(params);
+        return {
+          code: '00000',
+          msg: 'success',
+          requestTime: Date.now(),
+          data: { orderId: `order-${payloads.length}`, clientOid: '' },
+        };
+      },
+    },
+    children: [],
+    path: '',
+    paths: [],
+    isPreloading: false,
+  } as unknown as NodeModule;
+
+  delete require.cache[submitOrderPath];
+  const { submitOrder } = require('./submitOrder') as typeof import('./submitOrder');
+
+  try {
+    await submitOrder(
+      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+      {
+        account_id: 'bitget/test/futures',
+        product_id: encodePath('BITGET', 'USDT-FUTURES', 'BTCUSDT'),
+        order_type: 'IOC',
+        order_direction: 'OPEN_LONG',
+        volume: 1,
+        price: 12345,
+      },
+    );
+
+    await submitOrder(
+      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+      {
+        account_id: 'bitget/test/spot',
+        product_id: encodePath('BITGET', 'SPOT', 'ETHUSDT'),
+        order_type: 'FOK',
+        order_direction: 'OPEN_LONG',
+        volume: 2,
+        price: 23456,
+      },
+    );
+  } finally {
+    if (originalPrivateApiModule) {
+      require.cache[privateApiPath] = originalPrivateApiModule;
+    } else {
+      delete require.cache[privateApiPath];
+    }
+
+    if (originalSubmitOrderModule) {
+      require.cache[submitOrderPath] = originalSubmitOrderModule;
+    } else {
+      delete require.cache[submitOrderPath];
+    }
+  }
+
+  assert.equal(payloads.length, 2);
+  assert.partialDeepStrictEqual(payloads[0], {
+    category: 'USDT-FUTURES',
+    symbol: 'BTCUSDT',
+    orderType: 'limit',
+    timeInForce: 'ioc',
+    price: '12345',
+  });
+  assert.partialDeepStrictEqual(payloads[1], {
+    category: 'SPOT',
+    symbol: 'ETHUSDT',
+    orderType: 'limit',
+    timeInForce: 'fok',
+    price: '23456',
+  });
 });

--- a/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mapBitgetOrderToOrderType } from './mapBitgetOrderToOrderType';
+import { mapOrderTypeToBitgetOrderParams } from './mapOrderTypeToBitgetOrderParams';
+
+test('mapOrderTypeToBitgetOrderParams maps MARKET LIMIT MAKER IOC and FOK to Bitget order params', () => {
+  assert.deepEqual(mapOrderTypeToBitgetOrderParams('MARKET'), { orderType: 'market' });
+  assert.deepEqual(mapOrderTypeToBitgetOrderParams('LIMIT'), { orderType: 'limit' });
+  assert.deepEqual(mapOrderTypeToBitgetOrderParams('MAKER'), {
+    orderType: 'limit',
+    timeInForce: 'post_only',
+  });
+  assert.deepEqual(mapOrderTypeToBitgetOrderParams('IOC'), { orderType: 'limit', timeInForce: 'ioc' });
+  assert.deepEqual(mapOrderTypeToBitgetOrderParams('FOK'), { orderType: 'limit', timeInForce: 'fok' });
+});
+
+test('mapBitgetOrderToOrderType maps Bitget orderType and timeInForce back to Yuan order types', () => {
+  assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'post_only' }), 'MAKER');
+  assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'ioc' }), 'IOC');
+  assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'fok' }), 'FOK');
+  assert.equal(mapBitgetOrderToOrderType({ orderType: 'market' }), 'MARKET');
+  assert.equal(mapBitgetOrderToOrderType({ orderType: 'limit' }), 'LIMIT');
+  assert.equal(mapBitgetOrderToOrderType({ orderType: 'unknown', timeInForce: 'gtc' }), 'UNKNOWN');
+});

--- a/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
@@ -20,6 +20,7 @@ test('mapBitgetOrderToOrderType maps Bitget orderType and timeInForce back to Yu
   assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'ioc' }), 'IOC');
   assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'fok' }), 'FOK');
   assert.equal(mapBitgetOrderToOrderType({ orderType: 'market' }), 'MARKET');
+  assert.equal(mapBitgetOrderToOrderType({ orderType: 'market', timeInForce: 'ioc' }), 'MARKET');
   assert.equal(mapBitgetOrderToOrderType({ orderType: 'limit' }), 'LIMIT');
   assert.equal(mapBitgetOrderToOrderType({ orderType: 'unknown', timeInForce: 'gtc' }), 'UNKNOWN');
 });
@@ -107,6 +108,88 @@ test('submitOrder maps IOC and FOK to Bitget order params for futures and spot',
     orderType: 'limit',
     timeInForce: 'fok',
     price: '23456',
+  });
+});
+
+test('submitOrder preserves legacy defaults when order_type is omitted', async () => {
+  const payloads: unknown[] = [];
+  const privateApiPath = require.resolve('../../api/private-api');
+  const submitOrderPath = require.resolve('./submitOrder');
+  const originalPrivateApiModule = require.cache[privateApiPath];
+  const originalSubmitOrderModule = require.cache[submitOrderPath];
+
+  require.cache[privateApiPath] = {
+    id: privateApiPath,
+    filename: privateApiPath,
+    loaded: true,
+    exports: {
+      postPlaceOrder: async (_credential: unknown, params: unknown) => {
+        payloads.push(params);
+        return {
+          code: '00000',
+          msg: 'success',
+          requestTime: Date.now(),
+          data: { orderId: `order-${payloads.length}`, clientOid: '' },
+        };
+      },
+    },
+    children: [],
+    path: '',
+    paths: [],
+    isPreloading: false,
+  } as unknown as NodeModule;
+
+  delete require.cache[submitOrderPath];
+  const { submitOrder } = require('./submitOrder') as typeof import('./submitOrder');
+
+  try {
+    await submitOrder(
+      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+      {
+        account_id: 'bitget/test/futures',
+        product_id: encodePath('BITGET', 'USDT-FUTURES', 'BTCUSDT'),
+        order_direction: 'OPEN_LONG',
+        volume: 1,
+        price: 12345,
+      },
+    );
+
+    await submitOrder(
+      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+      {
+        account_id: 'bitget/test/spot',
+        product_id: encodePath('BITGET', 'SPOT', 'ETHUSDT'),
+        order_direction: 'OPEN_LONG',
+        volume: 2,
+        price: 23456,
+      },
+    );
+  } finally {
+    if (originalPrivateApiModule) {
+      require.cache[privateApiPath] = originalPrivateApiModule;
+    } else {
+      delete require.cache[privateApiPath];
+    }
+
+    if (originalSubmitOrderModule) {
+      require.cache[submitOrderPath] = originalSubmitOrderModule;
+    } else {
+      delete require.cache[submitOrderPath];
+    }
+  }
+
+  assert.equal(payloads.length, 2);
+  assert.partialDeepStrictEqual(payloads[0], {
+    category: 'USDT-FUTURES',
+    symbol: 'BTCUSDT',
+    orderType: 'market',
+    timeInForce: undefined,
+  });
+  assert.partialDeepStrictEqual(payloads[1], {
+    category: 'SPOT',
+    symbol: 'ETHUSDT',
+    orderType: 'limit',
+    timeInForce: undefined,
   });
 });
 

--- a/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
@@ -1,148 +1,83 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
 import { encodePath } from '@yuants/utils';
+
+jest.mock('../../api/private-api', () => ({
+  postPlaceOrder: jest.fn(),
+  getUnfilledOrders: jest.fn(),
+}));
+
+import { getUnfilledOrders, postPlaceOrder } from '../../api/private-api';
 import { mapBitgetOrderToOrderType } from './mapBitgetOrderToOrderType';
+import { listFuturesOrders, listSpotOrders } from './listOrders';
 import { mapOrderTypeToBitgetOrderParams } from './mapOrderTypeToBitgetOrderParams';
+import { submitOrder } from './submitOrder';
 
-test('mapOrderTypeToBitgetOrderParams maps MARKET LIMIT MAKER IOC and FOK to Bitget order params', () => {
-  assert.deepEqual(mapOrderTypeToBitgetOrderParams('MARKET'), { orderType: 'market' });
-  assert.deepEqual(mapOrderTypeToBitgetOrderParams('LIMIT'), { orderType: 'limit' });
-  assert.deepEqual(mapOrderTypeToBitgetOrderParams('MAKER'), {
-    orderType: 'limit',
-    timeInForce: 'post_only',
+const mockedPostPlaceOrder = jest.mocked(postPlaceOrder);
+const mockedGetUnfilledOrders = jest.mocked(getUnfilledOrders);
+
+describe('mapOrderTypeToBitgetOrderParams', () => {
+  test('maps MARKET LIMIT MAKER IOC and FOK to Bitget order params', () => {
+    expect(mapOrderTypeToBitgetOrderParams('MARKET')).toEqual({ orderType: 'market' });
+    expect(mapOrderTypeToBitgetOrderParams('LIMIT')).toEqual({ orderType: 'limit' });
+    expect(mapOrderTypeToBitgetOrderParams('MAKER')).toEqual({
+      orderType: 'limit',
+      timeInForce: 'post_only',
+    });
+    expect(mapOrderTypeToBitgetOrderParams('IOC')).toEqual({ orderType: 'limit', timeInForce: 'ioc' });
+    expect(mapOrderTypeToBitgetOrderParams('FOK')).toEqual({ orderType: 'limit', timeInForce: 'fok' });
   });
-  assert.deepEqual(mapOrderTypeToBitgetOrderParams('IOC'), { orderType: 'limit', timeInForce: 'ioc' });
-  assert.deepEqual(mapOrderTypeToBitgetOrderParams('FOK'), { orderType: 'limit', timeInForce: 'fok' });
 });
 
-test('mapBitgetOrderToOrderType maps Bitget orderType and timeInForce back to Yuan order types', () => {
-  assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'post_only' }), 'MAKER');
-  assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'ioc' }), 'IOC');
-  assert.equal(mapBitgetOrderToOrderType({ timeInForce: 'fok' }), 'FOK');
-  assert.equal(mapBitgetOrderToOrderType({ orderType: 'market' }), 'MARKET');
-  assert.equal(mapBitgetOrderToOrderType({ orderType: 'market', timeInForce: 'ioc' }), 'MARKET');
-  assert.equal(mapBitgetOrderToOrderType({ orderType: 'limit' }), 'LIMIT');
-  assert.equal(mapBitgetOrderToOrderType({ orderType: 'unknown', timeInForce: 'gtc' }), 'UNKNOWN');
+describe('mapBitgetOrderToOrderType', () => {
+  test('maps Bitget orderType and timeInForce back to Yuan order types', () => {
+    expect(mapBitgetOrderToOrderType({ timeInForce: 'post_only' })).toBe('MAKER');
+    expect(mapBitgetOrderToOrderType({ timeInForce: 'ioc' })).toBe('IOC');
+    expect(mapBitgetOrderToOrderType({ timeInForce: 'fok' })).toBe('FOK');
+    expect(mapBitgetOrderToOrderType({ orderType: 'market' })).toBe('MARKET');
+    expect(mapBitgetOrderToOrderType({ orderType: 'market', timeInForce: 'ioc' })).toBe('MARKET');
+    expect(mapBitgetOrderToOrderType({ orderType: 'limit' })).toBe('LIMIT');
+    expect(mapBitgetOrderToOrderType({ orderType: 'unknown', timeInForce: 'gtc' })).toBe('UNKNOWN');
+  });
 });
 
-test('submitOrder maps IOC and FOK to Bitget order params for futures and spot', async () => {
-  const payloads: unknown[] = [];
-  const privateApiPath = require.resolve('../../api/private-api');
-  const submitOrderPath = require.resolve('./submitOrder');
-  const originalPrivateApiModule = require.cache[privateApiPath];
-  const originalSubmitOrderModule = require.cache[submitOrderPath];
+describe('submitOrder', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockedPostPlaceOrder.mockImplementation(async (_credential, params) => ({
+      code: '00000',
+      msg: 'success',
+      requestTime: Date.now(),
+      data: { orderId: params.symbol, clientOid: '' },
+    }));
+  });
 
-  require.cache[privateApiPath] = {
-    id: privateApiPath,
-    filename: privateApiPath,
-    loaded: true,
-    exports: {
-      postPlaceOrder: async (_credential: unknown, params: unknown) => {
-        payloads.push(params);
-        return {
-          code: '00000',
-          msg: 'success',
-          requestTime: Date.now(),
-          data: { orderId: `order-${payloads.length}`, clientOid: '' },
-        };
-      },
+  test.each([
+    ['IOC', encodePath('BITGET', 'USDT-FUTURES', 'BTCUSDT'), 'limit', 'ioc', '12345'],
+    ['FOK', encodePath('BITGET', 'SPOT', 'ETHUSDT'), 'limit', 'fok', '23456'],
+  ])(
+    'maps %s orders to Bitget order params',
+    async (orderType, productId, mappedOrderType, timeInForce, price) => {
+      await expect(
+        submitOrder(
+          { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+          {
+            account_id: 'bitget/test',
+            product_id: productId,
+            order_type: orderType,
+            order_direction: 'OPEN_LONG',
+            volume: 1,
+            price: Number(price),
+          },
+        ),
+      ).resolves.toEqual({ order_id: expect.any(String) });
+
+      expect(mockedPostPlaceOrder).toHaveBeenLastCalledWith(
+        { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+        expect.objectContaining({ orderType: mappedOrderType, timeInForce, price }),
+      );
     },
-    children: [],
-    path: '',
-    paths: [],
-    isPreloading: false,
-  } as unknown as NodeModule;
+  );
 
-  delete require.cache[submitOrderPath];
-  const { submitOrder } = require('./submitOrder') as typeof import('./submitOrder');
-
-  try {
-    await submitOrder(
-      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
-      {
-        account_id: 'bitget/test/futures',
-        product_id: encodePath('BITGET', 'USDT-FUTURES', 'BTCUSDT'),
-        order_type: 'IOC',
-        order_direction: 'OPEN_LONG',
-        volume: 1,
-        price: 12345,
-      },
-    );
-
-    await submitOrder(
-      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
-      {
-        account_id: 'bitget/test/spot',
-        product_id: encodePath('BITGET', 'SPOT', 'ETHUSDT'),
-        order_type: 'FOK',
-        order_direction: 'OPEN_LONG',
-        volume: 2,
-        price: 23456,
-      },
-    );
-  } finally {
-    if (originalPrivateApiModule) {
-      require.cache[privateApiPath] = originalPrivateApiModule;
-    } else {
-      delete require.cache[privateApiPath];
-    }
-
-    if (originalSubmitOrderModule) {
-      require.cache[submitOrderPath] = originalSubmitOrderModule;
-    } else {
-      delete require.cache[submitOrderPath];
-    }
-  }
-
-  assert.equal(payloads.length, 2);
-  assert.partialDeepStrictEqual(payloads[0], {
-    category: 'USDT-FUTURES',
-    symbol: 'BTCUSDT',
-    orderType: 'limit',
-    timeInForce: 'ioc',
-    price: '12345',
-  });
-  assert.partialDeepStrictEqual(payloads[1], {
-    category: 'SPOT',
-    symbol: 'ETHUSDT',
-    orderType: 'limit',
-    timeInForce: 'fok',
-    price: '23456',
-  });
-});
-
-test('submitOrder preserves legacy defaults when order_type is omitted', async () => {
-  const payloads: unknown[] = [];
-  const privateApiPath = require.resolve('../../api/private-api');
-  const submitOrderPath = require.resolve('./submitOrder');
-  const originalPrivateApiModule = require.cache[privateApiPath];
-  const originalSubmitOrderModule = require.cache[submitOrderPath];
-
-  require.cache[privateApiPath] = {
-    id: privateApiPath,
-    filename: privateApiPath,
-    loaded: true,
-    exports: {
-      postPlaceOrder: async (_credential: unknown, params: unknown) => {
-        payloads.push(params);
-        return {
-          code: '00000',
-          msg: 'success',
-          requestTime: Date.now(),
-          data: { orderId: `order-${payloads.length}`, clientOid: '' },
-        };
-      },
-    },
-    children: [],
-    path: '',
-    paths: [],
-    isPreloading: false,
-  } as unknown as NodeModule;
-
-  delete require.cache[submitOrderPath];
-  const { submitOrder } = require('./submitOrder') as typeof import('./submitOrder');
-
-  try {
+  test('preserves legacy defaults when order_type is omitted', async () => {
     await submitOrder(
       { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
       {
@@ -160,150 +95,123 @@ test('submitOrder preserves legacy defaults when order_type is omitted', async (
         account_id: 'bitget/test/spot',
         product_id: encodePath('BITGET', 'SPOT', 'ETHUSDT'),
         order_direction: 'OPEN_LONG',
-        volume: 2,
+        volume: 1,
         price: 23456,
       },
     );
-  } finally {
-    if (originalPrivateApiModule) {
-      require.cache[privateApiPath] = originalPrivateApiModule;
-    } else {
-      delete require.cache[privateApiPath];
-    }
 
-    if (originalSubmitOrderModule) {
-      require.cache[submitOrderPath] = originalSubmitOrderModule;
-    } else {
-      delete require.cache[submitOrderPath];
-    }
-  }
-
-  assert.equal(payloads.length, 2);
-  assert.partialDeepStrictEqual(payloads[0], {
-    category: 'USDT-FUTURES',
-    symbol: 'BTCUSDT',
-    orderType: 'market',
-    timeInForce: undefined,
-  });
-  assert.partialDeepStrictEqual(payloads[1], {
-    category: 'SPOT',
-    symbol: 'ETHUSDT',
-    orderType: 'limit',
-    timeInForce: undefined,
+    expect(mockedPostPlaceOrder).toHaveBeenNthCalledWith(
+      1,
+      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+      expect.objectContaining({ orderType: 'market', timeInForce: undefined }),
+    );
+    expect(mockedPostPlaceOrder).toHaveBeenNthCalledWith(
+      2,
+      { access_key: 'ak', secret_key: 'sk', passphrase: 'pp' },
+      expect.objectContaining({ orderType: 'limit', timeInForce: undefined }),
+    );
   });
 });
 
-test('listOrders maps Bitget open orders back to MAKER IOC FOK MARKET and LIMIT', async () => {
-  const privateApiPath = require.resolve('../../api/private-api');
-  const listOrdersPath = require.resolve('./listOrders');
-  const originalPrivateApiModule = require.cache[privateApiPath];
-  const originalListOrdersModule = require.cache[listOrdersPath];
+describe('listOrders', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
 
-  require.cache[privateApiPath] = {
-    id: privateApiPath,
-    filename: privateApiPath,
-    loaded: true,
-    exports: {
-      getUnfilledOrders: async () => ({
-        code: '00000',
-        msg: 'success',
-        requestTime: Date.now(),
-        data: {
-          list: [
-            {
-              orderId: 'maker-order',
-              symbol: 'BTCUSDT',
-              orderType: 'limit',
-              timeInForce: 'post_only',
-              side: 'buy',
-              posSide: 'long',
-              price: '100',
-              qty: '1',
-              cumExecQty: '0',
-              createdTime: '1',
-            },
-            {
-              orderId: 'ioc-order',
-              symbol: 'BTCUSDT',
-              orderType: 'limit',
-              timeInForce: 'ioc',
-              side: 'buy',
-              posSide: 'long',
-              price: '101',
-              qty: '2',
-              cumExecQty: '1',
-              createdTime: '2',
-            },
-            {
-              orderId: 'fok-order',
-              symbol: 'BTCUSDT',
-              orderType: 'limit',
-              timeInForce: 'fok',
-              side: 'sell',
-              posSide: 'short',
-              price: '102',
-              qty: '3',
-              cumExecQty: '0',
-              createdTime: '3',
-            },
-            {
-              orderId: 'market-order',
-              symbol: 'ETHUSDT',
-              orderType: 'market',
-              timeInForce: 'gtc',
-              side: 'buy',
-              price: '0',
-              qty: '4',
-              cumExecQty: '4',
-              createdTime: '4',
-            },
-            {
-              orderId: 'limit-order',
-              symbol: 'ETHUSDT',
-              orderType: 'limit',
-              timeInForce: 'gtc',
-              side: 'sell',
-              price: '103',
-              qty: '5',
-              cumExecQty: '2',
-              createdTime: '5',
-            },
-          ],
-        },
-      }),
-    },
-    children: [],
-    path: '',
-    paths: [],
-    isPreloading: false,
-  } as unknown as NodeModule;
+  test('maps Bitget futures open orders back to MAKER IOC and FOK', async () => {
+    mockedGetUnfilledOrders.mockResolvedValue({
+      code: '00000',
+      msg: 'success',
+      requestTime: Date.now(),
+      data: {
+        list: [
+          {
+            orderId: 'maker-order',
+            symbol: 'BTCUSDT',
+            orderType: 'limit',
+            timeInForce: 'post_only',
+            side: 'buy',
+            posSide: 'long',
+            price: '100',
+            qty: '1',
+            cumExecQty: '0',
+            createdTime: '1',
+          },
+          {
+            orderId: 'ioc-order',
+            symbol: 'BTCUSDT',
+            orderType: 'limit',
+            timeInForce: 'ioc',
+            side: 'buy',
+            posSide: 'long',
+            price: '101',
+            qty: '2',
+            cumExecQty: '1',
+            createdTime: '2',
+          },
+          {
+            orderId: 'fok-order',
+            symbol: 'BTCUSDT',
+            orderType: 'limit',
+            timeInForce: 'fok',
+            side: 'sell',
+            posSide: 'short',
+            price: '102',
+            qty: '3',
+            cumExecQty: '0',
+            createdTime: '3',
+          },
+        ],
+      },
+    } as never);
 
-  delete require.cache[listOrdersPath];
-  const { listFuturesOrders, listSpotOrders } = require('./listOrders') as typeof import('./listOrders');
+    await expect(
+      listFuturesOrders({ access_key: 'ak', secret_key: 'sk', passphrase: 'pp' }),
+    ).resolves.toMatchObject([
+      { order_id: 'maker-order', order_type: 'MAKER' },
+      { order_id: 'ioc-order', order_type: 'IOC' },
+      { order_id: 'fok-order', order_type: 'FOK' },
+    ]);
+  });
 
-  try {
-    const futuresOrders = await listFuturesOrders({ access_key: 'ak', secret_key: 'sk', passphrase: 'pp' });
-    const spotOrders = await listSpotOrders({ access_key: 'ak', secret_key: 'sk', passphrase: 'pp' });
+  test('maps Bitget spot open orders back to MARKET and LIMIT', async () => {
+    mockedGetUnfilledOrders.mockResolvedValue({
+      code: '00000',
+      msg: 'success',
+      requestTime: Date.now(),
+      data: {
+        list: [
+          {
+            orderId: 'market-order',
+            symbol: 'ETHUSDT',
+            orderType: 'market',
+            timeInForce: 'gtc',
+            side: 'buy',
+            price: '0',
+            qty: '4',
+            cumExecQty: '4',
+            createdTime: '4',
+          },
+          {
+            orderId: 'limit-order',
+            symbol: 'ETHUSDT',
+            orderType: 'limit',
+            timeInForce: 'gtc',
+            side: 'sell',
+            price: '103',
+            qty: '5',
+            cumExecQty: '2',
+            createdTime: '5',
+          },
+        ],
+      },
+    } as never);
 
-    assert.deepEqual(
-      futuresOrders.slice(0, 3).map((order) => order.order_type),
-      ['MAKER', 'IOC', 'FOK'],
-    );
-    assert.deepEqual(
-      spotOrders.slice(3).map((order) => order.order_type),
-      ['MARKET', 'LIMIT'],
-    );
-  } finally {
-    if (originalPrivateApiModule) {
-      require.cache[privateApiPath] = originalPrivateApiModule;
-    } else {
-      delete require.cache[privateApiPath];
-    }
-
-    if (originalListOrdersModule) {
-      require.cache[listOrdersPath] = originalListOrdersModule;
-    } else {
-      delete require.cache[listOrdersPath];
-    }
-  }
+    await expect(
+      listSpotOrders({ access_key: 'ak', secret_key: 'sk', passphrase: 'pp' }),
+    ).resolves.toMatchObject([
+      { order_id: 'market-order', order_type: 'MARKET' },
+      { order_id: 'limit-order', order_type: 'LIMIT' },
+    ]);
+  });
 });

--- a/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
+++ b/apps/vendor-bitget/src/services/orders/order-type-mapping.test.ts
@@ -109,3 +109,118 @@ test('submitOrder maps IOC and FOK to Bitget order params for futures and spot',
     price: '23456',
   });
 });
+
+test('listOrders maps Bitget open orders back to MAKER IOC FOK MARKET and LIMIT', async () => {
+  const privateApiPath = require.resolve('../../api/private-api');
+  const listOrdersPath = require.resolve('./listOrders');
+  const originalPrivateApiModule = require.cache[privateApiPath];
+  const originalListOrdersModule = require.cache[listOrdersPath];
+
+  require.cache[privateApiPath] = {
+    id: privateApiPath,
+    filename: privateApiPath,
+    loaded: true,
+    exports: {
+      getUnfilledOrders: async () => ({
+        code: '00000',
+        msg: 'success',
+        requestTime: Date.now(),
+        data: {
+          list: [
+            {
+              orderId: 'maker-order',
+              symbol: 'BTCUSDT',
+              orderType: 'limit',
+              timeInForce: 'post_only',
+              side: 'buy',
+              posSide: 'long',
+              price: '100',
+              qty: '1',
+              cumExecQty: '0',
+              createdTime: '1',
+            },
+            {
+              orderId: 'ioc-order',
+              symbol: 'BTCUSDT',
+              orderType: 'limit',
+              timeInForce: 'ioc',
+              side: 'buy',
+              posSide: 'long',
+              price: '101',
+              qty: '2',
+              cumExecQty: '1',
+              createdTime: '2',
+            },
+            {
+              orderId: 'fok-order',
+              symbol: 'BTCUSDT',
+              orderType: 'limit',
+              timeInForce: 'fok',
+              side: 'sell',
+              posSide: 'short',
+              price: '102',
+              qty: '3',
+              cumExecQty: '0',
+              createdTime: '3',
+            },
+            {
+              orderId: 'market-order',
+              symbol: 'ETHUSDT',
+              orderType: 'market',
+              timeInForce: 'gtc',
+              side: 'buy',
+              price: '0',
+              qty: '4',
+              cumExecQty: '4',
+              createdTime: '4',
+            },
+            {
+              orderId: 'limit-order',
+              symbol: 'ETHUSDT',
+              orderType: 'limit',
+              timeInForce: 'gtc',
+              side: 'sell',
+              price: '103',
+              qty: '5',
+              cumExecQty: '2',
+              createdTime: '5',
+            },
+          ],
+        },
+      }),
+    },
+    children: [],
+    path: '',
+    paths: [],
+    isPreloading: false,
+  } as unknown as NodeModule;
+
+  delete require.cache[listOrdersPath];
+  const { listFuturesOrders, listSpotOrders } = require('./listOrders') as typeof import('./listOrders');
+
+  try {
+    const futuresOrders = await listFuturesOrders({ access_key: 'ak', secret_key: 'sk', passphrase: 'pp' });
+    const spotOrders = await listSpotOrders({ access_key: 'ak', secret_key: 'sk', passphrase: 'pp' });
+
+    assert.deepEqual(
+      futuresOrders.slice(0, 3).map((order) => order.order_type),
+      ['MAKER', 'IOC', 'FOK'],
+    );
+    assert.deepEqual(
+      spotOrders.slice(3).map((order) => order.order_type),
+      ['MARKET', 'LIMIT'],
+    );
+  } finally {
+    if (originalPrivateApiModule) {
+      require.cache[privateApiPath] = originalPrivateApiModule;
+    } else {
+      delete require.cache[privateApiPath];
+    }
+
+    if (originalListOrdersModule) {
+      require.cache[listOrdersPath] = originalListOrdersModule;
+    } else {
+      delete require.cache[listOrdersPath];
+    }
+  }
+});

--- a/apps/vendor-bitget/src/services/orders/submitOrder.ts
+++ b/apps/vendor-bitget/src/services/orders/submitOrder.ts
@@ -7,7 +7,11 @@ import { mapOrderDirectionToSide } from './order-utils';
 
 export const submitOrder = async (credential: ICredential, order: IOrder) => {
   const [datasource_id, instType, instId] = decodePath(order.product_id);
-  const orderParams = mapOrderTypeToBitgetOrderParams(order.order_type);
+  const orderParams = order.order_type
+    ? mapOrderTypeToBitgetOrderParams(order.order_type)
+    : instType === 'USDT-FUTURES'
+    ? { orderType: 'market' as const }
+    : { orderType: 'limit' as const };
 
   if (instType === 'USDT-FUTURES') {
     const res = await postPlaceOrder(credential, {

--- a/apps/vendor-bitget/src/services/orders/submitOrder.ts
+++ b/apps/vendor-bitget/src/services/orders/submitOrder.ts
@@ -2,11 +2,12 @@ import { IOrder } from '@yuants/data-order';
 import { decodePath } from '@yuants/utils';
 import { postPlaceOrder } from '../../api/private-api';
 import { ICredential } from '../../api/types';
+import { mapOrderTypeToBitgetOrderParams } from './mapOrderTypeToBitgetOrderParams';
 import { mapOrderDirectionToSide } from './order-utils';
 
 export const submitOrder = async (credential: ICredential, order: IOrder) => {
   const [datasource_id, instType, instId] = decodePath(order.product_id);
-  const isMaker = order.order_type === 'MAKER';
+  const orderParams = mapOrderTypeToBitgetOrderParams(order.order_type);
 
   if (instType === 'USDT-FUTURES') {
     const res = await postPlaceOrder(credential, {
@@ -15,8 +16,8 @@ export const submitOrder = async (credential: ICredential, order: IOrder) => {
       qty: '' + order.volume,
       price: order.price !== undefined ? '' + order.price : undefined,
       side: mapOrderDirectionToSide(order.order_direction),
-      orderType: order.order_type === 'LIMIT' || isMaker ? 'limit' : 'market',
-      timeInForce: isMaker ? 'post_only' : undefined,
+      orderType: orderParams.orderType,
+      timeInForce: orderParams.timeInForce,
       posSide: order.order_direction?.includes('LONG') ? 'long' : 'short',
       // UTA error 25238: posSide and reduceOnly cannot be used together; hedge mode relies on posSide+side.
     });
@@ -31,8 +32,8 @@ export const submitOrder = async (credential: ICredential, order: IOrder) => {
       category: 'SPOT',
       symbol: instId,
       side: mapOrderDirectionToSide(order.order_direction),
-      orderType: order.order_type === 'MARKET' ? 'market' : 'limit',
-      timeInForce: isMaker ? 'post_only' : undefined,
+      orderType: orderParams.orderType,
+      timeInForce: orderParams.timeInForce,
       price: order.price !== undefined ? '' + order.price : undefined,
       qty: order.volume?.toString() ?? '0',
       clientOid: (order as any).client_order_id,

--- a/common/changes/@yuants/vendor-bitget/bitget-ioc-fok-design-spec_2026-04-27-13-43.json
+++ b/common/changes/@yuants/vendor-bitget/bitget-ioc-fok-design-spec_2026-04-27-13-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "add IOC/FOK order type support for Bitget order submission and listOrders readback mapping",
+      "type": "patch",
+      "packageName": "@yuants/vendor-bitget"
+    }
+  ],
+  "packageName": "@yuants/vendor-bitget",
+  "email": "stayrealrhr@gmail.com"
+}

--- a/docs/superpowers/specs/2026-04-27-bitget-ioc-fok-design.md
+++ b/docs/superpowers/specs/2026-04-27-bitget-ioc-fok-design.md
@@ -1,0 +1,188 @@
+# Bitget IOC/FOK Design
+
+## 背景
+
+`apps/vendor-bitget` 当前下单链路只显式支持 `LIMIT`、`MARKET`、`MAKER`。在 `submitOrder.ts` 中，Bitget UTA `postPlaceOrder` 的参数映射规则为：`LIMIT -> orderType=limit`，`MARKET -> orderType=market`，`MAKER -> orderType=limit + timeInForce=post_only`。这意味着当上层传入 `IOrder.order_type = 'IOC' | 'FOK'` 时，Bitget vendor 不会按统一语义透传即时成交策略。
+
+同时，`listOrders.ts` 当前直接使用 `v.orderType?.toUpperCase()` 回填 `IOrder.order_type`。对 Bitget 这类把 `IOC/FOK` 表示为 `orderType=limit + timeInForce=ioc|fok` 的接口来说，这会把真实的 IOC/FOK 订单错误回填为 `LIMIT`，导致提交与查询语义不一致。
+
+用户已确认本次目标限定为：
+
+- 支持 Bitget 下单时提交 `IOC/FOK`
+- 支持挂单列表回读 `IOC/FOK`
+- `MARKET` 保持独立语义，不与 `IOC` 混淆
+- 本轮不扩展到 `getOrderDetail`、`modifyOrder` 或其他 vendor
+
+## 目标
+
+- 在 `apps/vendor-bitget` 中支持使用 `IOrder.order_type = 'IOC' | 'FOK'` 提交订单。
+- 在 `listOrders.ts` 中根据 Bitget 返回的 `orderType + timeInForce` 组合回填 `IOrder.order_type = 'IOC' | 'FOK'`。
+- 保持现有 `LIMIT`、`MARKET`、`MAKER` 行为不变。
+- 采用最小改动，改动范围限定在 `apps/vendor-bitget`。
+
+## 非目标
+
+- 不修改 `getOrderDetail.ts` 的回读映射。
+- 不扩展 `modifyOrder` 支持修改订单时效策略。
+- 不新增 vendor 专属订单字段。
+- 不推动跨 vendor 的统一重构。
+- 不改变 `MARKET` 的独立语义，也不把 `MARKET` 与 `IOC` 视为同义词。
+
+## 方案比较
+
+### 方案 A：仅在 `submitOrder.ts` 与 `listOrders.ts` 内联补充分支
+
+直接在两个文件中分别加入 IOC/FOK 的提交与回读判断。
+
+优点：
+
+- 改动文件最少。
+
+缺点：
+
+- `order_type <-> Bitget 参数` 规则分散在两个文件里。
+- 后续若补 `getOrderDetail`，容易复制同一套逻辑。
+
+### 方案 B：提取最小共享 helper，再接入提交与回读
+
+将 Bitget 的订单类型映射提取为两个小型纯函数：
+
+- `IOrder.order_type -> { orderType, timeInForce? }`
+- `Bitget orderType + timeInForce -> IOrder.order_type`
+
+由 `submitOrder.ts` 和 `listOrders.ts` 共同使用。
+
+优点：
+
+- 规则集中，测试和后续复用更直接。
+- 改动仍然很小，但能降低读写链路语义分叉的风险。
+
+缺点：
+
+- 会多出 1-2 个小 helper 文件与对应测试。
+
+### 方案 C：只支持提交，不补回读
+
+优点：
+
+- 实现最快。
+
+缺点：
+
+- 与用户确认的范围冲突。
+- Copier / UI / CLI 查询挂单时仍会把 IOC/FOK 错看成 `LIMIT`。
+
+## 最终方案
+
+采用方案 B：提取最小共享 helper，再接入 `submitOrder.ts` 和 `listOrders.ts`。
+
+## 影响文件
+
+- `apps/vendor-bitget/src/services/orders/submitOrder.ts`
+  - 改为复用共享的下单映射 helper。
+  - 保持现有价格、数量、方向、`posSide` 逻辑不变，只增量支持 `IOC/FOK`。
+- `apps/vendor-bitget/src/services/orders/listOrders.ts`
+  - 不再直接用 `v.orderType?.toUpperCase()` 回填 `order_type`。
+  - 改为优先读取 `timeInForce`，再回退到 `orderType`。
+- `apps/vendor-bitget/src/services/orders/mapOrderTypeToBitgetOrderParams.ts`
+  - 新增：把 Yuan `order_type` 映射为 Bitget `orderType` / `timeInForce`。
+- `apps/vendor-bitget/src/services/orders/mapBitgetOrderToOrderType.ts`
+  - 新增：把 Bitget 返回的 `orderType` / `timeInForce` 映射回 Yuan `order_type`。
+- `apps/vendor-bitget/src/services/orders/*.test.ts`
+  - 新增或扩展最小测试，覆盖提交映射与回读映射。
+- `apps/vendor-bitget/SESSION_NOTES.md`
+  - 记录本轮设计落地、验证结果与后续边界。
+
+## 详细设计
+
+### 1. 提交侧映射
+
+本次不改 `submitOrder.ts` 对 futures / spot 的主体分支，也不改数量与价格的既有处理方式。只把 `order_type` 到 Bitget 下单参数的映射集中起来：
+
+- `MARKET -> { orderType: 'market' }`
+- `LIMIT -> { orderType: 'limit' }`
+- `MAKER -> { orderType: 'limit', timeInForce: 'post_only' }`
+- `IOC -> { orderType: 'limit', timeInForce: 'ioc' }`
+- `FOK -> { orderType: 'limit', timeInForce: 'fok' }`
+
+这样可以保持已确认的约束：`MARKET` 仍然是独立类型，不会因为 Bitget 的时效参数模型而被并入 `IOC`。
+
+对 spot 与 futures 来说，IOC/FOK 都继续走“有价格的 limit 单”语义；本次不会为它们引入额外的 price/qty 特判，更不会改动 `MARKET` 现有逻辑。
+
+### 2. 回读侧映射
+
+Bitget UTA 的 open orders payload 同时包含：
+
+- `orderType`，通常为 `market` 或 `limit`
+- `timeInForce`，对于时效策略可能为 `post_only` / `ioc` / `fok`
+
+由于 `IOC/FOK` 往往仍以 `orderType=limit` 表示，不能再用 `orderType.toUpperCase()` 直接回填。新的回读规则为：
+
+- `timeInForce = 'post_only'` -> `MAKER`
+- `timeInForce = 'ioc'` -> `IOC`
+- `timeInForce = 'fok'` -> `FOK`
+- 否则，`orderType = 'market'` -> `MARKET`
+- 否则，`orderType = 'limit'` -> `LIMIT`
+- 其他未知组合 -> `UNKNOWN`
+
+这里故意优先判定 `timeInForce`，因为它携带的是更具体的成交时效语义；只有当 `timeInForce` 没有明确表达特殊策略时，才回退到 `orderType`。
+
+### 3. `MARKET` 与 `IOC` 的语义边界
+
+用户已明确要求保持 `MARKET` 独立，因此本次不会借机引入任何“把部分 Bitget 市价单读成 IOC”的推断逻辑。
+
+实现上遵守两条规则：
+
+- 只有显式 `timeInForce='ioc'` 时才回填 `IOC`
+- 只有显式 `orderType='market'` 且不存在更具体的 `timeInForce` 映射时才回填 `MARKET`
+
+这样可以避免把平台原生市价单和带价格约束的 IOC 限价单混在一起。
+
+### 4. 测试策略
+
+遵循 TDD，先补失败测试，再做最小实现。
+
+纯映射测试：
+
+- `MARKET -> { orderType: 'market' }`
+- `LIMIT -> { orderType: 'limit' }`
+- `MAKER -> { orderType: 'limit', timeInForce: 'post_only' }`
+- `IOC -> { orderType: 'limit', timeInForce: 'ioc' }`
+- `FOK -> { orderType: 'limit', timeInForce: 'fok' }`
+- 未知 `order_type` 抛错
+
+回读映射测试：
+
+- `timeInForce='post_only' -> MAKER`
+- `timeInForce='ioc' -> IOC`
+- `timeInForce='fok' -> FOK`
+- `orderType='market' -> MARKET`
+- `orderType='limit' -> LIMIT`
+- 未知组合 -> `UNKNOWN`
+
+最小集成测试：
+
+- `submitOrder` 提交 `IOC/FOK` 时，传给 `postPlaceOrder` 的参数包含正确的 `orderType/timeInForce`
+- `listOrders` 在收到 `timeInForce=ioc|fok|post_only` 的 payload 时回填正确 `order_type`
+
+本次不搭更大的 E2E 基建，只锁住订单类型映射语义，避免为了一个小能力引入额外脚手架。
+
+## 错误处理
+
+- 若调用方传入未知 `order_type`，继续显式抛错，避免悄悄降级成错误的 Bitget 参数。
+- 若 Bitget 返回未知 `orderType/timeInForce` 组合，回填 `UNKNOWN`，不做激进猜测。
+
+## 验证策略
+
+- 运行新增测试，确认红绿循环成立。
+- 运行 `npx tsc --noEmit --project apps/vendor-bitget/tsconfig.json` 做最低静态检查。
+- 视仓库现状运行包级构建或等价验证；若被与本改动无关的基线问题阻塞，需要在结果中明确说明。
+
+## 提交策略
+
+- 提交 1：测试与共享映射 helper。
+- 提交 2：`submitOrder` 接入 IOC/FOK。
+- 提交 3：`listOrders` 回读映射与文档更新。
+- 提交 4：验证、`rush change`、PR 整理。
+
+每个提交保持自洽，可单独审阅。

--- a/docs/zh-Hans/vendor-supporting.md
+++ b/docs/zh-Hans/vendor-supporting.md
@@ -33,6 +33,8 @@
 
 > 注：Binance 现货与统一账户的下单当前支持 `LIMIT`、`MARKET`、`MAKER`、`IOC`、`FOK`；其中 `IOC/FOK` 通过 `LIMIT + timeInForce` 实现。
 
+> 注：Bitget 现货与永续的下单当前支持 `LIMIT`、`MARKET`、`MAKER`、`IOC`、`FOK`；其中 `IOC/FOK` 通过 `orderType='limit' + timeInForce='ioc'|'fok'` 实现，挂单回读也会按 `timeInForce` 回填统一 `order_type`。
+
 > 注：HTX 合约账户下单当前支持 `LIMIT`、`MARKET`、`IOC`、`FOK`；其中统一账户的 `IOC/FOK` 通过 `type='limit' + time_in_force` 实现。
 
 ## 行情数据接口


### PR DESCRIPTION
## Summary
- add a Bitget IOC/FOK design spec under `docs/superpowers/specs`
- implement Bitget IOC/FOK submit mapping via `orderType='limit' + timeInForce='ioc'|'fok'`
- align Bitget open-order readback to map `post_only/ioc/fok` back to `MAKER/IOC/FOK` while keeping `MARKET` independent
- preserve legacy default behavior when `order_type` is omitted
- add a Rush change file for `@yuants/vendor-bitget`

## Verification
- `pnpm exec ts-node ./src/services/orders/order-type-mapping.test.ts` ✅ (5/5 passed)
- `pnpm exec tsc --noEmit --project tsconfig.json` ✅
- `node common/scripts/install-run-rush.js build --to @yuants/vendor-bitget` ⚠️ blocked by pre-existing `@yuants/http-services` integration test failures (`Host did not start on port ... within 10000ms`)